### PR TITLE
Centralize host IP configuration

### DIFF
--- a/TrinityBackendDjango/.env
+++ b/TrinityBackendDjango/.env
@@ -4,12 +4,16 @@ POSTGRES_USER=trinity_user
 POSTGRES_PASSWORD=trinity_pass
 CELERY_BROKER_URL=redis://redis:6379/0
 CELERY_RESULT_BACKEND=redis://redis:6379/1
+# IP address where the frontend and backend will be reachable
+HOST_IP=10.2.1.242
+# MongoDB connection string
+MONGO_URI=mongodb://mongo:27017/trinity
 
 # Frontend URL used for CORS
 # Address of the React frontend
-FRONTEND_URL=http://10.2.1.242:8080
+FRONTEND_URL=
 ALLOWED_HOSTS=*
-CSRF_TRUSTED_ORIGINS=http://10.2.1.242:8080
+CSRF_TRUSTED_ORIGINS=
 # Comma separated list of origins for CORS. Leave empty to allow all.
 CORS_ALLOWED_ORIGINS=
-ADDITIONAL_DOMAINS=10.2.1.242
+ADDITIONAL_DOMAINS=

--- a/TrinityBackendDjango/.env.example
+++ b/TrinityBackendDjango/.env.example
@@ -1,11 +1,16 @@
+# IP address where the frontend and backend will be reachable
+HOST_IP=10.2.1.242
+
 DEBUG=true
 POSTGRES_DB=trinity
 POSTGRES_USER=trinity
 POSTGRES_PASSWORD=trinity
 CELERY_BROKER_URL=redis://redis:6379/0
 CELERY_RESULT_BACKEND=redis://redis:6379/1
-# Address of the React frontend. Update if you deploy to another host.
-FRONTEND_URL=http://10.2.1.242:8080
+# MongoDB connection string
+MONGO_URI=mongodb://mongo:27017/trinity
+# Address of the React frontend. Uses HOST_IP if not overridden.
+FRONTEND_URL=
 # Requests for this domain (and 127.0.0.1) map to the default tenant
 PRIMARY_DOMAIN=localhost
 # If true, tenant creation skips migrations and seeding
@@ -15,9 +20,9 @@ SIMPLE_TENANT_CREATION=true
 ALLOWED_HOSTS=*
 # Domain for CSRF protection when accessing via browser (include protocol).
 # Set this to the IP or domain serving the frontend.
-CSRF_TRUSTED_ORIGINS=http://10.2.1.242:8080
+CSRF_TRUSTED_ORIGINS=
 # Comma separated list of origins for CORS. Leave empty to allow all (dev).
 CORS_ALLOWED_ORIGINS=
 # Extra comma separated domain names or IP addresses that should map to the
 # default tenant when using django-tenants. Useful when accessing via a LAN IP.
-ADDITIONAL_DOMAINS=10.2.1.242
+ADDITIONAL_DOMAINS=

--- a/TrinityBackendDjango/config/settings.py
+++ b/TrinityBackendDjango/config/settings.py
@@ -36,6 +36,8 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # ------------------------------------------------------------------
 # Security
 # ------------------------------------------------------------------
+HOST_IP = os.getenv("HOST_IP", "10.2.1.242")
+FRONTEND_URL = os.getenv("FRONTEND_URL", f"http://{HOST_IP}:8080")
 SECRET_KEY = os.getenv("SECRET_KEY", "change-me-in-production")
 DEBUG = os.getenv("DEBUG", "False") == "True"
 # Allow requests from the provided comma separated list of hosts. Use "*" to
@@ -45,8 +47,9 @@ ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "*").split(",")
 # Explicitly trust these origins for CSRF-protected requests such as the login
 # form. When deploying behind Cloudflare or another proxy, add your external
 # domain (e.g. "https://example.com") here so browser POSTs are accepted.
-_trusted = os.getenv("CSRF_TRUSTED_ORIGINS")
+_trusted = os.getenv("CSRF_TRUSTED_ORIGINS", FRONTEND_URL)
 CSRF_TRUSTED_ORIGINS = _trusted.split(",") if _trusted else []
+ADDITIONAL_DOMAINS = os.getenv("ADDITIONAL_DOMAINS", HOST_IP)
 
 # ------------------------------------------------------------------
 # CORS configuration

--- a/TrinityBackendDjango/create_tenant.py
+++ b/TrinityBackendDjango/create_tenant.py
@@ -72,7 +72,9 @@ def main():
 
         # Allow optional extra domains via env var so the app works when
         # accessed from an IP or external hostname.
-        additional = os.getenv("ADDITIONAL_DOMAINS", "")
+        additional = os.getenv("ADDITIONAL_DOMAINS")
+        if not additional:
+            additional = os.getenv("HOST_IP", "")
         for host in [h.strip() for h in additional.split(",") if h.strip()]:
             if host != primary_domain:
                 alias, created = Domain.objects.get_or_create(

--- a/TrinityBackendFastAPI/app/features/feature_overview/deps.py
+++ b/TrinityBackendFastAPI/app/features/feature_overview/deps.py
@@ -1,7 +1,12 @@
 from motor.motor_asyncio import AsyncIOMotorClient
-# from .config import settings
+import os
 
-client = AsyncIOMotorClient("mongodb://admin_dev:pass_dev@10.2.1.65:9005/?authSource=admin")
+MONGO_URI = os.getenv(
+    "OVERVIEW_MONGO_URI",
+    "mongodb://admin_dev:pass_dev@10.2.1.65:9005/?authSource=admin",
+)
+
+client = AsyncIOMotorClient(MONGO_URI)
 db = client["feature_overview_db"]
 
 async def get_unique_dataframe_results_collection():

--- a/TrinityFrontend/.env.example
+++ b/TrinityFrontend/.env.example
@@ -1,13 +1,15 @@
 # Example values for running everything on a single machine.
-# Update the IP if you deploy to another host.
-VITE_ACCOUNTS_API=http://10.2.1.242:8000/api/accounts
-VITE_REGISTRY_API=http://10.2.1.242:8000/api/registry
-VITE_TENANTS_API=http://10.2.1.242:8000/api/tenants
-VITE_TEXT_API=http://10.2.1.242:8001/api/t
-VITE_SUBSCRIPTIONS_API=http://10.2.1.242:8000/api/subscriptions
-VITE_CARD_API=http://10.2.1.242:8001/api
-# Base URL of the backend API used when the above variables are not set.
-VITE_BACKEND_ORIGIN=http://10.2.1.242:8000
+# Change VITE_HOST_IP if you deploy to another host.
+VITE_HOST_IP=10.2.1.242
+# Optional overrides for specific APIs. Leave empty to use VITE_HOST_IP.
+VITE_ACCOUNTS_API=
+VITE_REGISTRY_API=
+VITE_TENANTS_API=
+VITE_TEXT_API=
+VITE_SUBSCRIPTIONS_API=
+VITE_CARD_API=
+# Base URL of the backend API if you don't want to use VITE_HOST_IP.
+VITE_BACKEND_ORIGIN=
 
 # When deploying, change these URLs to your external domain.
 

--- a/TrinityFrontend/nginx.conf
+++ b/TrinityFrontend/nginx.conf
@@ -1,5 +1,6 @@
 server {
     listen 80;
+    # Change this to your domain if not using the IP directly
     server_name _;
     root /usr/share/nginx/html;
 

--- a/TrinityFrontend/src/lib/api.ts
+++ b/TrinityFrontend/src/lib/api.ts
@@ -1,8 +1,11 @@
+const hostIp = import.meta.env.VITE_HOST_IP;
 const backendOrigin =
   import.meta.env.VITE_BACKEND_ORIGIN ||
-  (typeof window !== 'undefined'
-    ? window.location.origin
-    : 'http://localhost:8000');
+  (hostIp
+    ? `http://${hostIp}:8000`
+    : typeof window !== 'undefined'
+      ? window.location.origin.replace(/:8080$/, ':8000')
+      : 'http://localhost:8000');
 
 export const ACCOUNTS_API =
   import.meta.env.VITE_ACCOUNTS_API || `${backendOrigin}/api/accounts`;

--- a/routing_fix.txt
+++ b/routing_fix.txt
@@ -31,3 +31,16 @@
    IP address (`http://10.2.1.242:8080`) or the `trinity.quantmatrix.ai` domain,
    log in, and manage clients or users without errors.
 
+7. **Running on a new host IP**
+   1. Edit `TrinityBackendDjango/.env` and set `HOST_IP` to the machine's IP
+      address. Leave `FRONTEND_URL`, `CSRF_TRUSTED_ORIGINS` and
+      `ADDITIONAL_DOMAINS` blank so Django derives them from `HOST_IP`.
+   2. Edit `TrinityFrontend/.env` and set `VITE_HOST_IP` to the same value.
+   3. If MongoDB runs elsewhere, set `OVERVIEW_MONGO_URI` in the backend `.env`
+      to the correct connection string.
+   4. Update `TrinityFrontend/nginx.conf` if you need a custom `server_name`.
+      The bundled config already rewrites unknown routes to `index.html` so the
+      React router works.
+   5. Rebuild the containers with `docker-compose up -d --build` and access the
+      app at `http://<HOST_IP>:8080`.
+


### PR DESCRIPTION
## Summary
- allow setting `HOST_IP` for Django backend defaults
- rely on `VITE_HOST_IP` in frontend API helper
- make Mongo URI configurable for feature overview service
- reference new variables in `.env` examples
- add guidance on switching IPs and nginx in `routing_fix.txt`

## Testing
- `pytest` *(no tests ran)*
- `npm test` *(failed: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6851014ca0b08321a600691f375ebd64