### PR TITLE
Add SVG layout for login page

### DIFF
--- a/TrinityFrontend/src/pages/Login.tsx
+++ b/TrinityFrontend/src/pages/Login.tsx
@@ -38,8 +38,19 @@ const Login = () => {
   };
 
   return (
-    <div className="min-h-screen bg-white flex items-center justify-center p-4">
-      <div className="w-full max-w-md space-y-8">
+    <div className="min-h-screen flex">
+      {/* Left half with animated SVG */}
+      <div className="w-1/2 hidden md:flex items-center justify-center bg-gray-50">
+        <img
+          src="/background.svg"
+          alt="Login background"
+          className="w-full h-full object-cover"
+        />
+      </div>
+
+      {/* Right half with existing login blocks */}
+      <div className="w-full md:w-1/2 bg-white flex items-center justify-center p-4">
+        <div className="w-full max-w-md space-y-8">
         {/* Trinity Logo */}
         <div className="flex flex-col items-center space-y-2">
           <AnimatedLogo className="w-20 h-20" />
@@ -140,7 +151,9 @@ const Login = () => {
         <div className="text-center mt-8">
           <p className="text-black/50 text-xs">"No one can be told what the Trinity is. You have to see it for yourself"</p>
         </div>
+        </div>
       </div>
+      {/* Close main container */}
     </div>
   );
 };

--- a/login_page_guide.txt
+++ b/login_page_guide.txt
@@ -1,0 +1,4 @@
+1. Place your animated SVG file named `background.svg` in the `TrinityFrontend/public` directory. Files placed here are served from the web root, so the image will be available at `/background.svg`.
+2. Start the frontend dev server with `npm run dev` inside `TrinityFrontend`.
+3. Visit the login page. The left half of the screen now loads the SVG automatically via the `<img src="/background.svg">` element.
+4. To update the animation later, replace `background.svg` with your new file in `TrinityFrontend/public` and refresh the browser.


### PR DESCRIPTION
## Summary
- split login page into two columns
- reference `/background.svg` for animation
- document how to add animated SVG

## Testing
- `npm run lint`
- `pytest -q TrinityBackendFastAPI/tests`

------
https://chatgpt.com/codex/tasks/task_e_684c38259c9c8321843464dabb90b1f7