### PR TITLE
Enable video background and IP-based configs

### DIFF
--- a/TrinityBackendDjango/.env
+++ b/TrinityBackendDjango/.env
@@ -12,3 +12,4 @@ ALLOWED_HOSTS=*
 CSRF_TRUSTED_ORIGINS=http://10.2.1.242:8080
 # Comma separated list of origins for CORS. Leave empty to allow all.
 CORS_ALLOWED_ORIGINS=
+ADDITIONAL_DOMAINS=10.2.1.242

--- a/TrinityBackendDjango/.env
+++ b/TrinityBackendDjango/.env
@@ -9,7 +9,7 @@ CELERY_RESULT_BACKEND=redis://redis:6379/1
 # Address of the React frontend
 FRONTEND_URL=http://10.2.1.242:8080
 ALLOWED_HOSTS=*
-CSRF_TRUSTED_ORIGINS=http://10.2.1.242:8080
+CSRF_TRUSTED_ORIGINS=http://10.2.1.242:8080,https://trinity.quantmatrix.ai
 # Comma separated list of origins for CORS. Leave empty to allow all.
 CORS_ALLOWED_ORIGINS=
-ADDITIONAL_DOMAINS=10.2.1.242
+ADDITIONAL_DOMAINS=10.2.1.242,trinity.quantmatrix.ai

--- a/TrinityBackendDjango/.env
+++ b/TrinityBackendDjango/.env
@@ -6,8 +6,9 @@ CELERY_BROKER_URL=redis://redis:6379/0
 CELERY_RESULT_BACKEND=redis://redis:6379/1
 
 # Frontend URL used for CORS
-FRONTEND_URL=http://localhost:8080
+# Address of the React frontend
+FRONTEND_URL=http://<YOUR-IP>:8080
 ALLOWED_HOSTS=*
-CSRF_TRUSTED_ORIGINS=https://example.com
+CSRF_TRUSTED_ORIGINS=http://<YOUR-IP>:8080
 # Comma separated list of origins for CORS. Leave empty to allow all.
 CORS_ALLOWED_ORIGINS=

--- a/TrinityBackendDjango/.env
+++ b/TrinityBackendDjango/.env
@@ -7,8 +7,8 @@ CELERY_RESULT_BACKEND=redis://redis:6379/1
 
 # Frontend URL used for CORS
 # Address of the React frontend
-FRONTEND_URL=http://<YOUR-IP>:8080
+FRONTEND_URL=http://10.2.1.242:8080
 ALLOWED_HOSTS=*
-CSRF_TRUSTED_ORIGINS=http://<YOUR-IP>:8080
+CSRF_TRUSTED_ORIGINS=http://10.2.1.242:8080
 # Comma separated list of origins for CORS. Leave empty to allow all.
 CORS_ALLOWED_ORIGINS=

--- a/TrinityBackendDjango/.env.example
+++ b/TrinityBackendDjango/.env.example
@@ -4,8 +4,8 @@ POSTGRES_USER=trinity
 POSTGRES_PASSWORD=trinity
 CELERY_BROKER_URL=redis://redis:6379/0
 CELERY_RESULT_BACKEND=redis://redis:6379/1
-# Address of the React frontend. Replace <YOUR-IP> with the host running Vite.
-FRONTEND_URL=http://<YOUR-IP>:8080
+# Address of the React frontend. Update if you deploy to another host.
+FRONTEND_URL=http://10.2.1.242:8080
 # Requests for this domain (and 127.0.0.1) map to the default tenant
 PRIMARY_DOMAIN=localhost
 # If true, tenant creation skips migrations and seeding
@@ -15,6 +15,6 @@ SIMPLE_TENANT_CREATION=true
 ALLOWED_HOSTS=*
 # Domain for CSRF protection when accessing via browser (include protocol).
 # Set this to the IP or domain serving the frontend.
-CSRF_TRUSTED_ORIGINS=http://<YOUR-IP>:8080
+CSRF_TRUSTED_ORIGINS=http://10.2.1.242:8080
 # Comma separated list of origins for CORS. Leave empty to allow all (dev).
 CORS_ALLOWED_ORIGINS=

--- a/TrinityBackendDjango/.env.example
+++ b/TrinityBackendDjango/.env.example
@@ -18,3 +18,6 @@ ALLOWED_HOSTS=*
 CSRF_TRUSTED_ORIGINS=http://10.2.1.242:8080
 # Comma separated list of origins for CORS. Leave empty to allow all (dev).
 CORS_ALLOWED_ORIGINS=
+# Extra comma separated domain names or IP addresses that should map to the
+# default tenant when using django-tenants. Useful when accessing via a LAN IP.
+ADDITIONAL_DOMAINS=10.2.1.242

--- a/TrinityBackendDjango/.env.example
+++ b/TrinityBackendDjango/.env.example
@@ -4,14 +4,17 @@ POSTGRES_USER=trinity
 POSTGRES_PASSWORD=trinity
 CELERY_BROKER_URL=redis://redis:6379/0
 CELERY_RESULT_BACKEND=redis://redis:6379/1
-FRONTEND_URL=http://localhost:8080
+# Address of the React frontend. Replace <YOUR-IP> with the host running Vite.
+FRONTEND_URL=http://<YOUR-IP>:8080
 # Requests for this domain (and 127.0.0.1) map to the default tenant
 PRIMARY_DOMAIN=localhost
 # If true, tenant creation skips migrations and seeding
 SIMPLE_TENANT_CREATION=true
-# Comma separated list of hosts allowed by Django
-ALLOWED_HOSTS=localhost
-# Domain for CSRF protection when accessing via browser (include protocol)
-CSRF_TRUSTED_ORIGINS=https://example.com
+# Comma separated list of hosts allowed by Django. Use "*" for dev so the
+# server is reachable from any IP address.
+ALLOWED_HOSTS=*
+# Domain for CSRF protection when accessing via browser (include protocol).
+# Set this to the IP or domain serving the frontend.
+CSRF_TRUSTED_ORIGINS=http://<YOUR-IP>:8080
 # Comma separated list of origins for CORS. Leave empty to allow all (dev).
 CORS_ALLOWED_ORIGINS=

--- a/TrinityBackendDjango/.env.example
+++ b/TrinityBackendDjango/.env.example
@@ -4,7 +4,7 @@ POSTGRES_USER=trinity
 POSTGRES_PASSWORD=trinity
 CELERY_BROKER_URL=redis://redis:6379/0
 CELERY_RESULT_BACKEND=redis://redis:6379/1
-# Address of the React frontend. Update if you deploy to another host.
+# Address of the React frontend. Replace the IP with your host or domain.
 FRONTEND_URL=http://10.2.1.242:8080
 # Requests for this domain (and 127.0.0.1) map to the default tenant
 PRIMARY_DOMAIN=localhost
@@ -15,9 +15,12 @@ SIMPLE_TENANT_CREATION=true
 ALLOWED_HOSTS=*
 # Domain for CSRF protection when accessing via browser (include protocol).
 # Set this to the IP or domain serving the frontend.
-CSRF_TRUSTED_ORIGINS=http://10.2.1.242:8080
+# Origins allowed to post to Django's CSRF protected views
+# Include your Cloudflare domain if tunnelling.
+CSRF_TRUSTED_ORIGINS=http://10.2.1.242:8080,https://trinity.quantmatrix.ai
 # Comma separated list of origins for CORS. Leave empty to allow all (dev).
 CORS_ALLOWED_ORIGINS=
 # Extra comma separated domain names or IP addresses that should map to the
 # default tenant when using django-tenants. Useful when accessing via a LAN IP.
-ADDITIONAL_DOMAINS=10.2.1.242
+# Extra hostnames that map to the default tenant. Add your domain when tunnelling.
+ADDITIONAL_DOMAINS=10.2.1.242,trinity.quantmatrix.ai

--- a/TrinityBackendDjango/create_tenant.py
+++ b/TrinityBackendDjango/create_tenant.py
@@ -69,6 +69,19 @@ def main():
                 )
                 if created:
                     print(f"   → Added alias domain: {alias}")
+
+        # Allow optional extra domains via env var so the app works when
+        # accessed from an IP or external hostname.
+        additional = os.getenv("ADDITIONAL_DOMAINS", "")
+        for host in [h.strip() for h in additional.split(",") if h.strip()]:
+            if host != primary_domain:
+                alias, created = Domain.objects.get_or_create(
+                    domain=host,
+                    tenant=tenant_obj,
+                    defaults={"is_primary": False},
+                )
+                if created:
+                    print(f"   → Added extra domain: {alias}")
     print()
 
     print(f"→ 3) Running TENANT-SCHEMA migrations for '{tenant_schema}'…")

--- a/TrinityFrontend/.env.example
+++ b/TrinityFrontend/.env.example
@@ -1,11 +1,13 @@
-VITE_ACCOUNTS_API=http://localhost:8000/api/accounts
-VITE_REGISTRY_API=http://localhost:8000/api/registry
-VITE_TENANTS_API=http://localhost:8000/api/tenants
-VITE_TEXT_API=http://localhost:8001/api/t
-VITE_SUBSCRIPTIONS_API=http://localhost:8000/api/subscriptions
-VITE_CARD_API=http://localhost:8001/api
+# Example values for running everything on a single machine. Replace
+# <YOUR-IP> with the address of the host so the app works from other devices.
+VITE_ACCOUNTS_API=http://<YOUR-IP>:8000/api/accounts
+VITE_REGISTRY_API=http://<YOUR-IP>:8000/api/registry
+VITE_TENANTS_API=http://<YOUR-IP>:8000/api/tenants
+VITE_TEXT_API=http://<YOUR-IP>:8001/api/t
+VITE_SUBSCRIPTIONS_API=http://<YOUR-IP>:8000/api/subscriptions
+VITE_CARD_API=http://<YOUR-IP>:8001/api
 # Base URL of the backend API used when the above variables are not set.
-VITE_BACKEND_ORIGIN=http://localhost:8000
+VITE_BACKEND_ORIGIN=http://<YOUR-IP>:8000
 
 # When deploying, change these URLs to your external domain.
 

--- a/TrinityFrontend/.env.example
+++ b/TrinityFrontend/.env.example
@@ -1,12 +1,12 @@
 # Example values for running everything on a single machine.
-# Update the IP if you deploy to another host.
+# Update the IP or replace it with your domain when tunnelling.
 VITE_ACCOUNTS_API=http://10.2.1.242:8000/api/accounts
 VITE_REGISTRY_API=http://10.2.1.242:8000/api/registry
 VITE_TENANTS_API=http://10.2.1.242:8000/api/tenants
 VITE_TEXT_API=http://10.2.1.242:8001/api/t
 VITE_SUBSCRIPTIONS_API=http://10.2.1.242:8000/api/subscriptions
 VITE_CARD_API=http://10.2.1.242:8001/api
-# Base URL of the backend API used when the above variables are not set.
+# Base URL used when the above variables aren't set.
 VITE_BACKEND_ORIGIN=http://10.2.1.242:8000
 
 # When deploying, change these URLs to your external domain.

--- a/TrinityFrontend/.env.example
+++ b/TrinityFrontend/.env.example
@@ -1,13 +1,13 @@
-# Example values for running everything on a single machine. Replace
-# <YOUR-IP> with the address of the host so the app works from other devices.
-VITE_ACCOUNTS_API=http://<YOUR-IP>:8000/api/accounts
-VITE_REGISTRY_API=http://<YOUR-IP>:8000/api/registry
-VITE_TENANTS_API=http://<YOUR-IP>:8000/api/tenants
-VITE_TEXT_API=http://<YOUR-IP>:8001/api/t
-VITE_SUBSCRIPTIONS_API=http://<YOUR-IP>:8000/api/subscriptions
-VITE_CARD_API=http://<YOUR-IP>:8001/api
+# Example values for running everything on a single machine.
+# Update the IP if you deploy to another host.
+VITE_ACCOUNTS_API=http://10.2.1.242:8000/api/accounts
+VITE_REGISTRY_API=http://10.2.1.242:8000/api/registry
+VITE_TENANTS_API=http://10.2.1.242:8000/api/tenants
+VITE_TEXT_API=http://10.2.1.242:8001/api/t
+VITE_SUBSCRIPTIONS_API=http://10.2.1.242:8000/api/subscriptions
+VITE_CARD_API=http://10.2.1.242:8001/api
 # Base URL of the backend API used when the above variables are not set.
-VITE_BACKEND_ORIGIN=http://<YOUR-IP>:8000
+VITE_BACKEND_ORIGIN=http://10.2.1.242:8000
 
 # When deploying, change these URLs to your external domain.
 

--- a/TrinityFrontend/Dockerfile
+++ b/TrinityFrontend/Dockerfile
@@ -9,5 +9,6 @@ RUN npm run build
 # Serve the compiled app with Nginx
 FROM nginx:1.25-alpine
 COPY --from=build /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/TrinityFrontend/nginx.conf
+++ b/TrinityFrontend/nginx.conf
@@ -1,0 +1,9 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/TrinityFrontend/src/pages/Login.tsx
+++ b/TrinityFrontend/src/pages/Login.tsx
@@ -38,11 +38,17 @@ const Login = () => {
   };
 
   return (
-    <div
-      className="min-h-screen bg-cover bg-center flex items-center justify-center p-4"
-      style={{ backgroundImage: "url('/background.svg')" }}
-    >
-      <div className="w-full max-w-md space-y-8 shadow-lg">
+    <div className="min-h-screen flex items-center justify-center p-4 relative">
+      <video
+        autoPlay
+        loop
+        muted
+        playsInline
+        className="absolute inset-0 w-full h-full object-cover"
+      >
+        <source src="/background.mp4" type="video/mp4" />
+      </video>
+      <div className="w-full max-w-md space-y-8 shadow-lg relative z-10">
         {/* Trinity Logo */}
         <div className="flex flex-col items-center space-y-2 text-white">
           <AnimatedLogo className="w-20 h-20 drop-shadow-[0_0_10px_rgba(255,255,255,0.8)]" />

--- a/routing_fix.txt
+++ b/routing_fix.txt
@@ -2,13 +2,14 @@
    The frontend Docker image now includes a custom Nginx config so React routes
    like `/login` work correctly.
 
-2. Update `TrinityBackendDjango/.env` with the following variables so the app works from any IP address:
-   - `ALLOWED_HOSTS=*` to accept requests from any domain or IP.
-   - `FRONTEND_URL=http://10.2.1.242:8080` matching where the React app runs.
-   - `CSRF_TRUSTED_ORIGINS=http://10.2.1.242:8080` so Django accepts login posts from that address.
-   - `ADDITIONAL_DOMAINS=10.2.1.242` to map the backend tenant to that IP. Use your external domain instead when tunnelling through Cloudflare.
+2. Update `TrinityBackendDjango/.env` with the following values so the app works from any IP or domain:
+   - `ALLOWED_HOSTS=*` to accept requests from any domain.
+   - `FRONTEND_URL=http://10.2.1.242:8080` or your external domain.
+   - `CSRF_TRUSTED_ORIGINS=http://10.2.1.242:8080,https://trinity.quantmatrix.ai`
+     so Django accepts login posts from both addresses.
+   - `ADDITIONAL_DOMAINS=10.2.1.242,trinity.quantmatrix.ai` to map the default tenant to each hostname.
 
-3. Rebuild and start the stack. This will also rebuild the frontend image so the
+3. Rebuild and start the stack and re-run `create_tenant.py` to apply the new domain aliases. This will also rebuild the frontend image so the
    custom Nginx config is used:
    ```bash
    cd TrinityBackendDjango

--- a/routing_fix.txt
+++ b/routing_fix.txt
@@ -1,12 +1,18 @@
-1. Update `TrinityBackendDjango/.env` with the following variables:
-   - `ALLOWED_HOSTS=*` to accept requests from any domain.
-   - `CSRF_TRUSTED_ORIGINS=https://your-domain.com` so Django accepts form posts when proxied through Cloudflare.
-2. Rebuild and start the stack:
+1. Copy `background.mp4` into `TrinityFrontend/public`. The login page now loads this video as the full-screen background.
+
+2. Update `TrinityBackendDjango/.env` with the following variables so the app works from any IP address:
+   - `ALLOWED_HOSTS=*` to accept requests from any domain or IP.
+   - `FRONTEND_URL=http://<YOUR-IP>:8080` matching where the React app runs.
+   - `CSRF_TRUSTED_ORIGINS=http://<YOUR-IP>:8080` so Django accepts login posts from that address. Use the public domain when tunnelling through Cloudflare.
+
+3. Rebuild and start the stack:
    ```bash
    cd TrinityBackendDjango
    docker-compose up -d --build
    ```
-3. Configure your Cloudflare tunnel to point to the frontend container on port `8080` and expose port `8000` for the Django API.
-4. Update `TrinityFrontend/.env` so the `VITE_*` variables (or `VITE_BACKEND_ORIGIN`) use the external domain for the backend. Also set `FRONTEND_URL` in `TrinityBackendDjango/.env` to the same domain.
-5. After rebuilding and restarting the containers you should be able to log in and add users or clients from any IP address via the tunneled domain.
+4. Configure your Cloudflare tunnel to point to the frontend container on port `8080` and expose port `8000` for the Django API.
+
+5. Update `TrinityFrontend/.env` so the `VITE_*` variables (or `VITE_BACKEND_ORIGIN`) use `http://<YOUR-IP>:8000` or your Cloudflare domain. Set `FRONTEND_URL` in `TrinityBackendDjango/.env` to the same value.
+
+6. After rebuilding and restarting the containers you can access the app via the IP address or tunneled domain, log in, and manage clients or users without errors.
 

--- a/routing_fix.txt
+++ b/routing_fix.txt
@@ -5,7 +5,8 @@
 2. Update `TrinityBackendDjango/.env` with the following variables so the app works from any IP address:
    - `ALLOWED_HOSTS=*` to accept requests from any domain or IP.
    - `FRONTEND_URL=http://10.2.1.242:8080` matching where the React app runs.
-   - `CSRF_TRUSTED_ORIGINS=http://10.2.1.242:8080` so Django accepts login posts from that address. Use the public domain when tunnelling through Cloudflare.
+   - `CSRF_TRUSTED_ORIGINS=http://10.2.1.242:8080` so Django accepts login posts from that address.
+   - `ADDITIONAL_DOMAINS=10.2.1.242` to map the backend tenant to that IP. Use your external domain instead when tunnelling through Cloudflare.
 
 3. Rebuild and start the stack. This will also rebuild the frontend image so the
    custom Nginx config is used:

--- a/routing_fix.txt
+++ b/routing_fix.txt
@@ -4,8 +4,8 @@
 
 2. Update `TrinityBackendDjango/.env` with the following variables so the app works from any IP address:
    - `ALLOWED_HOSTS=*` to accept requests from any domain or IP.
-   - `FRONTEND_URL=http://<YOUR-IP>:8080` matching where the React app runs.
-   - `CSRF_TRUSTED_ORIGINS=http://<YOUR-IP>:8080` so Django accepts login posts from that address. Use the public domain when tunnelling through Cloudflare.
+   - `FRONTEND_URL=http://10.2.1.242:8080` matching where the React app runs.
+   - `CSRF_TRUSTED_ORIGINS=http://10.2.1.242:8080` so Django accepts login posts from that address. Use the public domain when tunnelling through Cloudflare.
 
 3. Rebuild and start the stack. This will also rebuild the frontend image so the
    custom Nginx config is used:
@@ -13,7 +13,7 @@
    cd TrinityBackendDjango
    docker-compose up -d --build
    ```
-4. Update `TrinityFrontend/.env` so the `VITE_*` variables (or `VITE_BACKEND_ORIGIN`) use `http://<YOUR-IP>:8000` or your Cloudflare domain. Set `FRONTEND_URL` in `TrinityBackendDjango/.env` to the same value.
+4. Update `TrinityFrontend/.env` so the `VITE_*` variables (or `VITE_BACKEND_ORIGIN`) use `http://10.2.1.242:8000` or your Cloudflare domain. Set `FRONTEND_URL` in `TrinityBackendDjango/.env` to the same value.
 
 5. Configure a Cloudflare Tunnel so the app is reachable at `https://trinity.quantmatrix.ai`:
    1. Install the `cloudflared` CLI and authenticate with `cloudflared login`.
@@ -27,6 +27,6 @@
       `http://localhost:8000`.
 
 6. After rebuilding and restarting the containers you can access the app via the
-   IP address or the `trinity.quantmatrix.ai` domain, log in, and manage clients
-   or users without errors.
+   IP address (`http://10.2.1.242:8080`) or the `trinity.quantmatrix.ai` domain,
+   log in, and manage clients or users without errors.
 

--- a/routing_fix.txt
+++ b/routing_fix.txt
@@ -1,18 +1,32 @@
 1. Copy `background.mp4` into `TrinityFrontend/public`. The login page now loads this video as the full-screen background.
+   The frontend Docker image now includes a custom Nginx config so React routes
+   like `/login` work correctly.
 
 2. Update `TrinityBackendDjango/.env` with the following variables so the app works from any IP address:
    - `ALLOWED_HOSTS=*` to accept requests from any domain or IP.
    - `FRONTEND_URL=http://<YOUR-IP>:8080` matching where the React app runs.
    - `CSRF_TRUSTED_ORIGINS=http://<YOUR-IP>:8080` so Django accepts login posts from that address. Use the public domain when tunnelling through Cloudflare.
 
-3. Rebuild and start the stack:
+3. Rebuild and start the stack. This will also rebuild the frontend image so the
+   custom Nginx config is used:
    ```bash
    cd TrinityBackendDjango
    docker-compose up -d --build
    ```
-4. Configure your Cloudflare tunnel to point to the frontend container on port `8080` and expose port `8000` for the Django API.
+4. Update `TrinityFrontend/.env` so the `VITE_*` variables (or `VITE_BACKEND_ORIGIN`) use `http://<YOUR-IP>:8000` or your Cloudflare domain. Set `FRONTEND_URL` in `TrinityBackendDjango/.env` to the same value.
 
-5. Update `TrinityFrontend/.env` so the `VITE_*` variables (or `VITE_BACKEND_ORIGIN`) use `http://<YOUR-IP>:8000` or your Cloudflare domain. Set `FRONTEND_URL` in `TrinityBackendDjango/.env` to the same value.
+5. Configure a Cloudflare Tunnel so the app is reachable at `https://trinity.quantmatrix.ai`:
+   1. Install the `cloudflared` CLI and authenticate with `cloudflared login`.
+   2. Create a tunnel and give it a name:
+      `cloudflared tunnel create trinity`
+   3. Map the tunnel to the frontend container:
+      `cloudflared tunnel run trinity --url http://localhost:8080`
+   4. In the Cloudflare dashboard, add a DNS CNAME record for
+      `trinity.quantmatrix.ai` that points to the tunnel.
+   5. Optionally expose the backend by running another tunnel to
+      `http://localhost:8000`.
 
-6. After rebuilding and restarting the containers you can access the app via the IP address or tunneled domain, log in, and manage clients or users without errors.
+6. After rebuilding and restarting the containers you can access the app via the
+   IP address or the `trinity.quantmatrix.ai` domain, log in, and manage clients
+   or users without errors.
 


### PR DESCRIPTION
## Summary
- use `background.mp4` as login page background
- show how to configure FE/BE env files for any IP
- mention IP settings and Cloudflare domain in `routing_fix.txt`

## Testing
- `npm run lint`
- `npm run build`
- `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_6850024793f88321afe821eb775d8872