### PR TITLE
Refactor routing with app filtering

### DIFF
--- a/TrinityBackendFastAPI/app/features/data_upload_validate/Validate_Atom/app/database.py
+++ b/TrinityBackendFastAPI/app/features/data_upload_validate/Validate_Atom/app/database.py
@@ -1,0 +1,374 @@
+# app/database.py - MongoDB operations for Validator Atom System
+
+from pymongo import MongoClient
+from datetime import datetime
+import logging
+
+# MongoDB Configuration
+MONGODB_URL = "mongodb://admin_dev:pass_dev@10.2.1.65:9005/?authSource=admin"
+DATABASE_NAME = "validator_atoms_db"
+
+# Collection Names
+COLLECTIONS = {
+    "VALIDATOR_ATOMS": "validator_atoms",
+    "COLUMN_CLASSIFICATIONS": "column_classifications", 
+    "BUSINESS_DIMENSIONS": "business_dimensions_with_assignments",
+    "VALIDATION_LOGS": "validation_logs",
+    "VALIDATION_CONFIG": "validation_config"
+}
+
+# Initialize MongoDB client with timeout
+try:
+    mongo_client = MongoClient(MONGODB_URL, serverSelectionTimeoutMS=5000)
+    db = mongo_client[DATABASE_NAME]
+    
+    # Test connection
+    mongo_client.admin.command('ping')
+    print(f"✅ Connected to MongoDB at {MONGODB_URL}")
+    
+except Exception as e:
+    print(f"❌ MongoDB connection failed: {e}")
+    mongo_client = None
+    db = None
+
+def check_mongodb_connection():
+    """Check if MongoDB is available"""
+    return mongo_client is not None and db is not None
+
+def save_classification_to_mongo(validator_atom_id: str, file_key: str, classification_data: dict):
+    """Save column classification to MongoDB"""
+    if not check_mongodb_connection():
+        return {"status": "error", "error": "MongoDB not connected"}
+    
+    try:
+        document_id = f"{validator_atom_id}_{file_key}_classification"
+        document = {
+            "_id": document_id,
+            "validator_atom_id": validator_atom_id,
+            "file_key": file_key,
+            "created_at": datetime.utcnow(),
+            "updated_at": datetime.utcnow(),
+            **classification_data
+        }
+        
+        result = db[COLLECTIONS["COLUMN_CLASSIFICATIONS"]].replace_one(
+            {"_id": document_id}, 
+            document, 
+            upsert=True
+        )
+        
+        return {
+            "status": "success", 
+            "mongo_id": document_id,
+            "operation": "inserted" if result.upserted_id else "updated",
+            "collection": COLLECTIONS["COLUMN_CLASSIFICATIONS"]
+        }
+        
+    except Exception as e:
+        logging.error(f"MongoDB save error for classification: {e}")
+        return {"status": "error", "error": str(e)}
+
+def save_validator_atom_to_mongo(validator_atom_id: str, validator_data: dict):
+    """Save validator atom configuration to MongoDB"""
+    if not check_mongodb_connection():
+        return {"status": "error", "error": "MongoDB not connected"}
+    
+    try:
+        document = {
+            "_id": validator_atom_id,
+            "created_at": datetime.utcnow(),
+            "updated_at": datetime.utcnow(),
+            **validator_data
+        }
+        
+        result = db[COLLECTIONS["VALIDATOR_ATOMS"]].replace_one(
+            {"_id": validator_atom_id}, 
+            document, 
+            upsert=True
+        )
+        
+        return {
+            "status": "success", 
+            "mongo_id": validator_atom_id,
+            "operation": "inserted" if result.upserted_id else "updated",
+            "collection": COLLECTIONS["VALIDATOR_ATOMS"]
+        }
+        
+    except Exception as e:
+        logging.error(f"MongoDB save error for validator atom: {e}")
+        return {"status": "error", "error": str(e)}
+
+def save_validation_log_to_mongo(validation_data: dict):
+    """Save validation transaction log to MongoDB"""
+    if not check_mongodb_connection():
+        return {"status": "error", "error": "MongoDB not connected"}
+    
+    try:
+        document = {
+            "validation_timestamp": datetime.utcnow(),
+            **validation_data
+        }
+        
+        result = db[COLLECTIONS["VALIDATION_LOGS"]].insert_one(document)
+        
+        return {
+            "status": "success", 
+            "mongo_id": str(result.inserted_id),
+            "collection": COLLECTIONS["VALIDATION_LOGS"]
+        }
+        
+    except Exception as e:
+        logging.error(f"MongoDB save error for validation log: {e}")
+        return {"status": "error", "error": str(e)}
+
+def get_classification_from_mongo(validator_atom_id: str, file_key: str):
+    """Retrieve classification data from MongoDB"""
+    if not check_mongodb_connection():
+        return None
+    
+    try:
+        document_id = f"{validator_atom_id}_{file_key}_classification"
+        result = db[COLLECTIONS["COLUMN_CLASSIFICATIONS"]].find_one({"_id": document_id})
+        return result
+        
+    except Exception as e:
+        logging.error(f"MongoDB read error for classification: {e}")
+        return None
+
+def test_mongodb_operations():
+    """Test MongoDB connection and basic operations"""
+    if not check_mongodb_connection():
+        return {
+            "status": "error",
+            "message": "MongoDB not connected",
+            "mongodb_url": MONGODB_URL
+        }
+    
+    try:
+        # Test basic operations
+        databases = mongo_client.list_database_names()
+        collections = db.list_collection_names()
+        
+        return {
+            "status": "success",
+            "message": "MongoDB operations working",
+            "mongodb_url": MONGODB_URL,
+            "database": DATABASE_NAME,
+            "available_databases": databases,
+            "collections": collections
+        }
+        
+    except Exception as e:
+        return {
+            "status": "error",
+            "message": f"MongoDB test failed: {str(e)}",
+            "mongodb_url": MONGODB_URL
+        }
+
+
+
+def get_validator_atom_from_mongo(validator_atom_id: str):
+    """Get validator atom data from MongoDB"""
+    if not check_mongodb_connection():
+        return None
+    
+    try:
+        result = db[COLLECTIONS["VALIDATOR_ATOMS"]].find_one({"_id": validator_atom_id})
+        return result
+        
+    except Exception as e:
+        logging.error(f"MongoDB read error for validator atom: {e}")
+        return None
+
+
+def update_validator_atom_in_mongo(validator_atom_id: str, update_data: dict):
+    """Update validator atom document in MongoDB"""
+    if not check_mongodb_connection():
+        return {"status": "error", "error": "MongoDB not connected"}
+    
+    try:
+        result = db[COLLECTIONS["VALIDATOR_ATOMS"]].update_one(
+            {"_id": validator_atom_id},
+            {
+                "$set": {
+                    **update_data,
+                    "updated_at": datetime.utcnow()
+                }
+            }
+        )
+        
+        if result.matched_count == 0:
+            return {"status": "error", "error": "Validator atom not found"}
+        
+        return {
+            "status": "success",
+            "modified_count": result.modified_count,
+            "matched_count": result.matched_count
+        }
+        
+    except Exception as e:
+        logging.error(f"MongoDB update error for validator atom: {e}")
+        return {"status": "error", "error": str(e)}
+
+
+
+def save_business_dimensions_to_mongo(validator_atom_id: str, file_key: str, dimensions_data: dict):
+    """Save business dimensions to MongoDB"""
+    if not check_mongodb_connection():
+        return {"status": "error", "error": "MongoDB not connected"}
+    
+    try:
+        document_id = f"{validator_atom_id}_{file_key}_dimensions"
+        
+        # Convert dimensions dict to array format for MongoDB
+        dimensions_array = []
+        for dim_id, dim_data in dimensions_data.items():
+            dimensions_array.append({
+                "dimension_id": dim_id,
+                "dimension_name": dim_data.get("name", dim_id),
+                "description": dim_data.get("description", ""),
+                "assigned_identifiers": []  # Empty initially, filled by assign_identifiers endpoint
+            })
+        
+        document = {
+            "_id": document_id,
+            "validator_atom_id": validator_atom_id,
+            "file_key": file_key,
+            "created_at": datetime.utcnow(),
+            "updated_at": datetime.utcnow(),
+            "dimensions": dimensions_array,
+            "total_dimensions": len(dimensions_array)
+        }
+        
+        result = db[COLLECTIONS["BUSINESS_DIMENSIONS"]].replace_one(
+            {"_id": document_id}, 
+            document, 
+            upsert=True
+        )
+        
+        return {
+            "status": "success", 
+            "mongo_id": document_id,
+            "operation": "inserted" if result.upserted_id else "updated",
+            "collection": COLLECTIONS["BUSINESS_DIMENSIONS"]
+        }
+        
+    except Exception as e:
+        logging.error(f"MongoDB save error for business dimensions: {e}")
+        return {"status": "error", "error": str(e)}
+
+
+
+def get_business_dimensions_from_mongo(validator_atom_id: str, file_key: str):
+    """Get business dimensions data from MongoDB"""
+    if not check_mongodb_connection():
+        return None
+    
+    try:
+        document_id = f"{validator_atom_id}_{file_key}_dimensions"
+        result = db[COLLECTIONS["BUSINESS_DIMENSIONS"]].find_one({"_id": document_id})
+        return result
+        
+    except Exception as e:
+        logging.error(f"MongoDB read error for business dimensions: {e}")
+        return None
+
+def update_business_dimensions_assignments_in_mongo(validator_atom_id: str, file_key: str, assignments: dict):
+    """Update business dimensions with identifier assignments in MongoDB"""
+    if not check_mongodb_connection():
+        return {"status": "error", "error": "MongoDB not connected"}
+    
+    try:
+        document_id = f"{validator_atom_id}_{file_key}_dimensions"
+        
+        # ✅ SIMPLER APPROACH: Get document, modify, and replace
+        existing_doc = db[COLLECTIONS["BUSINESS_DIMENSIONS"]].find_one({"_id": document_id})
+        
+        if not existing_doc:
+            return {"status": "error", "error": "Business dimensions document not found"}
+        
+        # Update the dimensions array with assignments
+        updated_dimensions = existing_doc.get("dimensions", [])
+        for dimension in updated_dimensions:
+            dim_id = dimension.get("dimension_id")
+            if dim_id in assignments:
+                dimension["assigned_identifiers"] = assignments[dim_id]
+        
+        # Replace the entire document
+        result = db[COLLECTIONS["BUSINESS_DIMENSIONS"]].replace_one(
+            {"_id": document_id},
+            {
+                **existing_doc,
+                "dimensions": updated_dimensions,
+                "updated_at": datetime.utcnow()
+            }
+        )
+        
+        print(f"🔍 MongoDB update result: matched={result.matched_count}, modified={result.modified_count}")
+        
+        return {
+            "status": "success",
+            "modified_count": result.modified_count,
+            "matched_count": result.matched_count
+        }
+        
+    except Exception as e:
+        logging.error(f"MongoDB update error for business dimensions assignments: {e}")
+        return {"status": "error", "error": str(e)}
+
+
+
+# ✅ UPDATE: save_validation_config_to_mongo function in app/database.py
+def save_validation_config_to_mongo(validator_atom_id: str, file_key: str, config_data: dict):
+    """Save validation config to MongoDB with optional column frequencies"""
+    if not check_mongodb_connection():
+        return {"status": "error", "error": "MongoDB not connected"}
+    
+    try:
+        document_id = f"{validator_atom_id}_{file_key}_validation_config"
+        
+        # ✅ UPDATED: Include column_frequencies in document
+        document = {
+            "_id": document_id,
+            "validator_atom_id": validator_atom_id,
+            "file_key": file_key,
+            "created_at": datetime.utcnow(),
+            "updated_at": datetime.utcnow(),
+            "column_conditions": config_data.get("column_conditions", {}),
+            "column_frequencies": config_data.get("column_frequencies", {}),  # ✅ ADD THIS
+            "total_conditions": sum(len(cond_list) for cond_list in config_data.get("column_conditions", {}).values()),
+            "columns_with_conditions": list(config_data.get("column_conditions", {}).keys()),
+            "columns_with_frequencies": list(config_data.get("column_frequencies", {}).keys())  # ✅ ADD THIS
+        }
+        
+        result = db[COLLECTIONS["VALIDATION_CONFIG"]].replace_one(
+            {"_id": document_id}, 
+            document, 
+            upsert=True
+        )
+        
+        return {
+            "status": "success", 
+            "mongo_id": document_id,
+            "operation": "inserted" if result.upserted_id else "updated",
+            "collection": COLLECTIONS["VALIDATION_CONFIG"]
+        }
+        
+    except Exception as e:
+        logging.error(f"MongoDB save error for validation config: {e}")
+        return {"status": "error", "error": str(e)}
+
+
+def get_validation_config_from_mongo(validator_atom_id: str, file_key: str):
+    """Get validation config from MongoDB"""
+    if not check_mongodb_connection():
+        return None
+    
+    try:
+        document_id = f"{validator_atom_id}_{file_key}_validation_config"
+        result = db[COLLECTIONS["VALIDATION_CONFIG"]].find_one({"_id": document_id})
+        return result
+        
+    except Exception as e:
+        logging.error(f"MongoDB read error for validation config: {e}")
+        return None

--- a/TrinityBackendFastAPI/app/features/data_upload_validate/Validate_Atom/app/main.py
+++ b/TrinityBackendFastAPI/app/features/data_upload_validate/Validate_Atom/app/main.py
@@ -1,0 +1,67 @@
+# app/main.py - FastAPI App Entrypoint
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from .routes import router
+import uvicorn
+
+# Create FastAPI app instance
+app = FastAPI(
+    title="Validate Atom API",
+    description="Custom Data Validation System with Multiple Validator Types",
+    version="1.0.0",
+    docs_url="/docs",
+    redoc_url="/redoc"
+)
+
+# Add CORS middleware
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],  # In production, specify actual origins
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# Include API routes
+app.include_router(router, prefix="/validator_atom")
+
+# Root endpoint
+@app.get("/")
+async def root():
+    return {
+        "message": "Validate Atom API",
+        "version": "1.0.0",
+        "status": "running",
+        "docs": "/docs",
+        "health": "/validator_atom/health"
+    }
+
+# Health check endpoint (additional to the one in routes)
+@app.get("/")
+async def root():
+    return {
+        "message": "Data Validation Service API",
+        "docs": "/docs",
+        "health": "/health"
+    }
+
+# Optional: Add startup/shutdown events
+@app.on_event("startup")
+async def startup_event():
+    print("🚀 Validate Atom API starting up...")
+    print("📊 Available validators: base, price_elasticity, mmm, innovation, custom")
+    print("📖 API Documentation: http://localhost:8000/docs")
+
+@app.on_event("shutdown")
+async def shutdown_event():
+    print("🛑 Validate Atom API shutting down...")
+
+# For development - run with python -m app.main
+if __name__ == "__main__":
+    uvicorn.run(
+        "app.main:app",
+        host="0.0.0.0",
+        port=8000,
+        reload=True,
+        log_level="info"
+    )

--- a/TrinityBackendFastAPI/app/features/data_upload_validate/Validate_Atom/app/routes.py
+++ b/TrinityBackendFastAPI/app/features/data_upload_validate/Validate_Atom/app/routes.py
@@ -1,0 +1,2806 @@
+# app/routes.py - API Routes
+from fastapi import APIRouter, HTTPException, File, Form, UploadFile, Query, Request
+from typing import List, Dict, Any
+import json
+import pandas as pd
+import io
+import os
+from pathlib import Path
+import re
+
+# Add this line with your other imports
+from datetime import datetime
+
+
+from app.features.data_upload_validate.Validate_Atom.app.validators.mmm import validate_mmm
+from app.features.data_upload_validate.Validate_Atom.app.validators.category_forecasting import validate_category_forecasting
+# Add this import at the top of your routes.py file
+from app.features.data_upload_validate.Validate_Atom.app.validators.promo import validate_promo_intensity
+# app/routes.py - Add this import
+from app.features.data_upload_validate.Validate_Atom.app.schemas import (
+    # Create validator schemas
+    CreateValidatorResponse,
+    
+    # Classification schemas
+    ClassifyColumnsResponse,
+    Classification,
+    AutoClassification,
+    ClassificationSummary,
+    
+    # Column types schemas
+    UpdateColumnTypesResponse,
+    MongoDBUpdateStatus,
+    
+    # Business dimensions schemas
+    DefineDimensionsResponse,
+    BusinessDimensionItem,
+    
+    # Assignment schemas
+    AssignIdentifiersResponse,
+    AssignmentSummary,
+    
+    # Validation schemas
+    ValidateResponse,
+    FileValidationResult,
+    ValidationSummary,
+    MinIOUploadResult,ConditionFailure
+)
+
+# Add to your existing imports in app/routes.py
+from app.features.data_upload_validate.Validate_Atom.app.database import get_validation_config_from_mongo  # ✅ ADD THIS
+
+from app.features.data_upload_validate.Validate_Atom.app.database import save_validation_config_to_mongo
+from app.features.data_upload_validate.Validate_Atom.app.schemas import ConfigureValidationConfigResponse
+from app.features.data_upload_validate.Validate_Atom.app.database import save_classification_to_mongo
+from app.features.data_upload_validate.Validate_Atom.app.database import save_classification_to_mongo, get_validator_atom_from_mongo, update_validator_atom_in_mongo
+
+from app.features.data_upload_validate.Validate_Atom.app.database import save_business_dimensions_to_mongo, get_business_dimensions_from_mongo, get_business_dimensions_from_mongo,get_classification_from_mongo ,update_business_dimensions_assignments_in_mongo
+
+
+
+
+from app.features.data_upload_validate.Validate_Atom.app.database import (
+    get_validator_atom_from_mongo,  # Fallback function
+    save_validation_log_to_mongo
+)
+
+# Add this import
+from app.features.data_upload_validate.Validate_Atom.app.database import save_validator_atom_to_mongo
+from app.features.data_upload_validate.Validate_Atom.app.database import save_classification_to_mongo, get_validator_atom_from_mongo
+
+
+# Initialize router
+router = APIRouter()
+
+
+
+
+
+from app.features.data_upload_validate.Validate_Atom.app.validators.custom_validator import perform_enhanced_validation
+
+# Config directory
+CUSTOM_CONFIG_DIR = Path("custom_validations")
+CUSTOM_CONFIG_DIR.mkdir(exist_ok=True)
+
+# In-memory storage
+extraction_results = {}
+
+# Health check
+@router.get("/health")
+async def health_check():
+    return {"status": "healthy", "message": "Validate Atom API is running"}
+
+# app/routes.py - Add MinIO imports and configuration
+
+from minio import Minio
+from minio.error import S3Error
+import os
+
+# ✅ MINIO CONFIGURATION FOR YOUR SERVER
+MINIO_ENDPOINT = "10.2.1.65:9003"
+MINIO_ACCESS_KEY = "admin_dev"  # Update with your credentials
+MINIO_SECRET_KEY = "pass_dev"  # Update with your credentials
+MINIO_BUCKET = "validated-d1"    # Your existing bucket
+
+# Initialize MinIO client
+minio_client = Minio(
+    endpoint=MINIO_ENDPOINT,
+    access_key=MINIO_ACCESS_KEY,
+    secret_key=MINIO_SECRET_KEY,
+    secure=False
+)
+
+# Check bucket exists
+def check_minio_bucket():
+    try:
+        if minio_client.bucket_exists(MINIO_BUCKET):
+            print(f"✅ MinIO bucket '{MINIO_BUCKET}' is accessible")
+            return True
+        else:
+            print(f"❌ MinIO bucket '{MINIO_BUCKET}' not found")
+            return False
+    except Exception as e:
+        print(f"⚠️ MinIO connection error: {e}")
+        return False
+
+# Test connection on startup
+check_minio_bucket()
+
+
+
+# app/routes.py - Efficient MinIO upload function
+
+# app/routes.py - Add this function definition
+
+def upload_to_minio(file_content_bytes: bytes, filename: str, validator_atom_id: str, file_key: str) -> dict:
+    """
+    Upload file to MinIO - Complete function definition
+    """
+    try:
+        # Create unique object name with timestamp
+        timestamp = pd.Timestamp.now().strftime("%Y%m%d_%H%M%S")
+        object_name = f"{validator_atom_id}/{file_key}/{timestamp}_{filename}"
+        
+        # Convert bytes to BytesIO for seek operations
+        file_content = io.BytesIO(file_content_bytes)
+        
+        # Get file size
+        file_content.seek(0, os.SEEK_END)
+        file_size = file_content.tell()
+        file_content.seek(0)  # Reset to beginning
+        
+        # Upload directly to MinIO
+        result = minio_client.put_object(
+            bucket_name=MINIO_BUCKET,
+            object_name=object_name,
+            data=file_content,
+            length=file_size,
+            content_type="application/octet-stream"
+        )
+        
+        return {
+            "status": "success",
+            "bucket": MINIO_BUCKET,
+            "object_name": object_name,
+            "file_url": f"http://{MINIO_ENDPOINT}/{MINIO_BUCKET}/{object_name}",
+            "uploaded_at": timestamp,
+            "etag": result.etag,
+            "server": MINIO_ENDPOINT
+        }
+        
+    except S3Error as e:
+        return {
+            "status": "error",
+            "error_message": str(e),
+            "error_type": "minio_s3_error"
+        }
+    except Exception as e:
+        return {
+            "status": "error",
+            "error_message": str(e),
+            "error_type": "general_upload_error"
+        }
+
+
+# MongoDB directory setup
+MONGODB_DIR = Path("mongodb")
+MONGODB_DIR.mkdir(exist_ok=True)
+
+def save_non_validation_data(validator_atom_id: str, data_type: str, data: dict):
+    """
+    Save non-validation data to separate JSON files in mongodb folder
+    data_type: 'classification', 'business_dimensions', 'identifier_assignments'
+    """
+    try:
+        file_path = MONGODB_DIR / f"{validator_atom_id}_{data_type}.json"
+        
+        # Load existing data if file exists
+        existing_data = {}
+        if file_path.exists():
+            with open(file_path, "r") as f:
+                existing_data = json.load(f)
+        
+        # Merge with new data
+        existing_data.update(data)
+        
+        # Save updated data
+        with open(file_path, "w") as f:
+            json.dump(existing_data, f, indent=2)
+        
+        print(f"✅ Saved {data_type} for {validator_atom_id} to mongodb folder")
+        return True
+    except Exception as e:
+        print(f"❌ Error saving {data_type}: {str(e)}")
+        return False
+
+def load_non_validation_data(validator_atom_id: str, data_type: str) -> dict:
+    """
+    Load non-validation data from mongodb folder
+    Returns: dict with file_key as keys
+    """
+    try:
+        file_path = MONGODB_DIR / f"{validator_atom_id}_{data_type}.json"
+        if file_path.exists():
+            with open(file_path, "r") as f:
+                data = json.load(f)
+            print(f"✅ Loaded {data_type} for {validator_atom_id} from mongodb folder")
+            return data
+        else:
+            print(f"ℹ️ No {data_type} file found for {validator_atom_id}")
+            return {}
+    except Exception as e:
+        print(f"❌ Error loading {data_type}: {str(e)}")
+        return {}
+
+def load_all_non_validation_data(validator_atom_id: str) -> dict:
+    """
+    Load all non-validation data for a validator atom from mongodb folder
+    Returns: dict with classification, business_dimensions, identifier_assignments
+    """
+    classification = load_non_validation_data(validator_atom_id, "classification")
+    business_dimensions = load_non_validation_data(validator_atom_id, "business_dimensions")
+    identifier_assignments = load_non_validation_data(validator_atom_id, "identifier_assignments")
+    
+    return {
+        "classification": classification,
+        "business_dimensions": business_dimensions,
+        "identifier_assignments": identifier_assignments
+    }
+
+def get_validator_from_memory_or_disk(validator_atom_id: str):
+    """
+    Get validator from memory, or load from disk if not in memory
+    Loads both validation data (custom_validations/) and non-validation data (mongodb/)
+    """
+    # Check memory first
+    if validator_atom_id in extraction_results:
+        return extraction_results[validator_atom_id]
+    
+    # Load from disk if not in memory
+    config_path = CUSTOM_CONFIG_DIR / f"{validator_atom_id}.json"
+    if config_path.exists():
+        try:
+            # Load validation data
+            with open(config_path, "r") as f:
+                config = json.load(f)
+            
+            # Load non-validation data from mongodb folder
+            non_validation_data = load_all_non_validation_data(validator_atom_id)
+            
+            # Combine all data in memory
+            extraction_results[validator_atom_id] = {
+                "validator_atom_id": validator_atom_id,
+                "schemas": config.get("schemas", {}),
+                "column_types": config.get("column_types", {}),
+                "config_saved": True,
+                "config_path": str(config_path),
+                **non_validation_data  # Add classification, business_dimensions, identifier_assignments
+            }
+            
+            print(f"✅ Loaded {validator_atom_id} from disk (validation + mongodb data)")
+            return extraction_results[validator_atom_id]
+        except Exception as e:
+            print(f"❌ Error loading config from disk: {str(e)}")
+    
+    return None
+
+def load_existing_configs():
+    """
+    Load all existing validator configs from both folders on startup
+    - custom_validations/: validation data (schemas, column_types)
+    - mongodb/: non-validation data (classification, dimensions, assignments)
+    """
+    if not CUSTOM_CONFIG_DIR.exists():
+        print("ℹ️ No custom_validations folder found")
+        return
+    
+    print("📁 Loading configs from custom_validations and mongodb folders...")
+    
+    for config_file in CUSTOM_CONFIG_DIR.glob("*.json"):
+        try:
+            with open(config_file, "r") as f:
+                config = json.load(f)
+            
+            validator_atom_id = config.get("validator_atom_id")
+            if validator_atom_id:
+                # Load validation data
+                extraction_results[validator_atom_id] = {
+                    "validator_atom_id": validator_atom_id,
+                    "schemas": config.get("schemas", {}),
+                    "column_types": config.get("column_types", {}),
+                    "config_saved": True,
+                    "config_path": str(config_file)
+                }
+                
+                # Load non-validation data from mongodb folder
+                non_validation_data = load_all_non_validation_data(validator_atom_id)
+                extraction_results[validator_atom_id].update(non_validation_data)
+                
+                print(f"✅ Loaded validator atom: {validator_atom_id}")
+                print(f"   - Validation: {len(config.get('schemas', {}))}")
+                print(f"   - Classification: {len(non_validation_data.get('classification', {}))}")
+                print(f"   - Dimensions: {len(non_validation_data.get('business_dimensions', {}))}")
+                print(f"   - Assignments: {len(non_validation_data.get('identifier_assignments', {}))}")
+        except Exception as e:
+            print(f"⚠️ Failed to load config {config_file}: {str(e)}")
+
+
+            
+
+# POST: CREATE_NEW - Create validator atom with column preprocessing
+@router.post("/create_new", status_code=202, response_model=CreateValidatorResponse)
+async def create_new(
+    validator_atom_id: str = Form(..., description="Unique ID for your validator atom"),
+    files: List[UploadFile] = File(...),
+    file_keys: str = Form(...)
+) -> Dict[str, Any]:
+    """
+    Create new validator atom by uploading files and generating validation rules
+    """
+    # ✅ ADD COLUMN PREPROCESSING FUNCTION
+    def preprocess_column_name(col_name: str) -> str:
+        """
+        Preprocess column name:
+        - Strip leading/trailing spaces
+        - Lowercase
+        - Remove spaces inside the name but preserve underscores
+        """
+        col_name = col_name.strip().lower()
+        # Remove spaces but keep underscores
+        col_name = re.sub(r'(?<!_)\s+(?!_)', '', col_name)
+        return col_name
+
+    # Parse file_keys JSON
+    try:
+        keys = json.loads(file_keys)
+    except json.JSONDecodeError:
+        raise HTTPException(status_code=400, detail="Invalid JSON format for file_keys")
+
+    # Basic validations
+    if not validator_atom_id or not validator_atom_id.strip():
+        raise HTTPException(status_code=400, detail="validator_atom_id cannot be empty")
+    if len(files) != len(keys):
+        raise HTTPException(status_code=400, detail="Number of keys must match number of files")
+    if len(files) > 3:
+        raise HTTPException(status_code=400, detail="Maximum 3 files supported")
+
+    schemas = {}
+    dataframes = {}  # Store DataFrames for data type extraction
+    
+    # Process each file
+    for file, key in zip(files, keys):
+        # Read file
+        try:
+            content = await file.read()
+        except Exception as e:
+            raise HTTPException(status_code=400, detail=f"Error reading file {file.filename}: {str(e)}")
+
+        # Parse file to DataFrame
+        try:
+            if file.filename.lower().endswith(".csv"):
+                df = pd.read_csv(io.BytesIO(content))
+            elif file.filename.lower().endswith(".xlsx"):
+                df = pd.read_excel(io.BytesIO(content))
+            else:
+                raise HTTPException(status_code=400, detail="Only CSV and XLSX files supported")
+        except Exception as e:
+            raise HTTPException(status_code=400, detail=f"Error parsing file {file.filename}: {str(e)}")
+
+        # ✅ PREPROCESS COLUMN NAMES - Remove spaces but preserve underscores
+        df.columns = [preprocess_column_name(col) for col in df.columns]
+
+        # Store DataFrame for data type extraction
+        dataframes[key] = df
+
+        # Extract schema
+        schema = []
+        for col in df.columns:
+            dtype = str(df[col].dtype)
+            if "int" in dtype or "float" in dtype:
+                col_type = "numeric"
+            elif "datetime" in dtype:
+                col_type = "date"
+            elif "bool" in dtype:
+                col_type = "boolean"
+            else:
+                col_type = "string"
+            
+            schema.append({"column": col, "type": col_type})
+
+        # Store schema info
+        schemas[key] = {
+            "columns": schema,
+            "sample_rows": df.head(3).astype(str).to_dict(orient="records"),  # ✅ ONLY THIS LINE CHANGED
+            "total_rows": len(df),
+            "total_columns": len(df.columns)
+        }
+
+
+    # Extract data types for each column in each file
+    column_types = {}
+    for key, df in dataframes.items():
+        types = {}
+        for col in df.columns:
+            dtype = str(df[col].dtype)
+            if "int" in dtype:
+                types[col] = "integer"
+            elif "float" in dtype:
+                types[col] = "numeric"
+            elif "datetime" in dtype:
+                types[col] = "date"
+            elif "bool" in dtype:
+                types[col] = "boolean"
+            else:
+                types[col] = "string"
+        column_types[key] = types
+
+    # Also include column_types in the schemas
+    for key in schemas:
+        schemas[key]["column_types"] = column_types.get(key, {})
+
+    # Generate validation config
+    validation_config = {
+        "validator_atom_id": validator_atom_id,
+        "created_from_files": [f.filename for f in files],
+        "file_keys": keys,
+        "schemas": schemas,
+        "column_types": column_types,
+        "validation_mode": "simple"
+    }
+
+    # Save to file
+    try:
+        config_path = CUSTOM_CONFIG_DIR / f"{validator_atom_id}.json"
+        with open(config_path, "w") as f:
+            json.dump(validation_config, f, indent=2)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error saving config: {str(e)}")
+
+    # ✅ ADD: Save to MongoDB
+    mongo_result = save_validator_atom_to_mongo(validator_atom_id, validation_config)
+
+    # Store in memory for GET endpoint
+    extraction_results[validator_atom_id] = {
+        "validator_atom_id": validator_atom_id,
+        "schemas": schemas,
+        "column_types": column_types,
+        "config_saved": True,
+        "config_path": str(config_path)
+    }
+
+    # ✅ MINIMAL POST RESPONSE - Only success confirmation
+    return {
+        "status": "success",
+        "message": "Validator atom created successfully", 
+        "validator_atom_id": validator_atom_id,
+        "config_saved": True
+    }
+    
+    
+    
+# GET: VIEW_NEW - Retrieve only schemas for all file keys
+@router.get("/view_new/{validator_atom_id}")
+async def view_new(validator_atom_id: str):
+    """
+    Retrieve only schemas for all file keys - no metadata
+    """
+    if validator_atom_id not in extraction_results:
+        raise HTTPException(status_code=404, detail=f"Validator atom '{validator_atom_id}' not found")
+    
+    # ✅ RETURN ONLY SCHEMAS - No config_saved, config_path, validator_atom_id
+    data = extraction_results[validator_atom_id]
+    return data.get("schemas", {})
+
+
+# POST: CLASSIFY_COLUMNS - Complete fixed version for both validator types
+@router.post("/classify_columns", response_model=ClassifyColumnsResponse)
+async def classify_columns(
+    validator_atom_id: str = Form(...),
+    file_key: str = Form(...),
+    identifiers: str = Form(default="[]"),
+    measures: str = Form(default="[]"),
+    unclassified: str = Form(default="[]")
+):
+    """
+    Auto-classify columns first, then allow user to override classifications.
+    Works for both regular validator atoms (from /create_new) and template validator atoms (from /validate_*)
+    """
+    # Check if validator atom exists (MongoDB first, then fallback)
+    validator_data = get_validator_atom_from_mongo(validator_atom_id)
+    if not validator_data:
+        # Fallback to old method for backward compatibility (regular validator atoms)
+        validator_data = get_validator_from_memory_or_disk(validator_atom_id)
+
+    if not validator_data:
+        raise HTTPException(status_code=404, detail=f"Validator atom '{validator_atom_id}' not found")
+
+    # Get column information from existing schema
+    schema_data = validator_data["schemas"].get(file_key, {})
+    if not schema_data:
+        available_keys = list(validator_data["schemas"].keys())
+        raise HTTPException(
+            status_code=400, 
+            detail=f"File key '{file_key}' not found in validator. Available file keys: {available_keys}"
+        )
+
+    all_columns = [col["column"] for col in schema_data.get("columns", [])]
+    column_types = schema_data.get("column_types", {})
+
+    if not all_columns:
+        raise HTTPException(status_code=400, detail="No columns found in schema data")
+
+    # Parse user overrides (if provided)
+    try:
+        user_identifiers = json.loads(identifiers) if identifiers != "[]" else []
+        user_measures = json.loads(measures) if measures != "[]" else []
+        user_unclassified = json.loads(unclassified) if unclassified != "[]" else []
+    except json.JSONDecodeError as e:
+        raise HTTPException(status_code=400, detail=f"Invalid JSON format for classification lists: {str(e)}")
+
+    # Validate user inputs - ensure they reference actual columns
+    all_user_columns = user_identifiers + user_measures + user_unclassified
+    invalid_columns = [col for col in all_user_columns if col not in all_columns]
+    if invalid_columns:
+        raise HTTPException(
+            status_code=400, 
+            detail=f"Invalid columns specified: {invalid_columns}. Available columns: {all_columns}"
+        )
+
+    # ✅ FIXED LOGIC: Start with user-specified classifications
+    final_identifiers = user_identifiers.copy()
+    final_measures = user_measures.copy()
+    final_unclassified = user_unclassified.copy()
+
+    # Get columns already classified by user
+    user_classified_columns = set(final_identifiers + final_measures + final_unclassified)
+
+    # Check for user classification conflicts
+    all_user_specified = user_identifiers + user_measures + user_unclassified
+    if len(all_user_specified) != len(set(all_user_specified)):
+        raise HTTPException(status_code=400, detail="Column specified in multiple classification categories")
+
+    # AUTO-CLASSIFY only the remaining columns
+    identifier_keywords = ['id', 'name', 'brand', 'market', 'category', 'region', 'channel', 
+                          'date', 'time', 'year','week', 'month', 'variant', 'ppg', 'type', 'code', 'packsize', 'packtype']
+    measure_keywords = ['sales', 'revenue', 'volume', 'amount', 'value', 'price', 'cost', 
+                       'profit', 'units', 'd1', 'd2', 'd3', 'd4', 'd5', 'd6', 'salesvalue', 'baseprice', 'promoprice']
+
+    auto_identifiers = []
+    auto_measures = []
+    auto_unclassified = []
+
+    # Only auto-classify columns NOT already specified by user
+    remaining_columns = [col for col in all_columns if col not in user_classified_columns]
+
+    for col in remaining_columns:
+        col_lower = col.lower()
+        col_type = column_types.get(col, "string")
+        
+        # Auto-classify remaining columns
+        if any(keyword in col_lower for keyword in identifier_keywords):
+            auto_identifiers.append(col)
+            final_identifiers.append(col)
+        elif any(keyword in col_lower for keyword in measure_keywords):
+            auto_measures.append(col)
+            final_measures.append(col)
+        elif col_type in ["numeric", "integer", "float64"]:
+            auto_measures.append(col)
+            final_measures.append(col)
+        else:
+            auto_unclassified.append(col)
+            final_unclassified.append(col)
+
+    # Calculate confidence scores
+    confidence_scores = {}
+    for col in all_columns:
+        col_lower = col.lower()
+        if col in user_classified_columns:
+            confidence_scores[col] = 1.0  # User specified = 100% confidence
+        elif any(keyword in col_lower for keyword in identifier_keywords):
+            confidence_scores[col] = 0.9
+        elif any(keyword in col_lower for keyword in measure_keywords):
+            confidence_scores[col] = 0.9
+        elif column_types.get(col) in ["numeric", "integer", "float64"]:
+            confidence_scores[col] = 0.7
+        else:
+            confidence_scores[col] = 0.5
+
+    # ✅ FINAL VALIDATION: Check no duplicates and all columns classified
+    all_final = final_identifiers + final_measures + final_unclassified
+    if len(all_final) != len(set(all_final)):
+        raise HTTPException(status_code=400, detail="Internal error: Column classification conflict")
+    
+    if set(all_final) != set(all_columns):
+        missing = set(all_columns) - set(all_final)
+        extra = set(all_final) - set(all_columns)
+        error_msg = []
+        if missing:
+            error_msg.append(f"Missing columns: {list(missing)}")
+        if extra:
+            error_msg.append(f"Extra columns: {list(extra)}")
+        raise HTTPException(status_code=400, detail=f"Classification mismatch: {'; '.join(error_msg)}")
+
+    # Build classification data
+    classification_data = {
+        "auto_classification": {
+            "identifiers": auto_identifiers,
+            "measures": auto_measures,
+            "unclassified": auto_unclassified,
+        },
+        "final_classification": {
+            "identifiers": final_identifiers,
+            "measures": final_measures,
+            "unclassified": final_unclassified
+        },
+        "user_modified": bool(user_identifiers or user_measures or user_unclassified),
+        "timestamp": datetime.now().isoformat(),
+        "validator_type": validator_data.get("template_type", "custom")
+    }
+
+    # ✅ SAVE TO MONGODB
+    try:
+        mongo_result = save_classification_to_mongo(validator_atom_id, file_key, classification_data)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to save classification to MongoDB: {str(e)}")
+
+    # ✅ FIXED: Safe update in memory (works for both validator types)
+    try:
+        # Initialize extraction_results entry if it doesn't exist (for template validator atoms)
+        if validator_atom_id not in extraction_results:
+            extraction_results[validator_atom_id] = {}
+        
+        if "classification" not in extraction_results[validator_atom_id]:
+            extraction_results[validator_atom_id]["classification"] = {}
+        
+        extraction_results[validator_atom_id]["classification"][file_key] = classification_data
+        
+        in_memory_status = "success"
+    except Exception as e:
+        # Log but don't fail - MongoDB save is what matters
+        print(f"Warning: Could not update in-memory results for {validator_atom_id}: {e}")
+        in_memory_status = "warning"
+
+    return {
+        "status": "success",
+        "message": "Column classification completed successfully",
+        "validator_atom_id": validator_atom_id,
+        "file_key": file_key,
+        "validator_type": validator_data.get("template_type", "custom"),
+        "auto_classification": {
+            "identifiers": auto_identifiers,
+            "measures": auto_measures,
+            "unclassified": auto_unclassified,
+            "confidence_scores": confidence_scores
+        },
+        "user_classification": {
+            "identifiers": user_identifiers,
+            "measures": user_measures,
+            "unclassified": user_unclassified
+        },
+        "final_classification": {
+            "identifiers": final_identifiers,
+            "measures": final_measures,
+            "unclassified": final_unclassified
+        },
+        "user_modified": bool(user_identifiers or user_measures or user_unclassified),
+        "summary": {
+            "total_columns": len(all_columns),
+            "user_specified": len(user_identifiers + user_measures + user_unclassified),
+            "auto_classified": len(auto_identifiers + auto_measures + auto_unclassified),
+            "identifiers_count": len(final_identifiers),
+            "measures_count": len(final_measures),
+            "unclassified_count": len(final_unclassified)
+        },
+        "mongodb_save_status": mongo_result.get("status", "unknown"),
+        "in_memory_save_status": in_memory_status
+    }
+
+
+# # POST: CLASSIFY_COLUMNS - Fixed logic with MongoDB storage
+# @router.post("/classify_columns", response_model=ClassifyColumnsResponse)
+# async def classify_columns(
+#     validator_atom_id: str = Form(...),
+#     file_key: str = Form(...),
+#     identifiers: str = Form(default="[]"),
+#     measures: str = Form(default="[]"),
+#     unclassified: str = Form(default="[]")
+# ):
+#     """
+#     Auto-classify columns first, then allow user to override classifications
+#     """
+#     # Check if validator atom exists (MongoDB first, then fallback)
+#     validator_data = get_validator_atom_from_mongo(validator_atom_id)
+#     if not validator_data:
+#         # Fallback to old method for backward compatibility
+#         validator_data = get_validator_from_memory_or_disk(validator_atom_id)
+
+#     if not validator_data:
+#         raise HTTPException(status_code=404, detail=f"Validator atom '{validator_atom_id}' not found")
+
+
+#     # Get column information from existing schema
+#     schema_data = validator_data["schemas"].get(file_key, {})
+#     if not schema_data:
+#         raise HTTPException(status_code=400, detail=f"File key '{file_key}' not found in validator")
+
+#     all_columns = [col["column"] for col in schema_data.get("columns", [])]
+#     column_types = schema_data.get("column_types", {})
+
+#     # Parse user overrides (if provided)
+#     try:
+#         user_identifiers = json.loads(identifiers) if identifiers != "[]" else []
+#         user_measures = json.loads(measures) if measures != "[]" else []
+#         user_unclassified = json.loads(unclassified) if unclassified != "[]" else []
+#     except json.JSONDecodeError:
+#         raise HTTPException(status_code=400, detail="Invalid JSON format for classification lists")
+
+#     # ✅ FIXED LOGIC: Start with user-specified classifications
+#     final_identifiers = user_identifiers.copy()
+#     final_measures = user_measures.copy()
+#     final_unclassified = user_unclassified.copy()
+
+#     # Get columns already classified by user
+#     user_classified_columns = set(final_identifiers + final_measures + final_unclassified)
+
+#     # AUTO-CLASSIFY only the remaining columns
+#     identifier_keywords = ['id', 'name', 'brand', 'market', 'category', 'region', 'channel', 
+#                           'date', 'time', 'year', 'month', 'variant', 'ppg', 'type', 'code', 'packsize']
+#     measure_keywords = ['sales', 'revenue', 'volume', 'amount', 'value', 'price', 'cost', 
+#                        'profit', 'units', 'd1', 'd2', 'd3', 'd4', 'd5', 'd6']
+
+#     auto_identifiers = []
+#     auto_measures = []
+#     auto_unclassified = []
+
+#     # Only auto-classify columns NOT already specified by user
+#     remaining_columns = [col for col in all_columns if col not in user_classified_columns]
+
+#     for col in remaining_columns:
+#         col_lower = col.lower()
+#         col_type = column_types.get(col, "string")
+        
+#         # Auto-classify remaining columns
+#         if any(keyword in col_lower for keyword in identifier_keywords):
+#             auto_identifiers.append(col)
+#             final_identifiers.append(col)
+#         elif any(keyword in col_lower for keyword in measure_keywords):
+#             auto_measures.append(col)
+#             final_measures.append(col)
+#         elif col_type in ["numeric", "integer"]:
+#             auto_measures.append(col)
+#             final_measures.append(col)
+#         else:
+#             auto_unclassified.append(col)
+#             final_unclassified.append(col)
+
+#     # Calculate confidence scores
+#     confidence_scores = {}
+#     for col in all_columns:
+#         col_lower = col.lower()
+#         if col in user_classified_columns:
+#             confidence_scores[col] = 1.0  # User specified = 100% confidence
+#         elif any(keyword in col_lower for keyword in identifier_keywords):
+#             confidence_scores[col] = 0.9
+#         elif any(keyword in col_lower for keyword in measure_keywords):
+#             confidence_scores[col] = 0.9
+#         elif column_types.get(col) in ["numeric", "integer"]:
+#             confidence_scores[col] = 0.7
+#         else:
+#             confidence_scores[col] = 0.5
+
+#     # ✅ FINAL VALIDATION: Check no duplicates (should never happen now)
+#     all_final = final_identifiers + final_measures + final_unclassified
+#     if len(all_final) != len(set(all_final)):
+#         raise HTTPException(status_code=400, detail="Internal error: Column classification conflict")
+
+#     # Save classification
+#     classification_data = {
+#         "auto_classification": {
+#             "identifiers": auto_identifiers,
+#             "measures": auto_measures,
+#             "unclassified": auto_unclassified,
+#             "confidence_scores": confidence_scores
+#         },
+#         "final_classification": {
+#             "identifiers": final_identifiers,
+#             "measures": final_measures,
+#             "unclassified": final_unclassified
+#         },
+#         "user_modified": bool(user_identifiers or user_measures or user_unclassified)
+#     }
+
+#     # ✅ SAVE TO MONGODB
+#     mongo_result = save_classification_to_mongo(validator_atom_id, file_key, classification_data)
+
+
+#     # Update in memory
+#     if "classification" not in extraction_results[validator_atom_id]:
+#         extraction_results[validator_atom_id]["classification"] = {}
+#     extraction_results[validator_atom_id]["classification"][file_key] = classification_data
+
+#     return {
+#         "status": "success",
+#         "message": "Column classification completed successfully",
+#         "validator_atom_id": validator_atom_id,
+#         "file_key": file_key,
+#         "auto_classification": {
+#             "identifiers": auto_identifiers,
+#             "measures": auto_measures,
+#             "unclassified": auto_unclassified,
+#             "confidence_scores": confidence_scores
+#         },
+#         "user_classification": {
+#             "identifiers": user_identifiers,
+#             "measures": user_measures,
+#             "unclassified": user_unclassified
+#         },
+#         "final_classification": {
+#             "identifiers": final_identifiers,
+#             "measures": final_measures,
+#             "unclassified": final_unclassified
+#         },
+#         "user_modified": bool(user_identifiers or user_measures or user_unclassified),
+#         "summary": {
+#             "total_columns": len(all_columns),
+#             "user_specified": len(user_identifiers + user_measures + user_unclassified),
+#             "auto_classified": len(auto_identifiers + auto_measures + auto_unclassified)
+#         }
+#     }
+
+
+# POST: UPDATE_COLUMN_TYPES - Allow user to change column data types
+@router.post("/update_column_types", response_model=UpdateColumnTypesResponse)
+async def update_column_types(
+    validator_atom_id: str = Form(...),
+    file_key: str = Form(...),
+    column_types: str = Form(...)
+):
+    """
+    Update column data types for a specific validator atom and file key
+    """
+    # Parse column_types JSON
+    try:
+        new_column_types = json.loads(column_types)
+    except json.JSONDecodeError:
+        raise HTTPException(status_code=400, detail="Invalid JSON format for column_types")
+
+    # Check if validator atom exists (MongoDB first)
+    validator_data = get_validator_atom_from_mongo(validator_atom_id)
+    if not validator_data:
+        # Fallback to old method for backward compatibility
+        validator_data = get_validator_from_memory_or_disk(validator_atom_id)
+
+    if not validator_data:
+        raise HTTPException(status_code=404, detail=f"Validator atom '{validator_atom_id}' not found")
+
+    # Check if file_key exists
+    if file_key not in validator_data["schemas"]:
+        raise HTTPException(status_code=400, detail=f"File key '{file_key}' not found in validator")
+
+    # Get current schema
+    current_schema = validator_data["schemas"][file_key]
+    available_columns = [col["column"] for col in current_schema.get("columns", [])]
+
+    # Validate that all columns in new_column_types exist in the schema
+    invalid_columns = [col for col in new_column_types.keys() if col not in available_columns]
+    if invalid_columns:
+        raise HTTPException(
+            status_code=400, 
+            detail=f"Invalid columns: {invalid_columns}. Available columns: {available_columns}"
+        )
+
+    # Validate column type values
+    valid_types = ["string", "integer", "numeric", "date", "boolean"]
+    invalid_types = {col: typ for col, typ in new_column_types.items() if typ not in valid_types}
+    if invalid_types:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid column types: {invalid_types}. Valid types: {valid_types}"
+        )
+
+    # Update column_types in memory
+    current_column_types = extraction_results[validator_atom_id]["column_types"].get(file_key, {})
+    current_column_types.update(new_column_types)
+    extraction_results[validator_atom_id]["column_types"][file_key] = current_column_types
+
+    # Also update in schemas for consistency
+    extraction_results[validator_atom_id]["schemas"][file_key]["column_types"] = current_column_types
+
+    # Update the columns array with new types
+    updated_columns = []
+    for col_info in current_schema["columns"]:
+        col_name = col_info["column"]
+        if col_name in new_column_types:
+            col_info["type"] = new_column_types[col_name]
+        updated_columns.append(col_info)
+    
+    extraction_results[validator_atom_id]["schemas"][file_key]["columns"] = updated_columns
+
+    # Update JSON config file
+    try:
+        config_path = CUSTOM_CONFIG_DIR / f"{validator_atom_id}.json"
+        if config_path.exists():
+            with open(config_path, "r") as f:
+                config = json.load(f)
+            
+            # Update column_types in config
+            if "column_types" not in config:
+                config["column_types"] = {}
+            config["column_types"][file_key] = current_column_types
+            
+            # Update schemas in config
+            if "schemas" in config and file_key in config["schemas"]:
+                config["schemas"][file_key]["column_types"] = current_column_types
+                config["schemas"][file_key]["columns"] = updated_columns
+            
+            # Save updated config
+            with open(config_path, "w") as f:
+                json.dump(config, f, indent=2)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error updating config file: {str(e)}")
+
+    # ✅ MongoDB Update - INSERT THIS NEW CODE
+    mongo_update_data = {
+        f"schemas.{file_key}.column_types": current_column_types,
+        f"schemas.{file_key}.columns": updated_columns,
+        f"column_types.{file_key}": current_column_types
+    }
+    mongo_result = update_validator_atom_in_mongo(validator_atom_id, mongo_update_data)
+
+    # Optional: Log MongoDB result
+    if mongo_result["status"] == "success":
+        print(f"✅ Validator atom updated in MongoDB")
+    else:
+        print(f"⚠️ MongoDB update failed: {mongo_result['error']}")
+
+    return {
+        "status": "success",
+        "message": "Column types updated successfully",
+        "validator_atom_id": validator_atom_id,
+        "file_key": file_key,
+        "updated_column_types": new_column_types,
+        "current_all_column_types": current_column_types,
+        "updated_columns_count": len(new_column_types),
+        # ✅ ADD: MongoDB update status
+        "mongodb_update": {
+            "status": mongo_result["status"],
+            "modified": mongo_result.get("modified_count", 0) > 0 if mongo_result["status"] == "success" else False,
+            "details": mongo_result.get("error", "Update successful") if mongo_result["status"] == "error" else f"Matched: {mongo_result.get('matched_count', 0)}, Modified: {mongo_result.get('modified_count', 0)}"
+        }
+    }
+
+    
+    
+
+
+
+
+# # POST: DEFINE_DIMENSIONS - Complete fixed version for both validator types
+# @router.post("/define_dimensions", response_model=DefineDimensionsResponse)
+# async def define_dimensions(
+#     validator_atom_id: str = Form(...),
+#     file_key: str = Form(...),
+#     dimensions: str = Form(...)
+# ):
+#     """
+#     Endpoint to define business dimensions for a specific file key in a validator atom.
+#     Maximum of 4 dimensions allowed per file key.
+#     Works for both regular validator atoms (from /create_new) and template validator atoms (from /validate_*)
+#     """
+#     # Parse dimensions JSON
+#     try:
+#         dims = json.loads(dimensions)
+#     except json.JSONDecodeError as e:
+#         raise HTTPException(status_code=400, detail=f"Invalid JSON format for dimensions: {str(e)}")
+
+#     # Validate dims structure
+#     if not isinstance(dims, list):
+#         raise HTTPException(status_code=400, detail="Dimensions must be a list of objects")
+
+#     # ✅ ENFORCE MAX 4 DIMENSIONS
+#     if len(dims) > 4:
+#         raise HTTPException(status_code=400, detail="Maximum of 4 dimensions allowed")
+    
+#     if len(dims) == 0:
+#         raise HTTPException(status_code=400, detail="At least 1 dimension must be provided")
+
+#     # Validate each dimension structure
+#     required_fields = ['id', 'name']
+#     dimension_ids = []
+#     dimension_names = []
+    
+#     for i, dim in enumerate(dims):
+#         if not isinstance(dim, dict):
+#             raise HTTPException(status_code=400, detail=f"Dimension {i+1} must be an object")
+        
+#         # Check required fields
+#         for field in required_fields:
+#             if field not in dim:
+#                 raise HTTPException(status_code=400, detail=f"Dimension {i+1} missing required field: '{field}'")
+#             if not dim[field] or not isinstance(dim[field], str):
+#                 raise HTTPException(status_code=400, detail=f"Dimension {i+1} field '{field}' must be a non-empty string")
+        
+#         # Check for duplicate IDs and names
+#         if dim['id'] in dimension_ids:
+#             raise HTTPException(status_code=400, detail=f"Duplicate dimension ID: '{dim['id']}'")
+#         if dim['name'] in dimension_names:
+#             raise HTTPException(status_code=400, detail=f"Duplicate dimension name: '{dim['name']}'")
+        
+#         dimension_ids.append(dim['id'])
+#         dimension_names.append(dim['name'])
+
+#     # ✅ UPDATED: Check if validator atom exists (MongoDB first)
+#     validator_data = get_validator_atom_from_mongo(validator_atom_id)
+#     if not validator_data:
+#         # Fallback to old method for backward compatibility
+#         validator_data = get_validator_from_memory_or_disk(validator_atom_id)
+
+#     if not validator_data:
+#         raise HTTPException(status_code=404, detail=f"Validator atom '{validator_atom_id}' not found")
+
+#     # Check if file_key exists
+#     if file_key not in validator_data["schemas"]:
+#         available_keys = list(validator_data["schemas"].keys())
+#         raise HTTPException(
+#             status_code=400, 
+#             detail=f"File key '{file_key}' not found in validator. Available file keys: {available_keys}"
+#         )
+
+#     # Store dimensions for this specific file key
+#     dims_dict = {dim['id']: dim for dim in dims}
+    
+#     # Add metadata
+#     dimension_data = {
+#         "dimensions": dims_dict,
+#         "file_key": file_key,
+#         "validator_atom_id": validator_atom_id,
+#         "timestamp": datetime.now().isoformat(),
+#         "validator_type": validator_data.get("template_type", "custom"),
+#         "dimensions_count": len(dims)
+#     }
+
+#     # ✅ REPLACE: Save to MongoDB instead of file
+#     try:
+#         mongo_result = save_business_dimensions_to_mongo(validator_atom_id, file_key, dimension_data)
+#     except Exception as e:
+#         raise HTTPException(status_code=500, detail=f"Failed to save dimensions to MongoDB: {str(e)}")
+
+#     # ✅ FIXED: Safe update in memory (works for both validator types)
+#     try:
+#         # Initialize extraction_results entry if it doesn't exist (for template validator atoms)
+#         if validator_atom_id not in extraction_results:
+#             extraction_results[validator_atom_id] = {}
+        
+#         if "business_dimensions" not in extraction_results[validator_atom_id]:
+#             extraction_results[validator_atom_id]["business_dimensions"] = {}
+        
+#         extraction_results[validator_atom_id]["business_dimensions"][file_key] = dims_dict
+#         in_memory_status = "success"
+#     except Exception as e:
+#         # Log but don't fail - MongoDB save is what matters
+#         print(f"Warning: Could not update in-memory results for {validator_atom_id}: {e}")
+#         in_memory_status = "warning"
+
+#     return {
+#         "status": "success",
+#         "message": f"Business dimensions defined successfully for file key '{file_key}' ({len(dims)} dimensions)",
+#         "validator_atom_id": validator_atom_id,
+#         "file_key": file_key,
+#         "validator_type": validator_data.get("template_type", "custom"),
+#         "dimensions": dims_dict,
+#         "dimensions_count": len(dims),
+#         "max_allowed": 4,
+#         "dimension_details": {
+#             "dimension_ids": dimension_ids,
+#             "dimension_names": dimension_names,
+#             "created_at": datetime.now().isoformat()
+#         },
+#         "mongodb_saved": mongo_result.get("status") == "success",
+#         "in_memory_saved": in_memory_status,
+#         "next_steps": {
+#             "assign_identifiers": f"POST /assign_identifiers_to_dimensions with validator_atom_id: {validator_atom_id}",
+#             "view_assignments": f"GET /get_identifier_assignments/{validator_atom_id}/{file_key}"
+#         }
+#     }
+
+
+# POST: DEFINE_DIMENSIONS - Complete fixed version for both validator types
+@router.post("/define_dimensions", response_model=DefineDimensionsResponse)
+async def define_dimensions(
+    validator_atom_id: str = Form(...),
+    file_key: str = Form(...),
+    dimensions: str = Form(...)
+):
+    """
+    Endpoint to define business dimensions for a specific file key in a validator atom.
+    Maximum of 4 dimensions allowed per file key.
+    Works for both regular validator atoms (from /create_new) and template validator atoms (from /validate_*)
+    """
+    # Parse dimensions JSON
+    try:
+        dims = json.loads(dimensions)
+    except json.JSONDecodeError as e:
+        raise HTTPException(status_code=400, detail=f"Invalid JSON format for dimensions: {str(e)}")
+
+    # Validate dims structure
+    if not isinstance(dims, list):
+        raise HTTPException(status_code=400, detail="Dimensions must be a list of objects")
+
+    # ✅ ENFORCE MAX 4 DIMENSIONS
+    if len(dims) > 4:
+        raise HTTPException(status_code=400, detail="Maximum of 4 dimensions allowed")
+    
+    if len(dims) == 0:
+        raise HTTPException(status_code=400, detail="At least 1 dimension must be provided")
+
+    # Validate each dimension structure
+    required_fields = ['id', 'name']
+    dimension_ids = []
+    dimension_names = []
+    
+    for i, dim in enumerate(dims):
+        if not isinstance(dim, dict):
+            raise HTTPException(status_code=400, detail=f"Dimension {i+1} must be an object")
+        
+        # Check required fields
+        for field in required_fields:
+            if field not in dim:
+                raise HTTPException(status_code=400, detail=f"Dimension {i+1} missing required field: '{field}'")
+            if not dim[field] or not isinstance(dim[field], str):
+                raise HTTPException(status_code=400, detail=f"Dimension {i+1} field '{field}' must be a non-empty string")
+        
+        # Check for duplicate IDs and names
+        if dim['id'] in dimension_ids:
+            raise HTTPException(status_code=400, detail=f"Duplicate dimension ID: '{dim['id']}'")
+        if dim['name'] in dimension_names:
+            raise HTTPException(status_code=400, detail=f"Duplicate dimension name: '{dim['name']}'")
+        
+        dimension_ids.append(dim['id'])
+        dimension_names.append(dim['name'])
+
+    # ✅ UPDATED: Check if validator atom exists (MongoDB first)
+    validator_data = get_validator_atom_from_mongo(validator_atom_id)
+    if not validator_data:
+        # Fallback to old method for backward compatibility
+        validator_data = get_validator_from_memory_or_disk(validator_atom_id)
+
+    if not validator_data:
+        raise HTTPException(status_code=404, detail=f"Validator atom '{validator_atom_id}' not found")
+
+    # Check if file_key exists
+    if file_key not in validator_data["schemas"]:
+        available_keys = list(validator_data["schemas"].keys())
+        raise HTTPException(
+            status_code=400, 
+            detail=f"File key '{file_key}' not found in validator. Available file keys: {available_keys}"
+        )
+
+    # Store dimensions for this specific file key
+    dims_dict = {dim['id']: dim for dim in dims}
+    
+    # Add metadata
+    dimension_data = {
+        "dimensions": dims_dict,
+        "file_key": file_key,
+        "validator_atom_id": validator_atom_id,
+        "timestamp": datetime.now().isoformat(),
+        "validator_type": validator_data.get("template_type", "custom"),
+        "dimensions_count": len(dims)
+    }
+
+    # ✅ REPLACE: Save to MongoDB instead of file
+    try:
+        mongo_result = save_business_dimensions_to_mongo(validator_atom_id, file_key, dims_dict)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to save dimensions to MongoDB: {str(e)}")
+
+    # ✅ FIXED: Safe update in memory (works for both validator types)
+    try:
+        # Initialize extraction_results entry if it doesn't exist (for template validator atoms)
+        if validator_atom_id not in extraction_results:
+            extraction_results[validator_atom_id] = {}
+        
+        if "business_dimensions" not in extraction_results[validator_atom_id]:
+            extraction_results[validator_atom_id]["business_dimensions"] = {}
+        
+        extraction_results[validator_atom_id]["business_dimensions"][file_key] = dims_dict
+        in_memory_status = "success"
+    except Exception as e:
+        # Log but don't fail - MongoDB save is what matters
+        print(f"Warning: Could not update in-memory results for {validator_atom_id}: {e}")
+        in_memory_status = "warning"
+
+    return {
+        "status": "success",
+        "message": f"Business dimensions defined successfully for file key '{file_key}' ({len(dims)} dimensions)",
+        "validator_atom_id": validator_atom_id,
+        "file_key": file_key,
+        "validator_type": validator_data.get("template_type", "custom"),
+        "dimensions": dims_dict,
+        "dimensions_count": len(dims),
+        "max_allowed": 4,
+        "dimension_details": {
+            "dimension_ids": dimension_ids,
+            "dimension_names": dimension_names,
+            "created_at": datetime.now().isoformat()
+        },
+        "mongodb_saved": mongo_result.get("status") == "success",
+        "in_memory_saved": in_memory_status,
+        "next_steps": {
+            "assign_identifiers": f"POST /assign_identifiers_to_dimensions with validator_atom_id: {validator_atom_id}",
+            "view_assignments": f"GET /get_identifier_assignments/{validator_atom_id}/{file_key}"
+        }
+    }
+
+
+
+
+# # POST: ASSIGN_IDENTIFIERS_TO_DIMENSIONS - Save assignments in business dimensions structure
+# @router.post("/assign_identifiers_to_dimensions", response_model=AssignIdentifiersResponse)
+# async def assign_identifiers_to_dimensions(
+#     validator_atom_id: str = Form(...),
+#     file_key: str = Form(...),
+#     identifier_assignments: str = Form(...)
+# ):
+#     """
+#     Assign identifiers to dimensions and save within business dimensions structure
+#     """
+#     # Parse identifier_assignments JSON
+#     try:
+#         assignments = json.loads(identifier_assignments)
+#     except json.JSONDecodeError:
+#         raise HTTPException(status_code=400, detail="Invalid JSON format for identifier_assignments")
+
+#     # Validate assignments structure
+#     if not isinstance(assignments, dict):
+#         raise HTTPException(status_code=400, detail="identifier_assignments must be a JSON object")
+
+#     # ✅ Check if validator atom exists (MongoDB first)
+#     validator_data = get_validator_atom_from_mongo(validator_atom_id)
+#     if not validator_data:
+#         # Fallback to old method for backward compatibility
+#         validator_data = get_validator_from_memory_or_disk(validator_atom_id)
+
+#     if not validator_data:
+#         raise HTTPException(status_code=404, detail=f"Validator atom '{validator_atom_id}' not found")
+
+#     # Check if file_key exists
+#     if file_key not in validator_data.get("schemas", {}):
+#         raise HTTPException(status_code=400, detail=f"File key '{file_key}' not found in validator")
+
+#     # ✅ Get business dimensions from MongoDB first with correct structure handling
+#     mongo_dimensions = get_business_dimensions_from_mongo(validator_atom_id, file_key)
+
+#     if mongo_dimensions:
+#         # MongoDB format: extract from dimensions array
+#         dimensions_array = mongo_dimensions.get("dimensions", [])
+#         available_dimension_ids = [dim.get("dimension_id") for dim in dimensions_array]
+#         business_dimensions = {dim["dimension_id"]: dim for dim in dimensions_array}
+#     elif validator_data.get("business_dimensions", {}).get(file_key, {}):
+#         # Old format: dictionary of dimensions
+#         business_dimensions = validator_data.get("business_dimensions", {}).get(file_key, {})
+#         available_dimension_ids = list(business_dimensions.keys())
+#     else:
+#         raise HTTPException(status_code=400, detail=f"No business dimensions defined for file key '{file_key}'. Define dimensions first.")
+
+#     # Validate dimension IDs
+#     invalid_dimensions = [dim_id for dim_id in assignments.keys() if dim_id not in available_dimension_ids]
+#     if invalid_dimensions:
+#         raise HTTPException(
+#             status_code=400,
+#             detail=f"Invalid dimension IDs: {invalid_dimensions}. Available dimensions: {available_dimension_ids}"
+#         )
+
+#     # ✅ Get available identifiers from MongoDB classification
+#     mongo_classification = get_classification_from_mongo(validator_atom_id, file_key)
+    
+#     if mongo_classification:
+#         classification_data = mongo_classification
+#     elif validator_data.get("classification", {}).get(file_key, {}):
+#         classification_data = validator_data.get("classification", {}).get(file_key, {})
+#     else:
+#         raise HTTPException(status_code=400, detail=f"No column classification found for file key '{file_key}'. Classify columns first.")
+
+#     available_identifiers = classification_data.get("final_classification", {}).get("identifiers", [])
+#     if not available_identifiers:
+#         raise HTTPException(status_code=400, detail=f"No identifiers classified for file key '{file_key}'. Classify columns first.")
+
+#     # Validate assignments
+#     all_assigned_identifiers = []
+#     for dim_id, identifiers in assignments.items():
+#         if not isinstance(identifiers, list):
+#             raise HTTPException(status_code=400, detail=f"Identifiers for dimension '{dim_id}' must be a list")
+        
+#         invalid_identifiers = [ident for ident in identifiers if ident not in available_identifiers]
+#         if invalid_identifiers:
+#             raise HTTPException(
+#                 status_code=400,
+#                 detail=f"Invalid identifiers for dimension '{dim_id}': {invalid_identifiers}. Available: {available_identifiers}"
+#             )
+#         all_assigned_identifiers.extend(identifiers)
+
+#     # Check for unique assignment
+#     if len(all_assigned_identifiers) != len(set(all_assigned_identifiers)):
+#         duplicates = [ident for ident in set(all_assigned_identifiers) if all_assigned_identifiers.count(ident) > 1]
+#         raise HTTPException(status_code=400, detail=f"Identifiers cannot be assigned to multiple dimensions: {duplicates}")
+
+#     # ✅ UPDATE BUSINESS DIMENSIONS STRUCTURE WITH ASSIGNMENTS
+#     updated_business_dimensions = business_dimensions.copy()
+#     for dim_id, identifiers in assignments.items():
+#         if dim_id in updated_business_dimensions:
+#             updated_business_dimensions[dim_id]["assigned_identifiers"] = identifiers
+
+#     # ✅ Save to MongoDB
+#     mongo_result = update_business_dimensions_assignments_in_mongo(validator_atom_id, file_key, assignments)
+
+#     # Update in memory
+#     if "business_dimensions" not in extraction_results[validator_atom_id]:
+#         extraction_results[validator_atom_id]["business_dimensions"] = {}
+#     extraction_results[validator_atom_id]["business_dimensions"][file_key] = updated_business_dimensions
+
+#     # Find unassigned identifiers
+#     unassigned_identifiers = [ident for ident in available_identifiers if ident not in all_assigned_identifiers]
+
+#     return {
+#         "status": "success",
+#         "message": f"Identifiers assigned to dimensions and saved in business dimensions structure for file key '{file_key}'",
+#         "validator_atom_id": validator_atom_id,
+#         "file_key": file_key,
+#         "updated_business_dimensions": updated_business_dimensions,
+#         "assignment_summary": {
+#             "total_identifiers": len(available_identifiers),
+#             "assigned_identifiers": len(all_assigned_identifiers),
+#             "unassigned_identifiers": len(unassigned_identifiers)
+#         },
+#         "unassigned_identifiers": unassigned_identifiers,
+#         "dimension_breakdown": {dim_id: len(identifiers) for dim_id, identifiers in assignments.items()},
+#         "mongodb_updated": mongo_result["status"] == "success"
+#     }
+
+# POST: ASSIGN_IDENTIFIERS_TO_DIMENSIONS - Complete fixed version for both validator types
+@router.post("/assign_identifiers_to_dimensions", response_model=AssignIdentifiersResponse)
+async def assign_identifiers_to_dimensions(
+    validator_atom_id: str = Form(...),
+    file_key: str = Form(...),
+    identifier_assignments: str = Form(...)
+):
+    """
+    Assign identifiers to dimensions and save within business dimensions structure.
+    Works for both regular validator atoms (from /create_new) and template validator atoms (from /validate_*)
+    """
+    # Parse identifier_assignments JSON
+    try:
+        assignments = json.loads(identifier_assignments)
+    except json.JSONDecodeError as e:
+        raise HTTPException(status_code=400, detail=f"Invalid JSON format for identifier_assignments: {str(e)}")
+
+    # Validate assignments structure
+    if not isinstance(assignments, dict):
+        raise HTTPException(status_code=400, detail="identifier_assignments must be a JSON object")
+    
+    if not assignments:
+        raise HTTPException(status_code=400, detail="identifier_assignments cannot be empty")
+
+    # ✅ Check if validator atom exists (MongoDB first)
+    validator_data = get_validator_atom_from_mongo(validator_atom_id)
+    if not validator_data:
+        # Fallback to old method for backward compatibility
+        validator_data = get_validator_from_memory_or_disk(validator_atom_id)
+
+    if not validator_data:
+        raise HTTPException(status_code=404, detail=f"Validator atom '{validator_atom_id}' not found")
+
+    # Check if file_key exists
+    if file_key not in validator_data.get("schemas", {}):
+        available_keys = list(validator_data.get("schemas", {}).keys())
+        raise HTTPException(
+            status_code=400, 
+            detail=f"File key '{file_key}' not found in validator. Available file keys: {available_keys}"
+        )
+
+    # ✅ Get business dimensions from MongoDB first with correct structure handling
+    mongo_dimensions = get_business_dimensions_from_mongo(validator_atom_id, file_key)
+
+    if mongo_dimensions:
+        # MongoDB format: extract from dimensions array
+        dimensions_array = mongo_dimensions.get("dimensions", [])
+        available_dimension_ids = [dim.get("dimension_id") for dim in dimensions_array]
+        business_dimensions = {dim["dimension_id"]: dim for dim in dimensions_array}
+    elif validator_data.get("business_dimensions", {}).get(file_key, {}):
+        # Old format: dictionary of dimensions
+        business_dimensions = validator_data.get("business_dimensions", {}).get(file_key, {})
+        available_dimension_ids = list(business_dimensions.keys())
+    else:
+        raise HTTPException(
+            status_code=400, 
+            detail=f"No business dimensions defined for file key '{file_key}'. Define dimensions first using /define_dimensions."
+        )
+
+    # Validate dimension IDs
+    invalid_dimensions = [dim_id for dim_id in assignments.keys() if dim_id not in available_dimension_ids]
+    if invalid_dimensions:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid dimension IDs: {invalid_dimensions}. Available dimensions: {available_dimension_ids}"
+        )
+
+    # ✅ Get available identifiers from MongoDB classification
+    mongo_classification = get_classification_from_mongo(validator_atom_id, file_key)
+    
+    if mongo_classification:
+        classification_data = mongo_classification
+    elif validator_data.get("classification", {}).get(file_key, {}):
+        classification_data = validator_data.get("classification", {}).get(file_key, {})
+    else:
+        raise HTTPException(
+            status_code=400, 
+            detail=f"No column classification found for file key '{file_key}'. Classify columns first using /classify_columns."
+        )
+
+    available_identifiers = classification_data.get("final_classification", {}).get("identifiers", [])
+    if not available_identifiers:
+        raise HTTPException(
+            status_code=400, 
+            detail=f"No identifiers classified for file key '{file_key}'. Classify columns first using /classify_columns."
+        )
+
+    # Validate assignments
+    all_assigned_identifiers = []
+    for dim_id, identifiers in assignments.items():
+        if not isinstance(identifiers, list):
+            raise HTTPException(status_code=400, detail=f"Identifiers for dimension '{dim_id}' must be a list")
+        
+        if not identifiers:
+            raise HTTPException(status_code=400, detail=f"Identifiers list for dimension '{dim_id}' cannot be empty")
+        
+        invalid_identifiers = [ident for ident in identifiers if ident not in available_identifiers]
+        if invalid_identifiers:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid identifiers for dimension '{dim_id}': {invalid_identifiers}. Available: {available_identifiers}"
+            )
+        all_assigned_identifiers.extend(identifiers)
+
+    # Check for unique assignment
+    if len(all_assigned_identifiers) != len(set(all_assigned_identifiers)):
+        duplicates = [ident for ident in set(all_assigned_identifiers) if all_assigned_identifiers.count(ident) > 1]
+        raise HTTPException(status_code=400, detail=f"Identifiers cannot be assigned to multiple dimensions: {duplicates}")
+
+    # ✅ UPDATE BUSINESS DIMENSIONS STRUCTURE WITH ASSIGNMENTS
+    updated_business_dimensions = business_dimensions.copy()
+    for dim_id, identifiers in assignments.items():
+        if dim_id in updated_business_dimensions:
+            updated_business_dimensions[dim_id]["assigned_identifiers"] = identifiers
+            updated_business_dimensions[dim_id]["assignment_timestamp"] = datetime.now().isoformat()
+
+    # ✅ Save to MongoDB
+    try:
+        mongo_result = update_business_dimensions_assignments_in_mongo(validator_atom_id, file_key, assignments)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to save assignments to MongoDB: {str(e)}")
+
+    # ✅ FIXED: Safe update in memory (works for both validator types)
+    try:
+        # Initialize extraction_results entry if it doesn't exist (for template validator atoms)
+        if validator_atom_id not in extraction_results:
+            extraction_results[validator_atom_id] = {}
+        
+        if "business_dimensions" not in extraction_results[validator_atom_id]:
+            extraction_results[validator_atom_id]["business_dimensions"] = {}
+        
+        extraction_results[validator_atom_id]["business_dimensions"][file_key] = updated_business_dimensions
+        in_memory_status = "success"
+    except Exception as e:
+        # Log but don't fail - MongoDB save is what matters
+        print(f"Warning: Could not update in-memory results for {validator_atom_id}: {e}")
+        in_memory_status = "warning"
+
+    # Find unassigned identifiers
+    unassigned_identifiers = [ident for ident in available_identifiers if ident not in all_assigned_identifiers]
+
+    return {
+        "status": "success",
+        "message": f"Identifiers assigned to dimensions and saved in business dimensions structure for file key '{file_key}'",
+        "validator_atom_id": validator_atom_id,
+        "file_key": file_key,
+        "validator_type": validator_data.get("template_type", "custom"),
+        "updated_business_dimensions": updated_business_dimensions,
+        "assignment_summary": {
+            "total_identifiers": len(available_identifiers),
+            "assigned_identifiers": len(all_assigned_identifiers),
+            "unassigned_identifiers": len(unassigned_identifiers),
+            "dimensions_with_assignments": len(assignments),
+            "assignment_timestamp": datetime.now().isoformat()
+        },
+        "unassigned_identifiers": unassigned_identifiers,
+        "dimension_breakdown": {dim_id: len(identifiers) for dim_id, identifiers in assignments.items()},
+        "mongodb_updated": mongo_result.get("status") == "success",
+        "in_memory_updated": in_memory_status,
+        "next_steps": {
+            "view_complete_setup": f"GET /get_validator_atom_summary/{validator_atom_id}",
+            "export_configuration": f"GET /export_validator_atom/{validator_atom_id}"
+        }
+    }
+
+
+
+# Add this constant at the top of routes.py (after imports)
+VALIDATION_OPERATORS = {
+    "greater_than": ">",
+    "greater_than_or_equal": ">=", 
+    "less_than": "<",
+    "less_than_or_equal": "<=",
+    "equal_to": "==",
+    "not_equal_to": "!=",
+    "between": "BETWEEN",
+    "contains": "CONTAINS",
+    "not_contains": "NOT_CONTAINS",
+    "starts_with": "STARTS_WITH",
+    "ends_with": "ENDS_WITH",
+    "regex_match": "REGEX",
+    "in_list": "IN",
+    "not_in_list": "NOT_IN",
+    "date_before": "DATE_BEFORE",
+    "date_after": "DATE_AFTER",
+    "date_between": "DATE_BETWEEN"
+}
+
+# ✅ ADD: Valid frequency options
+VALID_FREQUENCIES = ["daily", "weekly", "monthly"]
+
+# Updated endpoint with data frequency per column support
+@router.post("/configure_validation_config", response_model=ConfigureValidationConfigResponse)
+async def configure_validation_config(request: Request):
+    """
+    Configure custom validation config for specific columns with optional date frequency per column
+    """
+    data = await request.json()
+    validator_atom_id = data.get("validator_atom_id")
+    file_key = data.get("file_key")
+    column_conditions = data.get("column_conditions")
+    column_frequencies = data.get("column_frequencies", {})  # ✅ NEW: Optional dict of column to frequency
+
+    if not validator_atom_id:
+        raise HTTPException(status_code=400, detail="validator_atom_id is required")
+    if not file_key:
+        raise HTTPException(status_code=400, detail="file_key is required")
+    if not column_conditions:
+        raise HTTPException(status_code=400, detail="column_conditions is required")
+
+    if not isinstance(column_conditions, dict):
+        raise HTTPException(status_code=400, detail="column_conditions must be a dictionary of column to list of conditions")
+
+    if not isinstance(column_frequencies, dict):
+        raise HTTPException(status_code=400, detail="column_frequencies must be a dictionary of column to frequency strings")
+
+    # ✅ NEW: Validate frequencies if provided
+    for col, freq in column_frequencies.items():
+        if freq.lower() not in VALID_FREQUENCIES:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid frequency '{freq}' for column '{col}'. Valid options: {VALID_FREQUENCIES}"
+            )
+
+    validator_data = get_validator_atom_from_mongo(validator_atom_id)
+    if not validator_data:
+        validator_data = get_validator_from_memory_or_disk(validator_atom_id)
+
+    if not validator_data:
+        raise HTTPException(status_code=404, detail=f"Validator atom '{validator_atom_id}' not found")
+
+    if file_key not in validator_data.get("schemas", {}):
+        raise HTTPException(status_code=400, detail=f"File key '{file_key}' not found in validator")
+
+    available_columns = [col["column"] for col in validator_data["schemas"][file_key].get("columns", [])]
+
+    total_conditions = 0
+    for col, cond_list in column_conditions.items():
+        if col not in available_columns:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Column '{col}' not found in validator schema. Available columns: {available_columns}"
+            )
+        if not isinstance(cond_list, list):
+            raise HTTPException(status_code=400, detail=f"Conditions for column '{col}' must be a list")
+        
+        for i, cond in enumerate(cond_list):
+            if not isinstance(cond, dict):
+                raise HTTPException(status_code=400, detail=f"Condition {i+1} for column '{col}' must be a dictionary")
+            
+            required_fields = ['operator', 'value', 'error_message']
+            missing_fields = [field for field in required_fields if field not in cond]
+            if missing_fields:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Condition {i+1} for column '{col}' missing required fields: {missing_fields}"
+                )
+            
+            if cond['operator'] not in VALIDATION_OPERATORS:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Invalid operator '{cond['operator']}' for column '{col}'. Valid operators: {list(VALIDATION_OPERATORS.keys())}"
+                )
+            
+            if 'severity' not in cond:
+                cond['severity'] = 'error'
+            
+            if cond['severity'] not in ['error', 'warning']:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Invalid severity '{cond['severity']}' for column '{col}'. Must be 'error' or 'warning'"
+                )
+            
+            total_conditions += 1
+
+    # ✅ NEW: Build config data with optional column frequencies
+    config_data = {
+        "column_conditions": column_conditions,
+        "column_frequencies": column_frequencies
+    }
+
+    mongo_result = save_validation_config_to_mongo(validator_atom_id, file_key, config_data)
+
+    message = f"Validation config configured successfully for file key '{file_key}' with {total_conditions} conditions"
+    if column_frequencies:
+        message += f" and frequencies specified for columns: {list(column_frequencies.keys())}"
+
+    return {
+        "status": "success",
+        "message": message,
+        "validator_atom_id": validator_atom_id,
+        "file_key": file_key,
+        "mongo_id": mongo_result.get("mongo_id", ""),
+        "operation": mongo_result.get("operation", "unknown"),
+        "total_conditions": total_conditions,
+        "columns_configured": list(column_conditions.keys()),
+        "columns_with_frequencies": list(column_frequencies.keys()),  # ✅ NEW
+        "mongodb_saved": mongo_result["status"] == "success"
+    }
+
+
+
+
+# POST: VALIDATE - Enhanced validation with auto-correction, custom conditions, and MongoDB logging
+@router.post("/validate", response_model=ValidateResponse)
+async def validate(
+    validator_atom_id: str = Form(...),
+    files: List[UploadFile] = File(...),
+    file_keys: str = Form(...),
+    date_frequency: str = Form(default=None)
+):
+    """
+    Enhanced validation: mandatory columns + type check + auto-correction + custom conditions + MongoDB logging
+    """
+    try:
+        keys = json.loads(file_keys)
+    except json.JSONDecodeError:
+        raise HTTPException(status_code=400, detail="Invalid JSON format for file_keys")
+    
+    if len(files) != len(keys):
+        raise HTTPException(status_code=400, detail="Number of files must match number of keys")
+    
+    if len(files) > 3:
+        raise HTTPException(status_code=400, detail="Maximum 3 files allowed")
+    
+    # ✅ Get validator atom data from MongoDB first
+    validator_data = get_validator_atom_from_mongo(validator_atom_id)
+    if not validator_data:
+        # Fallback to old method for backward compatibility
+        validator_data = get_validator_from_memory_or_disk(validator_atom_id)
+    
+    if not validator_data:
+        raise HTTPException(status_code=404, detail=f"Validator atom '{validator_atom_id}' not found")
+    
+    # ✅ ADD: Pass validator_atom_id to validation function for custom conditions lookup
+    validator_data["validator_atom_id"] = validator_atom_id
+    
+    # ✅ Column preprocessing function (same as create_new)
+    def preprocess_column_name(col_name: str) -> str:
+        """Preprocess column name: strip, lowercase, remove spaces but preserve underscores"""
+        col_name = col_name.strip().lower()
+        col_name = re.sub(r'(?<!_)\s+(?!_)', '', col_name)
+        return col_name
+    
+    # ✅ Parse files and store content for MinIO
+    files_data = []
+    file_contents = []
+    
+    for file, key in zip(files, keys):
+        try:
+            content = await file.read()
+            file_contents.append((content, file.filename, key))
+            
+            # Parse file based on extension
+            if file.filename.lower().endswith(".csv"):
+                df = pd.read_csv(io.BytesIO(content))
+            elif file.filename.lower().endswith(".xlsx"):
+                df = pd.read_excel(io.BytesIO(content))
+            else:
+                raise HTTPException(status_code=400, detail="Only CSV and XLSX files supported")
+            
+            # ✅ Preprocess columns (same logic as create_new)
+            df.columns = [preprocess_column_name(col) for col in df.columns]
+            files_data.append((key, df))
+            
+        except Exception as e:
+            raise HTTPException(status_code=400, detail=f"Error parsing file {file.filename}: {str(e)}")
+    
+    # ✅ Enhanced validation with auto-correction and custom conditions
+    validation_results = perform_enhanced_validation(files_data, validator_data)
+    
+    # ✅ MinIO upload: Only if validation passes or passes with warnings
+    minio_uploads = []
+    if validation_results["overall_status"] in ["passed", "passed_with_warnings"]:
+        for content, filename, key in file_contents:
+            upload_result = upload_to_minio(content, filename, validator_atom_id, key)
+            minio_uploads.append({
+                "file_key": key,
+                "filename": filename,
+                "minio_upload": upload_result
+            })
+    
+    # ✅ Save detailed validation log to MongoDB
+    validation_log_data = {
+        "validator_atom_id": validator_atom_id,
+        "files_validated": [
+            {
+                "file_key": key,
+                "filename": next(f[1] for f in file_contents if f[2] == key),
+                "file_size_bytes": len(next(f[0] for f in file_contents if f[2] == key)),
+                "overall_status": validation_results["file_results"].get(key, {}).get("status", "unknown"),
+                "errors": validation_results["file_results"].get(key, {}).get("errors", []),
+                "warnings": validation_results["file_results"].get(key, {}).get("warnings", []),
+                "auto_corrections": validation_results["file_results"].get(key, {}).get("auto_corrections", []),
+                "condition_failures": validation_results["file_results"].get(key, {}).get("condition_failures", []),  # ✅ ADD
+                "columns_checked": validation_results["file_results"].get(key, {}).get("columns_checked", 0),
+                "data_corrections_applied": validation_results["file_results"].get(key, {}).get("data_corrections_applied", 0),
+                "custom_conditions_failed": validation_results["file_results"].get(key, {}).get("custom_conditions_failed", 0),  # ✅ ADD
+                "validation_duration_ms": 0  # Will implement timing later
+            }
+            for key in keys
+        ],
+        "overall_status": validation_results["overall_status"],
+        "total_files": len(keys),
+        "total_duration_ms": 0,  # Will implement timing later
+        "minio_uploads": minio_uploads,
+        "summary_stats": {
+            "total_auto_corrections": validation_results["summary"].get("total_auto_corrections", 0),
+            "total_condition_failures": validation_results["summary"].get("total_condition_failures", 0),  # ✅ ADD
+            "total_errors": sum(len(result.get("errors", [])) for result in validation_results["file_results"].values()),
+            "total_warnings": sum(len(result.get("warnings", [])) for result in validation_results["file_results"].values())
+        }
+    }
+    
+    # ✅ Save to MongoDB validation logs collection
+    mongo_log_result = save_validation_log_to_mongo(validation_log_data)
+
+    return {
+        "overall_status": validation_results["overall_status"],
+        "validator_atom_id": validator_atom_id,
+        "file_validation_results": validation_results["file_results"],
+        "summary": validation_results["summary"],
+        "minio_uploads": minio_uploads,
+        "validation_log_saved": mongo_log_result["status"] == "success",
+        "validation_log_id": mongo_log_result.get("mongo_id", ""),
+        "total_auto_corrections": validation_results["summary"].get("total_auto_corrections", 0),
+        "total_condition_failures": validation_results["summary"].get("total_condition_failures", 0)  # ✅ ADD
+    }
+
+    
+    
+
+
+
+# DELETE: DELETE_VALIDATOR_ATOM - Delete a custom validator atom completely
+@router.delete("/delete_validator_atom/{validator_atom_id}")
+async def delete_validator_atom(validator_atom_id: str):
+    """
+    Delete a custom validator atom completely
+    - Removes from custom_validations folder
+    - Removes from mongodb folder (all related files)
+    - Clears from memory
+    """
+    
+    def delete_validator_atom_files(validator_atom_id: str):
+        """Delete all files related to a validator atom from disk and memory"""
+        # Paths
+        custom_dir = Path("custom_validations")
+        mongo_dir = Path("mongodb")
+        deleted_files = []
+
+        # Delete from custom_validations
+        custom_file = custom_dir / f"{validator_atom_id}.json"
+        if custom_file.exists():
+            custom_file.unlink()
+            deleted_files.append(str(custom_file))
+
+        # Delete from mongodb folder - classification, dimensions, assignments
+        for suffix in ["classification", "business_dimensions", "identifier_assignments"]:
+            mongo_file = mongo_dir / f"{validator_atom_id}_{suffix}.json"
+            if mongo_file.exists():
+                mongo_file.unlink()
+                deleted_files.append(str(mongo_file))
+
+        # Clear from memory
+        if validator_atom_id in extraction_results:
+            del extraction_results[validator_atom_id]
+            deleted_files.append("memory_cleared")
+
+        return deleted_files
+    
+    # Validate validator_atom_id
+    if not validator_atom_id or not validator_atom_id.strip():
+        raise HTTPException(status_code=400, detail="validator_atom_id cannot be empty")
+    
+    # Check if validator atom exists
+    validator_exists = False
+    custom_file = CUSTOM_CONFIG_DIR / f"{validator_atom_id}.json"
+    mongo_classification = MONGODB_DIR / f"{validator_atom_id}_classification.json"
+    mongo_dimensions = MONGODB_DIR / f"{validator_atom_id}_business_dimensions.json"
+    mongo_assignments = MONGODB_DIR / f"{validator_atom_id}_identifier_assignments.json"
+    
+    if (custom_file.exists() or 
+        mongo_classification.exists() or 
+        mongo_dimensions.exists() or 
+        mongo_assignments.exists() or 
+        validator_atom_id in extraction_results):
+        validator_exists = True
+    
+    if not validator_exists:
+        raise HTTPException(status_code=404, detail=f"Validator atom '{validator_atom_id}' not found")
+    
+    # Delete all files and clear memory
+    try:
+        deleted_files = delete_validator_atom_files(validator_atom_id)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error deleting validator atom: {str(e)}")
+    
+    return {
+        "status": "success",
+        "message": f"Validator atom '{validator_atom_id}' deleted completely",
+        "validator_atom_id": validator_atom_id,
+        "deleted_files": deleted_files,
+        "deletion_summary": {
+            "custom_validations_removed": any("custom_validations" in f for f in deleted_files),
+            "mongodb_files_removed": any("mongodb" in f for f in deleted_files),
+            "memory_cleared": "memory_cleared" in deleted_files,
+            "total_files_deleted": len([f for f in deleted_files if f != "memory_cleared"])
+        }
+    }
+
+
+############################prebuild
+
+# # ✅ UPDATED: Complete MMM Validation Endpoint with MinIO Upload
+# @router.post("/validate_mmm")
+# async def validate_mmm_endpoint(
+#     files: List[UploadFile] = File(...),
+#     file_keys: str = Form(...)
+# ):
+#     """
+#     Validate files using MMM (Media Mix Modeling) validation rules and save to MinIO if passed.
+#     Requires both 'media' and 'sales' datasets.
+#     """
+#     try:
+#         keys = json.loads(file_keys)
+#     except json.JSONDecodeError:
+#         raise HTTPException(status_code=400, detail="Invalid JSON format for file_keys")
+    
+#     if len(files) != len(keys):
+#         raise HTTPException(status_code=400, detail="Number of files must match number of keys")
+    
+#     if len(files) != 2:
+#         raise HTTPException(status_code=400, detail="MMM validation requires exactly 2 files: media and sales")
+    
+#     # ✅ FIXED: Column preprocessing function that matches MMM validation expectations
+#     def preprocess_column_name(col_name: str) -> str:
+#         """Preprocess column name: strip, lowercase, replace spaces with underscores"""
+#         col_name = col_name.strip().lower()
+#         col_name = col_name.replace(' ', '_').replace('-', '_').replace('__', '_')
+#         col_name = col_name.strip('_')  # Remove leading/trailing underscores
+#         return col_name
+    
+#     # Parse files and store data
+#     files_data = {}
+#     file_contents = []
+    
+#     for file, key in zip(files, keys):
+#         try:
+#             content = await file.read()
+#             file_contents.append((content, file.filename, key))
+            
+#             # Parse file based on extension
+#             if file.filename.lower().endswith(".csv"):
+#                 df = pd.read_csv(io.BytesIO(content))
+#             elif file.filename.lower().endswith(".xlsx"):
+#                 df = pd.read_excel(io.BytesIO(content))
+#             else:
+#                 raise HTTPException(status_code=400, detail="Only CSV and XLSX files supported")
+            
+#             # ✅ FIXED: Preprocess columns to match MMM validation expectations
+#             df.columns = [preprocess_column_name(col) for col in df.columns]
+#             files_data[key] = df
+            
+#         except Exception as e:
+#             raise HTTPException(status_code=400, detail=f"Error parsing file {file.filename}: {str(e)}")
+    
+#     # Check required keys
+#     if 'media' not in files_data or 'sales' not in files_data:
+#         available_keys = list(files_data.keys())
+#         raise HTTPException(
+#             status_code=400, 
+#             detail=f"MMM validation requires 'media' and 'sales' file keys. Found: {available_keys}"
+#         )
+    
+#     media_df = files_data['media']
+#     sales_df = files_data['sales']
+    
+#     # Validate that datasets are not empty
+#     if media_df.empty:
+#         raise HTTPException(status_code=400, detail="Media dataset is empty")
+#     if sales_df.empty:
+#         raise HTTPException(status_code=400, detail="Sales dataset is empty")
+    
+#     try:
+#         # Call MMM validation
+#         validation_report = validate_mmm(media_df, sales_df)
+        
+#         # ✅ NEW: Auto-generate validator_atom_id for MMM
+#         from datetime import datetime
+#         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+#         validator_atom_id = f"mmm_template_{timestamp}"
+        
+#         # ✅ NEW: MinIO upload if validation passes
+#         minio_uploads = []
+#         mongo_log_result = {"status": "skipped", "reason": "validation_failed"}
+        
+#         if validation_report.status == "success":
+#             for content, filename, key in file_contents:
+#                 upload_result = upload_to_minio(content, filename, validator_atom_id, key)
+#                 minio_uploads.append({
+#                     "file_key": key,
+#                     "filename": filename,
+#                     "minio_upload": upload_result
+#                 })
+            
+#             # ✅ NEW: Save validation log to MongoDB
+#             validation_log_data = {
+#                 "validator_atom_id": validator_atom_id,
+#                 "validation_type": "mmm_template",
+#                 "files_validated": [
+#                     {
+#                         "file_key": key,
+#                         "filename": next(f[1] for f in file_contents if f[2] == key),
+#                         "file_size_bytes": len(next(f[0] for f in file_contents if f[2] == key)),
+#                         "overall_status": "passed",
+#                         "records_count": len(files_data[key]),
+#                         "columns_found": list(files_data[key].columns),
+#                         "validation_duration_ms": 0
+#                     }
+#                     for key in keys
+#                 ],
+#                 "overall_status": "passed",
+#                 "total_files": len(keys),
+#                 "minio_uploads": minio_uploads,
+#                 "timestamp": datetime.now().isoformat(),
+#                 "summary_stats": {
+#                     "media_records": len(media_df),
+#                     "sales_records": len(sales_df),
+#                     "total_validation_checks": len(validation_report.results)
+#                 }
+#             }
+#             mongo_log_result = save_validation_log_to_mongo(validation_log_data)
+        
+#         # Build detailed response
+#         validation_results = {
+#             "overall_status": "passed" if validation_report.status == "success" else "failed",
+#             "validation_type": "mmm_template",
+#             "file_results": {
+#                 "media": {
+#                     "status": "passed" if not validation_report.has_failures("media") else "failed",
+#                     "errors": validation_report.get_failures("media"),
+#                     "warnings": validation_report.get_warnings("media"),
+#                     "successes": validation_report.get_successes("media"),
+#                     "columns_checked": len(media_df.columns),
+#                     "records_count": len(media_df),
+#                     "columns_found": list(media_df.columns)
+#                 },
+#                 "sales": {
+#                     "status": "passed" if not validation_report.has_failures("sales") else "failed", 
+#                     "errors": validation_report.get_failures("sales"),
+#                     "warnings": validation_report.get_warnings("sales"),
+#                     "successes": validation_report.get_successes("sales"),
+#                     "columns_checked": len(sales_df.columns),
+#                     "records_count": len(sales_df),
+#                     "columns_found": list(sales_df.columns)
+#                 }
+#             },
+#             "summary": {
+#                 "total_files": 2,
+#                 "media_records": len(media_df),
+#                 "sales_records": len(sales_df),
+#                 "validation_checks_performed": len(validation_report.results)
+#             },
+#             "mmm_specific_validations": {
+#                 "media_columns_validated": len([col for col in media_df.columns if col in validation_report.media_rules["required"]]),
+#                 "sales_columns_validated": len([col for col in sales_df.columns if col in validation_report.sales_rules["required"]])
+#             }
+#         }
+        
+#         return {
+#             "overall_status": validation_results["overall_status"],
+#             "validation_type": "mmm_template",
+#             "validator_atom_id": validator_atom_id,  # ✅ NEW
+#             "file_validation_results": validation_results["file_results"],
+#             "summary": validation_results["summary"],
+#             "mmm_specific_results": validation_results["mmm_specific_validations"],
+#             "minio_uploads": minio_uploads,  # ✅ NEW
+#             "validation_log_saved": mongo_log_result.get("status") == "success",  # ✅ NEW
+#             "validation_log_id": mongo_log_result.get("mongo_id", ""),  # ✅ NEW
+#             "files_processed": {
+#                 "media": {
+#                     "filename": file_contents[0][1] if len(file_contents) > 0 else "unknown",
+#                     "size_bytes": len(file_contents[0][0]) if len(file_contents) > 0 else 0
+#                 },
+#                 "sales": {
+#                     "filename": file_contents[1][1] if len(file_contents) > 1 else "unknown", 
+#                     "size_bytes": len(file_contents[1][0]) if len(file_contents) > 1 else 0
+#                 }
+#             },
+#             "debug_info": {
+#                 "media_columns_after_preprocessing": list(media_df.columns),
+#                 "sales_columns_after_preprocessing": list(sales_df.columns),
+#                 "validation_results_count": len(validation_report.results)
+#             }
+#         }
+        
+#     except Exception as e:
+#         raise HTTPException(status_code=500, detail=f"MMM validation failed: {str(e)}")
+
+# ✅ UPDATED: Complete MMM Validation Endpoint with Full Integration
+@router.post("/validate_mmm")
+async def validate_mmm_endpoint(
+    files: List[UploadFile] = File(...),
+    file_keys: str = Form(...)
+):
+    """
+    Validate files using MMM (Media Mix Modeling) validation rules and save to MinIO if passed.
+    Requires both 'media' and 'sales' datasets.
+    Includes validator atom schema saving for classification workflow.
+    """
+    try:
+        keys = json.loads(file_keys)
+    except json.JSONDecodeError:
+        raise HTTPException(status_code=400, detail="Invalid JSON format for file_keys")
+    
+    if len(files) != len(keys):
+        raise HTTPException(status_code=400, detail="Number of files must match number of keys")
+    
+    if len(files) != 2:
+        raise HTTPException(status_code=400, detail="MMM validation requires exactly 2 files: media and sales")
+    
+    # ✅ FIXED: Column preprocessing function that matches MMM validation expectations
+    def preprocess_column_name(col_name: str) -> str:
+        """Preprocess column name: strip, lowercase, replace spaces with underscores"""
+        col_name = col_name.strip().lower()
+        col_name = col_name.replace(' ', '_').replace('-', '_').replace('__', '_')
+        col_name = col_name.strip('_')  # Remove leading/trailing underscores
+        return col_name
+    
+    # Parse files and store data
+    files_data = {}
+    file_contents = []
+    
+    for file, key in zip(files, keys):
+        try:
+            content = await file.read()
+            file_contents.append((content, file.filename, key))
+            
+            # Parse file based on extension
+            if file.filename.lower().endswith(".csv"):
+                df = pd.read_csv(io.BytesIO(content))
+            elif file.filename.lower().endswith(".xlsx"):
+                df = pd.read_excel(io.BytesIO(content))
+            else:
+                raise HTTPException(status_code=400, detail="Only CSV and XLSX files supported")
+            
+            # ✅ FIXED: Preprocess columns to match MMM validation expectations
+            df.columns = [preprocess_column_name(col) for col in df.columns]
+            files_data[key] = df
+            
+        except Exception as e:
+            raise HTTPException(status_code=400, detail=f"Error parsing file {file.filename}: {str(e)}")
+    
+    # Check required keys
+    if 'media' not in files_data or 'sales' not in files_data:
+        available_keys = list(files_data.keys())
+        raise HTTPException(
+            status_code=400, 
+            detail=f"MMM validation requires 'media' and 'sales' file keys. Found: {available_keys}"
+        )
+    
+    media_df = files_data['media']
+    sales_df = files_data['sales']
+    
+    # Validate that datasets are not empty
+    if media_df.empty:
+        raise HTTPException(status_code=400, detail="Media dataset is empty")
+    if sales_df.empty:
+        raise HTTPException(status_code=400, detail="Sales dataset is empty")
+    
+    try:
+        # Call MMM validation
+        validation_report = validate_mmm(media_df, sales_df)
+        
+        # ✅ NEW: Auto-generate validator_atom_id for MMM
+        from datetime import datetime
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        validator_atom_id = f"mmm_template_{timestamp}"
+        
+        # ✅ NEW: MinIO upload and validator atom schema saving if validation passes
+        minio_uploads = []
+        mongo_log_result = {"status": "skipped", "reason": "validation_failed"}
+        validator_atom_result = {"status": "skipped", "reason": "validation_failed"}
+        
+        if validation_report.status == "success":
+            for content, filename, key in file_contents:
+                upload_result = upload_to_minio(content, filename, validator_atom_id, key)
+                minio_uploads.append({
+                    "file_key": key,
+                    "filename": filename,
+                    "minio_upload": upload_result
+                })
+            
+            # ✅ NEW: Save validator atom schema to MongoDB for classification
+            validator_atom_schema = {
+                "_id": validator_atom_id,
+                "validator_atom_id": validator_atom_id,
+                "template_type": "mmm_template",
+                "schemas": {
+                    key: {
+                        "columns": [{"column": col} for col in files_data[key].columns],
+                        "column_types": {
+                            col: "numeric" if pd.api.types.is_numeric_dtype(files_data[key][col]) 
+                                 else "datetime" if pd.api.types.is_datetime64_any_dtype(files_data[key][col])
+                                 else "string"
+                            for col in files_data[key].columns
+                        },
+                        "template_type": "mmm_template"
+                    }
+                    for key in keys  # Creates schema for both media and sales
+                },
+                "created_at": datetime.now().isoformat(),
+                "template_generated": True
+            }
+            
+            # Save validator atom schema
+            validator_atom_result = save_validator_atom_to_mongo(validator_atom_id, validator_atom_schema)
+            
+            # ✅ NEW: Save validation log to MongoDB
+            validation_log_data = {
+                "validator_atom_id": validator_atom_id,
+                "validation_type": "mmm_template",
+                "files_validated": [
+                    {
+                        "file_key": key,
+                        "filename": next(f[1] for f in file_contents if f[2] == key),
+                        "file_size_bytes": len(next(f[0] for f in file_contents if f[2] == key)),
+                        "overall_status": "passed",
+                        "records_count": len(files_data[key]),
+                        "columns_found": list(files_data[key].columns),
+                        "validation_duration_ms": 0
+                    }
+                    for key in keys
+                ],
+                "overall_status": "passed",
+                "total_files": len(keys),
+                "minio_uploads": minio_uploads,
+                "timestamp": datetime.now().isoformat(),
+                "summary_stats": {
+                    "media_records": len(media_df),
+                    "sales_records": len(sales_df),
+                    "total_validation_checks": len(validation_report.results)
+                }
+            }
+            mongo_log_result = save_validation_log_to_mongo(validation_log_data)
+        
+        # Build detailed response
+        validation_results = {
+            "overall_status": "passed" if validation_report.status == "success" else "failed",
+            "validation_type": "mmm_template",
+            "file_results": {
+                "media": {
+                    "status": "passed" if not validation_report.has_failures("media") else "failed",
+                    "errors": validation_report.get_failures("media"),
+                    "warnings": validation_report.get_warnings("media"),
+                    "successes": validation_report.get_successes("media"),
+                    "columns_checked": len(media_df.columns),
+                    "records_count": len(media_df),
+                    "columns_found": list(media_df.columns)
+                },
+                "sales": {
+                    "status": "passed" if not validation_report.has_failures("sales") else "failed", 
+                    "errors": validation_report.get_failures("sales"),
+                    "warnings": validation_report.get_warnings("sales"),
+                    "successes": validation_report.get_successes("sales"),
+                    "columns_checked": len(sales_df.columns),
+                    "records_count": len(sales_df),
+                    "columns_found": list(sales_df.columns)
+                }
+            },
+            "summary": {
+                "total_files": 2,
+                "media_records": len(media_df),
+                "sales_records": len(sales_df),
+                "validation_checks_performed": len(validation_report.results)
+            },
+            "mmm_specific_validations": {
+                "media_columns_validated": len([col for col in media_df.columns if col in validation_report.media_rules["required"]]),
+                "sales_columns_validated": len([col for col in sales_df.columns if col in validation_report.sales_rules["required"]])
+            }
+        }
+        
+        return {
+            "overall_status": validation_results["overall_status"],
+            "validation_type": "mmm_template",
+            "validator_atom_id": validator_atom_id,
+            "file_validation_results": validation_results["file_results"],
+            "summary": validation_results["summary"],
+            "mmm_specific_results": validation_results["mmm_specific_validations"],
+            "minio_uploads": minio_uploads,
+            "validation_log_saved": mongo_log_result.get("status") == "success",
+            "validation_log_id": mongo_log_result.get("mongo_id", ""),
+            # ✅ NEW: Template integration section
+            "template_integration": {
+                "validator_atom_saved": validator_atom_result.get("status") == "success" if validation_report.status == "success" else False,
+                "classify_columns_ready": True if validation_report.status == "success" else False,
+                "available_file_keys": keys if validation_report.status == "success" else [],
+                "next_steps": {
+                    "classification_media": f"POST /classify_columns with validator_atom_id: {validator_atom_id}, file_key: media",
+                    "classification_sales": f"POST /classify_columns with validator_atom_id: {validator_atom_id}, file_key: sales",
+                    "dimensions_media": f"POST /define_dimensions with validator_atom_id: {validator_atom_id}, file_key: media",
+                    "dimensions_sales": f"POST /define_dimensions with validator_atom_id: {validator_atom_id}, file_key: sales"
+                } if validation_report.status == "success" else {}
+            },
+            "files_processed": {
+                "media": {
+                    "filename": file_contents[0][1] if len(file_contents) > 0 else "unknown",
+                    "size_bytes": len(file_contents[0][0]) if len(file_contents) > 0 else 0
+                },
+                "sales": {
+                    "filename": file_contents[1][1] if len(file_contents) > 1 else "unknown", 
+                    "size_bytes": len(file_contents[1][0]) if len(file_contents) > 1 else 0
+                }
+            },
+        }
+        
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"MMM validation failed: {str(e)}")
+
+
+# # ✅ UPDATED: Category Forecasting Validation Endpoint with MinIO Upload
+# @router.post("/validate_category_forecasting")
+# async def validate_category_forecasting_endpoint(
+#     files: List[UploadFile] = File(...),
+#     file_keys: str = Form(...),
+#     date_col: str = Form(default="Date"),
+#     fiscal_start_month: int = Form(default=4)
+# ):
+#     """
+#     Validate files using Category Forecasting validation rules and save to MinIO if passed.
+#     Requires one file with category forecasting data.
+#     """
+#     try:
+#         keys = json.loads(file_keys)
+#     except json.JSONDecodeError:
+#         raise HTTPException(status_code=400, detail="Invalid JSON format for file_keys")
+    
+#     if len(files) != len(keys):
+#         raise HTTPException(status_code=400, detail="Number of files must match number of keys")
+    
+#     if len(files) != 1:
+#         raise HTTPException(status_code=400, detail="Category Forecasting validation requires exactly 1 file")
+    
+#     # Column preprocessing function
+#     def preprocess_column_name(col_name: str) -> str:
+#         """Preprocess column name: strip, lowercase, minimal processing for CF"""
+#         col_name = col_name.strip()
+#         return col_name
+    
+#     # Parse file
+#     file = files[0]
+#     key = keys[0]
+    
+#     try:
+#         content = await file.read()
+        
+#         # Parse file based on extension
+#         if file.filename.lower().endswith(".csv"):
+#             df = pd.read_csv(io.BytesIO(content))
+#         elif file.filename.lower().endswith(".xlsx"):
+#             df = pd.read_excel(io.BytesIO(content))
+#         else:
+#             raise HTTPException(status_code=400, detail="Only CSV and XLSX files supported")
+        
+#         # Light preprocessing (CF validation handles most column standardization)
+#         df.columns = [preprocess_column_name(col) for col in df.columns]
+        
+#     except Exception as e:
+#         raise HTTPException(status_code=400, detail=f"Error parsing file {file.filename}: {str(e)}")
+    
+#     # Validate that dataset is not empty
+#     if df.empty:
+#         raise HTTPException(status_code=400, detail="Dataset is empty")
+    
+#     try:
+#         # Call Category Forecasting validation
+#         validation_report = validate_category_forecasting(
+#             df, 
+#             date_col=date_col, 
+#             fiscal_start_month=fiscal_start_month
+#         )
+        
+#         # ✅ NEW: Auto-generate validator_atom_id for Category Forecasting
+#         from datetime import datetime
+#         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+#         validator_atom_id = f"category_forecasting_template_{timestamp}"
+        
+#         # ✅ NEW: MinIO upload if validation passes
+#         minio_uploads = []
+#         mongo_log_result = {"status": "skipped", "reason": "validation_failed"}
+        
+#         if validation_report.status == "success":
+#             upload_result = upload_to_minio(content, file.filename, validator_atom_id, key)
+#             minio_uploads.append({
+#                 "file_key": key,
+#                 "filename": file.filename,
+#                 "minio_upload": upload_result
+#             })
+            
+#             # ✅ NEW: Save validation log to MongoDB
+#             validation_log_data = {
+#                 "validator_atom_id": validator_atom_id,
+#                 "validation_type": "category_forecasting_template",
+#                 "files_validated": [{
+#                     "file_key": key,
+#                     "filename": file.filename,
+#                     "file_size_bytes": len(content),
+#                     "overall_status": "passed",
+#                     "date_column_used": date_col,
+#                     "fiscal_start_month": fiscal_start_month,
+#                     "records_count": len(df),
+#                     "columns_found": list(df.columns),
+#                     "validation_duration_ms": 0
+#                 }],
+#                 "overall_status": "passed",
+#                 "total_files": 1,
+#                 "minio_uploads": minio_uploads,
+#                 "timestamp": datetime.now().isoformat(),
+#                 "summary_stats": {
+#                     "total_records": len(df),
+#                     "total_columns": len(df.columns),
+#                     "validation_checks": len(validation_report.results)
+#                 }
+#             }
+#             mongo_log_result = save_validation_log_to_mongo(validation_log_data)
+        
+#         # Build response
+#         return {
+#             "overall_status": "passed" if validation_report.status == "success" else "failed",
+#             "validation_type": "category_forecasting_template",
+#             "validator_atom_id": validator_atom_id,  # ✅ NEW
+#             "file_validation_results": {
+#                 key: {
+#                     "status": "passed" if not validation_report.has_failures() else "failed",
+#                     "errors": validation_report.get_failures(),
+#                     "warnings": validation_report.get_warnings(),
+#                     "successes": validation_report.get_successes(),
+#                     "columns_checked": len(df.columns),
+#                     "records_count": len(df),
+#                     "columns_found": list(df.columns)
+#                 }
+#             },
+#             "summary": {
+#                 "total_files": 1,
+#                 "records_processed": len(df),
+#                 "columns_processed": len(df.columns),
+#                 "validation_checks_performed": len(validation_report.results),
+#                 "date_column_used": date_col,
+#                 "fiscal_start_month": fiscal_start_month
+#             },
+#             "category_forecasting_specific_results": {
+#                 "date_column_validation": any("date" in r["check"] for r in validation_report.results),
+#                 "dimension_columns_found": len([r for r in validation_report.results if "dimension" in r["check"] and r["status"] == "passed"]),
+#                 "fiscal_year_handling": any("fiscal" in r["check"] for r in validation_report.results)
+#             },
+#             "minio_uploads": minio_uploads,  # ✅ NEW
+#             "validation_log_saved": mongo_log_result.get("status") == "success",  # ✅ NEW
+#             "validation_log_id": mongo_log_result.get("mongo_id", ""),  # ✅ NEW
+#             "files_processed": {
+#                 key: {
+#                     "filename": file.filename,
+#                     "size_bytes": len(content)
+#                 }
+#             }
+#         }
+        
+#     except Exception as e:
+#         raise HTTPException(status_code=500, detail=f"Category Forecasting validation failed: {str(e)}")
+
+
+
+# ✅ UPDATED: Complete Category Forecasting Validation Endpoint with Full Integration
+@router.post("/validate_category_forecasting")
+async def validate_category_forecasting_endpoint(
+    files: List[UploadFile] = File(...),
+    file_keys: str = Form(...),
+    date_col: str = Form(default="Date"),
+    fiscal_start_month: int = Form(default=4)
+):
+    """
+    Validate files using Category Forecasting validation rules and save to MinIO if passed.
+    Requires one file with category forecasting data.
+    Includes validator atom schema saving for classification workflow.
+    """
+    try:
+        keys = json.loads(file_keys)
+    except json.JSONDecodeError:
+        raise HTTPException(status_code=400, detail="Invalid JSON format for file_keys")
+    
+    if len(files) != len(keys):
+        raise HTTPException(status_code=400, detail="Number of files must match number of keys")
+    
+    if len(files) != 1:
+        raise HTTPException(status_code=400, detail="Category Forecasting validation requires exactly 1 file")
+    
+    # Column preprocessing function
+    def preprocess_column_name(col_name: str) -> str:
+        """Preprocess column name: strip, lowercase, minimal processing for CF"""
+        col_name = col_name.strip()
+        return col_name
+    
+    # Parse file
+    file = files[0]
+    key = keys[0]
+    
+    try:
+        content = await file.read()
+        
+        # Parse file based on extension
+        if file.filename.lower().endswith(".csv"):
+            df = pd.read_csv(io.BytesIO(content))
+        elif file.filename.lower().endswith(".xlsx"):
+            df = pd.read_excel(io.BytesIO(content))
+        else:
+            raise HTTPException(status_code=400, detail="Only CSV and XLSX files supported")
+        
+        # Light preprocessing (CF validation handles most column standardization)
+        df.columns = [preprocess_column_name(col) for col in df.columns]
+        
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Error parsing file {file.filename}: {str(e)}")
+    
+    # Validate that dataset is not empty
+    if df.empty:
+        raise HTTPException(status_code=400, detail="Dataset is empty")
+    
+    try:
+        # Call Category Forecasting validation
+        validation_report = validate_category_forecasting(
+            df, 
+            date_col=date_col, 
+            fiscal_start_month=fiscal_start_month
+        )
+        
+        # ✅ NEW: Auto-generate validator_atom_id for Category Forecasting
+        from datetime import datetime
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        validator_atom_id = f"category_forecasting_template_{timestamp}"
+        
+        # ✅ NEW: MinIO upload and validator atom schema saving if validation passes
+        minio_uploads = []
+        mongo_log_result = {"status": "skipped", "reason": "validation_failed"}
+        validator_atom_result = {"status": "skipped", "reason": "validation_failed"}
+        
+        if validation_report.status == "success":
+            upload_result = upload_to_minio(content, file.filename, validator_atom_id, key)
+            minio_uploads.append({
+                "file_key": key,
+                "filename": file.filename,
+                "minio_upload": upload_result
+            })
+            
+            # ✅ NEW: Save validator atom schema to MongoDB for classification
+            validator_atom_schema = {
+                "_id": validator_atom_id,
+                "validator_atom_id": validator_atom_id,
+                "template_type": "category_forecasting_template",
+                "schemas": {
+                    key: {
+                        "columns": [{"column": col} for col in df.columns],
+                        "column_types": {
+                            col: "numeric" if pd.api.types.is_numeric_dtype(df[col]) 
+                                 else "datetime" if pd.api.types.is_datetime64_any_dtype(df[col])
+                                 else "string"
+                            for col in df.columns
+                        },
+                        "template_type": "category_forecasting_template"
+                    }
+                },
+                "created_at": datetime.now().isoformat(),
+                "template_generated": True
+            }
+            
+            # Save validator atom schema
+            validator_atom_result = save_validator_atom_to_mongo(validator_atom_id, validator_atom_schema)
+            
+            # ✅ NEW: Save validation log to MongoDB
+            validation_log_data = {
+                "validator_atom_id": validator_atom_id,
+                "validation_type": "category_forecasting_template",
+                "files_validated": [{
+                    "file_key": key,
+                    "filename": file.filename,
+                    "file_size_bytes": len(content),
+                    "overall_status": "passed",
+                    "date_column_used": date_col,
+                    "fiscal_start_month": fiscal_start_month,
+                    "records_count": len(df),
+                    "columns_found": list(df.columns),
+                    "validation_duration_ms": 0
+                }],
+                "overall_status": "passed",
+                "total_files": 1,
+                "minio_uploads": minio_uploads,
+                "timestamp": datetime.now().isoformat(),
+                "summary_stats": {
+                    "total_records": len(df),
+                    "total_columns": len(df.columns),
+                    "validation_checks": len(validation_report.results)
+                }
+            }
+            mongo_log_result = save_validation_log_to_mongo(validation_log_data)
+        
+        # Build response
+        return {
+            "overall_status": "passed" if validation_report.status == "success" else "failed",
+            "validation_type": "category_forecasting_template",
+            "validator_atom_id": validator_atom_id,
+            "file_validation_results": {
+                key: {
+                    "status": "passed" if not validation_report.has_failures() else "failed",
+                    "errors": validation_report.get_failures(),
+                    "warnings": validation_report.get_warnings(),
+                    "successes": validation_report.get_successes(),
+                    "columns_checked": len(df.columns),
+                    "records_count": len(df),
+                    "columns_found": list(df.columns)
+                }
+            },
+            "summary": {
+                "total_files": 1,
+                "records_processed": len(df),
+                "columns_processed": len(df.columns),
+                "validation_checks_performed": len(validation_report.results),
+                "date_column_used": date_col,
+                "fiscal_start_month": fiscal_start_month
+            },
+            "category_forecasting_specific_results": {
+                "date_column_validation": any("date" in r["check"] for r in validation_report.results),
+                "dimension_columns_found": len([r for r in validation_report.results if "dimension" in r["check"] and r["status"] == "passed"]),
+                "fiscal_year_handling": any("fiscal" in r["check"] for r in validation_report.results)
+            },
+            "minio_uploads": minio_uploads,
+            "validation_log_saved": mongo_log_result.get("status") == "success",
+            "validation_log_id": mongo_log_result.get("mongo_id", ""),
+            # ✅ NEW: Template integration section
+            "template_integration": {
+                "validator_atom_saved": validator_atom_result.get("status") == "success" if validation_report.status == "success" else False,
+                "classify_columns_ready": True if validation_report.status == "success" else False,
+                "available_file_keys": [key] if validation_report.status == "success" else [],
+                "next_steps": {
+                    "classification": f"POST /classify_columns with validator_atom_id: {validator_atom_id}",
+                    "dimensions": f"POST /define_dimensions with validator_atom_id: {validator_atom_id}"
+                } if validation_report.status == "success" else {}
+            },
+            "files_processed": {
+                key: {
+                    "filename": file.filename,
+                    "size_bytes": len(content)
+                }
+            },
+            # ✅ NEW: Debug info for troubleshooting
+            "debug_info": {
+                "columns_after_preprocessing": list(df.columns),
+                "validation_results_count": len(validation_report.results)
+            }
+        }
+        
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Category Forecasting validation failed: {str(e)}")
+
+
+
+
+
+# ✅ UPDATED: Complete Promo Validation Endpoint with MinIO Upload
+@router.post("/validate_promo")
+async def validate_promo_endpoint(
+    files: List[UploadFile] = File(...),
+    file_keys: str = Form(...)
+):
+    """
+    Validate files using Promo Intensity validation rules and save to MinIO if passed.
+    Requires one file with promotional data.
+    """
+    try:
+        keys = json.loads(file_keys)
+    except json.JSONDecodeError:
+        raise HTTPException(status_code=400, detail="Invalid JSON format for file_keys")
+    
+    if len(files) != len(keys):
+        raise HTTPException(status_code=400, detail="Number of files must match number of keys")
+    
+    if len(files) != 1:
+        raise HTTPException(status_code=400, detail="Promo validation requires exactly 1 file")
+    
+    # Column preprocessing function
+    def preprocess_column_name(col_name: str) -> str:
+        """Preprocess column name: strip, minimal processing for Promo"""
+        col_name = col_name.strip()
+        return col_name
+    
+    # Parse file
+    file = files[0]
+    key = keys[0]
+    
+    try:
+        content = await file.read()
+        
+        # Parse file based on extension
+        if file.filename.lower().endswith(".csv"):
+            df = pd.read_csv(io.BytesIO(content))
+        elif file.filename.lower().endswith(".xlsx"):
+            df = pd.read_excel(io.BytesIO(content))
+        else:
+            raise HTTPException(status_code=400, detail="Only CSV and XLSX files supported")
+        
+        # Light preprocessing (Promo validation handles column standardization)
+        df.columns = [preprocess_column_name(col) for col in df.columns]
+        
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Error parsing file {file.filename}: {str(e)}")
+    
+    # Validate that dataset is not empty
+    if df.empty:
+        raise HTTPException(status_code=400, detail="Dataset is empty")
+    
+    try:
+        # Call Promo validation
+        validation_report = validate_promo_intensity(df)
+        
+        # ✅ NEW: Auto-generate validator_atom_id for Promo
+        from datetime import datetime
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        validator_atom_id = f"promo_template_{timestamp}"
+        
+        # ✅ NEW: MinIO upload if validation passes
+        minio_uploads = []
+        mongo_log_result = {"status": "skipped", "reason": "validation_failed"}
+        
+        if validation_report.status == "success":
+            upload_result = upload_to_minio(content, file.filename, validator_atom_id, key)
+            minio_uploads.append({
+                "file_key": key,
+                "filename": file.filename,
+                "minio_upload": upload_result
+            })
+            
+            
+            # ✅ ADD THIS: Save validator atom schema to MongoDB for classification
+            # ✅ CORRECT: Use the actual key from file_keys
+            validator_atom_schema = {
+                "_id": validator_atom_id,
+                "validator_atom_id": validator_atom_id,
+                "template_type": "promo_template",
+                "schemas": {
+                    key: {  # ✅ Use the actual key variable (which should be "promo")
+                        "columns": [{"column": col} for col in df.columns],
+                        "column_types": {
+                            col: "numeric" if pd.api.types.is_numeric_dtype(df[col]) 
+                                else "datetime" if pd.api.types.is_datetime64_any_dtype(df[col])
+                                else "string"
+                            for col in df.columns
+                        },
+                        "template_type": "promo_template"
+                    }
+                },
+                "created_at": datetime.now().isoformat(),
+                "template_generated": True
+            }
+            
+            validator_atom_result = save_validator_atom_to_mongo(validator_atom_id, validator_atom_schema)
+            
+            
+            # ✅ NEW: Save validation log to MongoDB
+            validation_log_data = {
+                "validator_atom_id": validator_atom_id,
+                "validation_type": "promo_template",
+                "files_validated": [{
+                    "file_key": key,
+                    "filename": file.filename,
+                    "file_size_bytes": len(content),
+                    "overall_status": "passed",
+                    "records_count": len(df),
+                    "columns_found": list(df.columns),
+                    "validation_duration_ms": 0
+                }],
+                "overall_status": "passed",
+                "total_files": 1,
+                "minio_uploads": minio_uploads,
+                "timestamp": datetime.now().isoformat(),
+                "summary_stats": {
+                    "total_records": len(df),
+                    "total_columns": len(df.columns),
+                    "validation_checks": len(validation_report.results)
+                }
+            }
+            mongo_log_result = save_validation_log_to_mongo(validation_log_data)
+        
+        # Build response
+        return {
+            "overall_status": "passed" if validation_report.status == "success" else "failed",
+            "validation_type": "promo_template",
+            "validator_atom_id": validator_atom_id,  # ✅ NEW
+            "file_validation_results": {
+                key: {
+                    "status": "passed" if not validation_report.has_failures() else "failed",
+                    "errors": validation_report.get_failures(),
+                    "warnings": validation_report.get_warnings(),
+                    "successes": validation_report.get_successes(),
+                    "columns_checked": len(df.columns),
+                    "records_count": len(df),
+                    "columns_found": list(df.columns)
+                }
+            },
+            "summary": {
+                "total_files": 1,
+                "records_processed": len(df),
+                "columns_processed": len(df.columns),
+                "validation_checks_performed": len(validation_report.results)
+            },
+            "promo_specific_results": {
+                "required_columns_validated": len([r for r in validation_report.results if "required" in r["check"]]),
+                "time_granularity_detected": any("granularity" in r["check"] for r in validation_report.results),
+                "promotion_indicators_found": len([r for r in validation_report.results if "promotion_indicator" in r["check"] and r["status"] == "passed"]),
+                "price_columns_validated": len([r for r in validation_report.results if "price" in r["check"] or "Price" in r["check"]]),
+                "aggregator_columns_found": len([r for r in validation_report.results if "aggregator" in r["check"] and r["status"] == "passed"])
+            },
+            "minio_uploads": minio_uploads,  # ✅ NEW
+            "validation_log_saved": mongo_log_result.get("status") == "success",  # ✅ NEW
+            "validation_log_id": mongo_log_result.get("mongo_id", ""),  # ✅ NEW
+            "files_processed": {
+                key: {
+                    "filename": file.filename,
+                    "size_bytes": len(content)
+                }
+            },
+            "template_integration": {
+                "validator_atom_saved": validator_atom_result.get("status") == "success" if validation_report.status == "success" else False,
+                "classify_columns_ready": True if validation_report.status == "success" else False,
+                "available_file_keys": [key] if validation_report.status == "success" else [],  # ✅ Use actual key
+                "next_steps": {
+                    "classification": f"POST /classify_columns with validator_atom_id: {validator_atom_id}",
+                    "dimensions": f"POST /define_dimensions with validator_atom_id: {validator_atom_id}"
+                } if validation_report.status == "success" else {}
+            }
+
+        }
+
+        
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Promo validation failed: {str(e)}")
+
+
+# Call this function when the module loads
+load_existing_configs()

--- a/TrinityBackendFastAPI/app/features/data_upload_validate/Validate_Atom/app/schemas.py
+++ b/TrinityBackendFastAPI/app/features/data_upload_validate/Validate_Atom/app/schemas.py
@@ -1,0 +1,183 @@
+# Pydantic Models
+from pydantic import BaseModel, Field
+from typing import Dict, List, Any, Optional
+
+
+# ✅ ADD THESE - New enhanced validation schemas
+class ConditionFailure(BaseModel):
+    column: str = Field(..., description="Column name")
+    operator: str = Field(..., description="Validation operator")
+    expected_value: Any = Field(..., description="Expected value")
+    error_message: str = Field(..., description="Custom error message")
+    severity: str = Field(..., description="Severity level")
+    failed_rows: List[int] = Field(..., description="List of failed row indices")
+    failed_count: int = Field(..., description="Number of rows that failed")
+    failed_percentage: float = Field(..., description="Percentage of rows that failed")
+
+# Your existing classes below...
+class FileValidationResult(BaseModel):
+    status: str = Field(..., description="File validation status")
+    errors: List[str] = Field(default_factory=list, description="Validation errors")
+    warnings: List[str] = Field(default_factory=list, description="Validation warnings")
+    auto_corrections: List[str] = Field(default_factory=list, description="Auto-corrections applied")
+    condition_failures: List[ConditionFailure] = Field(default_factory=list, description="Custom condition failures")  
+    columns_checked: int = Field(..., description="Number of columns checked")
+    mandatory_columns_missing: int = Field(..., description="Number of missing mandatory columns")
+    extra_columns_found: int = Field(..., description="Number of extra columns found")
+    data_corrections_applied: int = Field(..., description="Number of auto-corrections applied")
+    custom_conditions_failed: int = Field(..., description="Number of custom conditions that failed") 
+
+class ValidationSummary(BaseModel):
+    total_files: int = Field(..., description="Total files validated")
+    passed_files: int = Field(..., description="Number of files that passed")
+    failed_files: int = Field(..., description="Number of files that failed")
+    files_with_warnings: int = Field(..., description="Number of files with warnings")
+    total_auto_corrections: int = Field(..., description="Total auto-corrections across all files")
+    total_condition_failures: int = Field(..., description="Total custom condition failures")  # ✅ ADD THIS
+
+
+class MinIOUploadResult(BaseModel):
+    file_key: str = Field(..., description="File key")
+    filename: str = Field(..., description="Original filename")
+    minio_upload: Dict[str, Any] = Field(..., description="MinIO upload result")
+
+class ValidateResponse(BaseModel):
+    overall_status: str = Field(..., description="Overall validation status")
+    validator_atom_id: str = Field(..., description="Validator atom ID")
+    file_validation_results: Dict[str, FileValidationResult] = Field(..., description="Per-file validation results")
+    summary: ValidationSummary = Field(..., description="Validation summary")
+    minio_uploads: List[MinIOUploadResult] = Field(default_factory=list, description="MinIO upload results")
+    validation_log_saved: bool = Field(..., description="Whether validation log was saved to MongoDB")
+    validation_log_id: str = Field(..., description="MongoDB validation log document ID")
+    total_auto_corrections: int = Field(..., description="Total corrections applied across all files")
+    total_condition_failures: int = Field(..., description="Total custom condition failures")  # ✅ ADD THIS
+
+
+
+# Add to your schemas.py
+class CreateValidatorResponse(BaseModel):
+    status: str = Field(..., description="Operation status") 
+    message: str = Field(..., description="Success or error message")
+    validator_atom_id: str = Field(..., description="Validator atom identifier")
+    config_saved: bool = Field(..., description="Configuration saved successfully")
+
+
+##############for classifying the columns -
+
+# Add to app/schemas.py
+
+class Classification(BaseModel):
+    identifiers: List[str] = Field(default_factory=list, description="Identifier columns")
+    measures: List[str] = Field(default_factory=list, description="Measure columns") 
+    unclassified: List[str] = Field(default_factory=list, description="Unclassified columns")
+
+class AutoClassification(Classification):
+    confidence_scores: Dict[str, float] = Field(default_factory=dict, description="Confidence scores for auto-classification")
+
+class ClassificationSummary(BaseModel):
+    total_columns: int = Field(..., description="Total number of columns")
+    user_specified: int = Field(..., description="Number of user-specified columns")
+    auto_classified: int = Field(..., description="Number of auto-classified columns")
+
+class ClassifyColumnsResponse(BaseModel):
+    status: str = Field(..., description="Operation status")
+    message: str = Field(..., description="Success message")
+    validator_atom_id: str = Field(..., description="Validator atom ID")
+    file_key: str = Field(..., description="File key")
+    auto_classification: AutoClassification = Field(..., description="Auto-classification results")
+    user_classification: Classification = Field(..., description="User-provided classification")
+    final_classification: Classification = Field(..., description="Final merged classification")
+    user_modified: bool = Field(..., description="Whether user modified the classification")
+    summary: ClassificationSummary = Field(..., description="Classification summary")
+
+
+class MongoDBUpdateStatus(BaseModel):
+    status: str = Field(..., description="MongoDB update status (success/error)")
+    modified: bool = Field(..., description="Whether any documents were actually modified")
+    details: str = Field(..., description="Additional details about the update")
+
+class UpdateColumnTypesResponse(BaseModel):
+    status: str = Field(..., description="Operation status")
+    message: str = Field(..., description="Success message")
+    validator_atom_id: str = Field(..., description="Validator atom ID")
+    file_key: str = Field(..., description="File key")
+    updated_column_types: Dict[str, str] = Field(..., description="Column types that were updated")
+    current_all_column_types: Dict[str, str] = Field(..., description="All column types after update")
+    updated_columns_count: int = Field(..., description="Number of columns updated")
+    mongodb_update: MongoDBUpdateStatus = Field(..., description="MongoDB update status")  # ✅ ADD THIS
+
+
+class BusinessDimensionItem(BaseModel):
+    id: str = Field(..., description="Dimension ID")
+    name: str = Field(..., description="Dimension name")
+    description: Optional[str] = Field(None, description="Dimension description")
+
+class DefineDimensionsResponse(BaseModel):
+    status: str = Field(..., description="Operation status")
+    message: str = Field(..., description="Success message")
+    validator_atom_id: str = Field(..., description="Validator atom ID")
+    file_key: str = Field(..., description="File key")
+    dimensions: Dict[str, BusinessDimensionItem] = Field(..., description="Defined dimensions")
+    dimensions_count: int = Field(..., description="Number of dimensions defined")
+    max_allowed: int = Field(..., description="Maximum dimensions allowed")
+    mongodb_saved: bool = Field(..., description="Whether saved to MongoDB successfully")
+
+
+
+
+
+##################for config
+
+# Add these schemas to app/schemas.py
+
+class ValidationCondition(BaseModel):
+    operator: str = Field(..., description="Validation operator (greater_than, contains, etc.)")
+    value: Any = Field(..., description="Value to compare against")
+    error_message: str = Field(..., description="Custom error message")
+    severity: str = Field(default="error", description="Severity level (error, warning)")
+
+# ✅ UPDATE: ConfigureValidationConfigResponse in app/schemas.py
+class ConfigureValidationConfigResponse(BaseModel):
+    status: str = Field(..., description="Operation status")
+    message: str = Field(..., description="Success message")
+    validator_atom_id: str = Field(..., description="Validator atom ID")
+    file_key: str = Field(..., description="File key")
+    mongo_id: str = Field(..., description="MongoDB document ID")
+    operation: str = Field(..., description="MongoDB operation (inserted/updated)")
+    total_conditions: int = Field(..., description="Total number of conditions configured")
+    columns_configured: List[str] = Field(..., description="Columns that have conditions")
+    columns_with_frequencies: List[str] = Field(default_factory=list, description="Columns that have frequency validation")  # ✅ ADD THIS
+    mongodb_saved: bool = Field(..., description="Whether saved to MongoDB successfully")
+
+
+
+
+
+###################
+
+
+
+
+
+
+
+
+
+
+
+
+class AssignmentSummary(BaseModel):
+    total_identifiers: int = Field(..., description="Total available identifiers")
+    assigned_identifiers: int = Field(..., description="Number of assigned identifiers")
+    unassigned_identifiers: int = Field(..., description="Number of unassigned identifiers")
+
+class AssignIdentifiersResponse(BaseModel):
+    status: str = Field(..., description="Operation status")
+    message: str = Field(..., description="Success message")
+    validator_atom_id: str = Field(..., description="Validator atom ID")
+    file_key: str = Field(..., description="File key")
+    updated_business_dimensions: Dict[str, Any] = Field(..., description="Updated business dimensions with assignments")
+    assignment_summary: AssignmentSummary = Field(..., description="Assignment summary statistics")
+    unassigned_identifiers: List[str] = Field(..., description="List of unassigned identifiers")
+    dimension_breakdown: Dict[str, int] = Field(..., description="Number of identifiers per dimension")
+    mongodb_updated: bool = Field(..., description="Whether MongoDB was successfully updated")

--- a/TrinityBackendFastAPI/app/features/data_upload_validate/Validate_Atom/app/validator_dispatcher.py
+++ b/TrinityBackendFastAPI/app/features/data_upload_validate/Validate_Atom/app/validator_dispatcher.py
@@ -1,0 +1,22 @@
+# Validator Dispatcher
+from .validators.base import BaseValidator
+from .validators.promo import PriceElasticityValidator
+from .validators.mmm import MMMValidator
+from typing import Dict, Any
+import pandas as pd
+
+class ValidatorDispatcher:
+    def __init__(self):
+        self.validators = {
+            "base": BaseValidator(),
+            "price_elasticity": PriceElasticityValidator(),
+            "mmm": MMMValidator(),
+        }
+    
+    def validate(self, validator_atom: str, df: pd.DataFrame, file_key: str) -> Dict[str, Any]:
+        if validator_atom.startswith("custom_"):
+            return self.validators["base"].validate(df, file_key, validator_atom)
+        else:
+            validator_name = validator_atom.split("_")[0]
+            validator = self.validators.get(validator_name, self.validators["base"])
+            return validator.validate(df, file_key, validator_atom)

--- a/TrinityBackendFastAPI/app/features/data_upload_validate/Validate_Atom/app/validators/base.py
+++ b/TrinityBackendFastAPI/app/features/data_upload_validate/Validate_Atom/app/validators/base.py
@@ -1,0 +1,44 @@
+# Base Validator
+import pandas as pd
+from typing import Dict, Any
+import json
+from pathlib import Path
+
+class BaseValidator:
+    def __init__(self):
+        self.config_dir = Path("custom_validations")
+    
+    def validate(self, df: pd.DataFrame, file_key: str, validator_atom: str) -> Dict[str, Any]:
+        """Simple validation: required columns + data types"""
+        issues = []
+        successes = []
+        
+        # For now, basic validation
+        required_columns = ["SalesValue", "Volume"]  # Default required columns
+        missing_columns = [col for col in required_columns if col not in df.columns]
+        
+        if missing_columns:
+            issues.append({
+                "severity": "critical",
+                "title": "Missing Required Columns",
+                "description": f"Missing: {', '.join(missing_columns)}",
+                "affected_items": missing_columns
+            })
+        else:
+            successes.append({
+                "title": "Required Columns Check",
+                "description": f"All required columns present"
+            })
+        
+        overall_status = "failed" if any(issue["severity"] == "critical" for issue in issues) else "passed"
+        
+        return {
+            "overall_status": overall_status,
+            "summary": {
+                "total_checks": 1,
+                "passed": len(successes),
+                "failed": len(issues)
+            },
+            "issues": issues,
+            "successes": successes
+        }

--- a/TrinityBackendFastAPI/app/features/data_upload_validate/Validate_Atom/app/validators/category_forecasting.py
+++ b/TrinityBackendFastAPI/app/features/data_upload_validate/Validate_Atom/app/validators/category_forecasting.py
@@ -1,0 +1,188 @@
+# app/validators/category_forecasting.py
+import pandas as pd
+from typing import Optional, List
+
+class ValidationReport:
+    """Simple validation report class for Category Forecasting validation"""
+    
+    def __init__(self):
+        self.results = []
+        self.status = "success"
+    
+    def pass_(self, check_name: str, message: str = ""):
+        """Record a passing validation"""
+        self.results.append({
+            "check": check_name,
+            "status": "passed",
+            "message": message,
+            "type": "success"
+        })
+    
+    def fail(self, check_name: str, message: str):
+        """Record a failing validation"""
+        self.results.append({
+            "check": check_name,
+            "status": "failed", 
+            "message": message,
+            "type": "error"
+        })
+        self.status = "failed"
+    
+    def warn(self, check_name: str, message: str):
+        """Record a warning"""
+        self.results.append({
+            "check": check_name,
+            "status": "warning",
+            "message": message,
+            "type": "warning"
+        })
+    
+    def has_failures(self, dataset_prefix: str = "") -> bool:
+        """Check if there are any failures"""
+        return any(r["status"] == "failed" for r in self.results)
+    
+    def get_failures(self) -> List[str]:
+        """Get all failure messages"""
+        return [f"{r['check']}: {r['message']}" for r in self.results if r["status"] == "failed"]
+    
+    def get_warnings(self) -> List[str]:
+        """Get all warning messages"""
+        return [f"{r['check']}: {r['message']}" for r in self.results if r["status"] == "warning"]
+    
+    def get_successes(self) -> List[str]:
+        """Get all success messages"""
+        return [f"{r['check']}: {r['message']}" for r in self.results if r["status"] == "passed"]
+
+def clean_and_standardize_columns(df: pd.DataFrame, rep: ValidationReport) -> None:
+    """Clean and standardize columns - strip, lowercase, spaces to underscores"""
+    # Step 1: Remove leading/trailing whitespace
+    renamed_cols = {c: c.strip() for c in df.columns if c != c.strip()}
+    if renamed_cols:
+        df.rename(columns=renamed_cols, inplace=True)
+        rep.pass_("cleanup", f"Cleaned whitespace from columns: {list(renamed_cols.keys())}")
+    
+    # Step 2: Convert to lowercase
+    lowercase_cols = {c: c.lower() for c in df.columns if c != c.lower()}
+    if lowercase_cols:
+        df.rename(columns=lowercase_cols, inplace=True)
+        rep.pass_("lowercase", f"Converted to lowercase: {list(lowercase_cols.keys())}")
+    
+    # Step 3: Replace spaces with underscores for consistency
+    standardized_cols = {}
+    for col in df.columns:
+        new_col = col.replace(' ', '_').replace('-', '_').replace('__', '_').strip('_')
+        if col != new_col:
+            standardized_cols[col] = new_col
+    
+    if standardized_cols:
+        df.rename(columns=standardized_cols, inplace=True)
+        rep.pass_("standardization", f"Standardized columns: {list(standardized_cols.keys())} → {list(standardized_cols.values())}")
+
+def find_column_variations(df: pd.DataFrame, target_column: str) -> str:
+    """Find column variations - checks for multiple formats"""
+    variations = [
+        target_column.lower(),  # lowercase
+        target_column.lower().replace('_', ''),  # no underscore
+        target_column.lower().replace('_', ' '),  # with space
+        target_column.lower().replace('_', '-'),  # with hyphen
+    ]
+    
+    for variation in variations:
+        if variation in df.columns:
+            return variation
+    
+    return None
+
+def check_missing(df: pd.DataFrame, rep: ValidationReport) -> None:
+    """Simple missing values check - informational only"""
+    total_missing = df.isnull().sum().sum()
+    if total_missing == 0:
+        rep.pass_("missing_values", "No missing values found")
+    else:
+        rep.warn("missing_values", f"Total missing values: {total_missing}")
+
+def validate_category_forecasting(
+    df: pd.DataFrame,
+    *,
+    date_col: str = "Date",
+    fiscal_start_month: int = 4,
+) -> ValidationReport:
+    """
+    Category Forecasting validation with proper column mapping
+    """
+    rep = ValidationReport()
+    
+    # 1. ✅ Clean and standardize column names (strip, lowercase, underscores)
+    clean_and_standardize_columns(df, rep)
+    
+    # 2. ✅ Date column validation with flexible matching
+    date_col_lower = date_col.lower()  # Convert target to lowercase
+    date_col_found = find_column_variations(df, date_col_lower)
+    
+    if not date_col_found:
+        rep.fail("date_column", f"'{date_col}' not found. Available columns: {list(df.columns)}")
+    else:
+        if date_col_found != date_col_lower:
+            # Rename to standard name
+            df.rename(columns={date_col_found: date_col_lower}, inplace=True)
+            rep.pass_("date_mapping", f"Mapped '{date_col_found}' to '{date_col_lower}'")
+        
+        working_date_col = date_col_lower
+        
+        if not pd.api.types.is_datetime64_any_dtype(df[working_date_col]):
+            try:
+                df[working_date_col] = pd.to_datetime(df[working_date_col], errors="coerce")
+                if df[working_date_col].isna().all():
+                    rep.fail("date_column", "all values NaT after conversion")
+                else:
+                    rep.pass_("date_column", "valid datetime")
+            except Exception as e:
+                rep.fail("date_column", f"error converting: {str(e)}")
+        else:
+            rep.pass_("date_column", "valid datetime")
+        
+        # Simple duplicate check (warning only)
+        if working_date_col in df.columns and pd.api.types.is_datetime64_any_dtype(df[working_date_col]):
+            dup = df[working_date_col].duplicated().sum()
+            if dup:
+                rep.warn("duplicate_dates", f"{dup} duplicates")
+            else:
+                rep.pass_("duplicate_dates", "No duplicate dates")
+            
+            # Simple date range info
+            if not df[working_date_col].isna().all():
+                min_date = df[working_date_col].min().date()
+                max_date = df[working_date_col].max().date()
+                rep.pass_("date_range", f"from {min_date} to {max_date}")
+    
+    # 3. ✅ Business key check with flexible matching (all lowercase)
+    business_keys = ["market", "channel", "region", "category", "subcategory", "brand", "ppg", "variant", "packtype", "packsize"]
+    found = []
+    
+    for required in business_keys:
+        found_col = find_column_variations(df, required)
+        if found_col:
+            found.append(found_col)
+    
+    if found:
+        rep.pass_("dimension_check", f"found {', '.join(found)}")
+    else:
+        rep.fail("dimension_check", f"need at least one of {', '.join(business_keys)}")
+    
+    # 4. ✅ Fiscal year check with flexible matching
+    fiscal_col_found = find_column_variations(df, "fiscal_year")
+    if fiscal_col_found:
+        rep.pass_("fiscal_year", "Fiscal Year column found")
+    else:
+        rep.warn("fiscal_year", f"will compute at runtime (start month={fiscal_start_month})")
+    
+    # 5. Simple missing values summary (informational only)
+    check_missing(df, rep)
+    
+    # 6. Empty data check
+    if df.empty:
+        rep.fail("data_empty", "Data is empty after validations")
+    else:
+        rep.pass_("records_count", f"{len(df)} records")
+    
+    return rep

--- a/TrinityBackendFastAPI/app/features/data_upload_validate/Validate_Atom/app/validators/custom_validator.py
+++ b/TrinityBackendFastAPI/app/features/data_upload_validate/Validate_Atom/app/validators/custom_validator.py
@@ -1,0 +1,354 @@
+# app/validation_utils.py - Enhanced validation function
+
+import pandas as pd
+import re
+from typing import List, Dict, Any
+from app.features.data_upload_validate.Validate_Atom.app.database import get_validation_config_from_mongo
+
+
+def perform_enhanced_validation(files_data: List[tuple], validator_data: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Enhanced validation: Check mandatory columns, auto-correct types, and provide detailed messages
+    """
+    file_results = {}
+    overall_errors = []
+    overall_warnings = []
+    
+    for file_key, df in files_data:
+        file_errors = []
+        file_warnings = []
+        auto_corrections = []
+        condition_failures = []  # ✅ ADD: Initialize condition_failures
+        
+        # Get expected schema
+        expected_schema = validator_data.get("schemas", {}).get(file_key, {})
+        if not expected_schema:
+            file_errors.append(f"No schema found for file key '{file_key}'")
+            file_results[file_key] = {
+                "status": "failed",
+                "errors": file_errors,
+                "warnings": file_warnings,
+                "auto_corrections": auto_corrections,
+                "condition_failures": condition_failures  # ✅ ADD
+            }
+            continue
+        
+        expected_columns = [col["column"] for col in expected_schema.get("columns", [])]
+        expected_types = expected_schema.get("column_types", {})
+        
+        # ✅ CHECK 1: Mandatory columns
+        uploaded_columns = list(df.columns)
+        missing_columns = [col for col in expected_columns if col not in uploaded_columns]
+        extra_columns = [col for col in uploaded_columns if col not in expected_columns]
+        
+        if missing_columns:
+            file_errors.append(f"Missing mandatory columns: {missing_columns}")
+        
+        if extra_columns:
+            file_warnings.append(f"Extra columns found (allowed): {extra_columns}")
+        
+        # ✅ CHECK 2: Auto-correct column types
+        for col in uploaded_columns:
+            if col in expected_types:
+                expected_type = expected_types[col]
+                
+                try:
+                    if expected_type == "numeric":
+                        original_dtype = str(df[col].dtype)
+                        if not ("int" in original_dtype or "float" in original_dtype):
+                            df[col] = pd.to_numeric(df[col], errors='coerce')
+                            if df[col].isna().any():
+                                failed_rows = df[df[col].isna()].index.tolist()[:5]
+                                file_errors.append(f"Column '{col}' contains non-numeric data that cannot be converted (rows: {failed_rows})")
+                            else:
+                                auto_corrections.append(f"Column '{col}' converted from {original_dtype} to numeric")
+                    
+                    elif expected_type == "integer":
+                        original_dtype = str(df[col].dtype)
+                        if "int" not in original_dtype:
+                            numeric_col = pd.to_numeric(df[col], errors='coerce')
+                            if numeric_col.isna().any():
+                                failed_rows = df[numeric_col.isna()].index.tolist()[:5]
+                                file_errors.append(f"Column '{col}' contains non-integer data that cannot be converted (rows: {failed_rows})")
+                            else:
+                                df[col] = numeric_col.astype(int)
+                                auto_corrections.append(f"Column '{col}' converted from {original_dtype} to integer")
+                    
+                    elif expected_type == "string":
+                        original_dtype = str(df[col].dtype)
+                        if "object" not in original_dtype:
+                            df[col] = df[col].astype(str)
+                            auto_corrections.append(f"Column '{col}' converted from {original_dtype} to string")
+                    
+                    elif expected_type == "date":
+                        original_dtype = str(df[col].dtype)
+                        if "datetime" not in original_dtype:
+                            df[col] = pd.to_datetime(df[col], errors='coerce')
+                            if df[col].isna().any():
+                                failed_rows = df[df[col].isna()].index.tolist()[:5]
+                                file_errors.append(f"Column '{col}' contains invalid date formats that cannot be converted (rows: {failed_rows})")
+                            else:
+                                auto_corrections.append(f"Column '{col}' converted from {original_dtype} to datetime")
+                
+                except Exception as e:
+                    file_errors.append(f"Failed to convert column '{col}' to {expected_type}: {str(e)}")
+        
+        # ✅ MOVE OUTSIDE LOOP: CUSTOM CONDITIONS VALIDATION
+        validator_atom_id = validator_data.get("validator_atom_id", "unknown")
+        validation_config = get_validation_config_from_mongo(validator_atom_id, file_key)
+        
+        if validation_config:
+            column_conditions = validation_config.get('column_conditions', {})
+            print(f"🔍 Found validation config with {len(column_conditions)} column conditions")
+            
+            for col, conditions in column_conditions.items():
+                if col in df.columns:
+                    for condition in conditions:
+                        operator = condition['operator']
+                        value = condition['value']
+                        error_message = condition['error_message']
+                        severity = condition.get('severity', 'error')
+                        
+                        # Apply condition and get failed rows
+                        failed_rows = apply_validation_condition(df[col], operator, value, col)
+                        
+                        if failed_rows:
+                            condition_failure = {
+                                "column": col,
+                                "operator": operator,
+                                "expected_value": value,
+                                "error_message": error_message,
+                                "severity": severity,
+                                "failed_rows": failed_rows[:10],
+                                "failed_count": len(failed_rows),
+                                "failed_percentage": round((len(failed_rows) / len(df)) * 100, 2)
+                            }
+                            
+                            condition_failures.append(condition_failure)
+                            
+                            # Add to errors or warnings based on severity
+                            if severity == "error":
+                                file_errors.append(f"Column '{col}': {error_message} ({len(failed_rows)} rows failed)")
+                            else:
+                                file_warnings.append(f"Column '{col}': {error_message} ({len(failed_rows)} rows failed)")
+            
+            # ✅ FIX: Move this INSIDE the if validation_config block (same indentation as the custom conditions loop above)
+            column_frequencies = validation_config.get('column_frequencies', {})
+            if column_frequencies:
+                print(f"📅 Applying frequency validation to {len(column_frequencies)} columns")
+                for col, frequency in column_frequencies.items():
+                    if col in df.columns:
+                        date_frequency_issues = validate_date_frequency_for_column(df[col], frequency, col)
+                        
+                        if date_frequency_issues:
+                            condition_failures.extend(date_frequency_issues)
+                            for issue in date_frequency_issues:
+                                if issue["severity"] == "error":
+                                    file_errors.append(f"Date frequency issue: {issue['error_message']}")
+                                else:
+                                    file_warnings.append(f"Date frequency warning: {issue['error_message']}")
+
+
+        
+        # ✅ CHECK 3: Additional data quality checks
+        data_quality_warnings = []
+        for col in uploaded_columns:
+            if col in expected_columns:
+                null_count = df[col].isna().sum()
+                if null_count > 0:
+                    data_quality_warnings.append(f"Column '{col}' has {null_count} null/empty values")
+                
+                if any(id_keyword in col.lower() for id_keyword in ['id', 'code', 'key']):
+                    duplicate_count = df[col].duplicated().sum()
+                    if duplicate_count > 0:
+                        data_quality_warnings.append(f"Column '{col}' has {duplicate_count} duplicate values")
+        
+        file_warnings.extend(data_quality_warnings)
+        
+        # ✅ UPDATED: Determine file status (include condition failures)
+        if file_errors:
+            status = "failed"
+        elif file_warnings or auto_corrections or condition_failures:
+            status = "passed_with_warnings"
+        else:
+            status = "passed"
+        
+        file_results[file_key] = {
+            "status": status,
+            "errors": file_errors,
+            "warnings": file_warnings,
+            "auto_corrections": auto_corrections,
+            "condition_failures": condition_failures,  # ✅ ADD
+            "columns_checked": len(uploaded_columns),
+            "mandatory_columns_missing": len(missing_columns),
+            "extra_columns_found": len(extra_columns),
+            "data_corrections_applied": len(auto_corrections),
+            "custom_conditions_failed": len(condition_failures)  # ✅ ADD
+        }
+        
+        overall_errors.extend(file_errors)
+        overall_warnings.extend(file_warnings)
+    
+    # Overall status
+    if overall_errors:
+        overall_status = "failed"
+    elif overall_warnings:
+        overall_status = "passed_with_warnings"
+    else:
+        overall_status = "passed"
+    
+    return {
+        "overall_status": overall_status,
+        "file_results": file_results,
+        "summary": {
+            "total_files": len(files_data),
+            "passed_files": len([r for r in file_results.values() if r["status"] == "passed"]),
+            "failed_files": len([r for r in file_results.values() if r["status"] == "failed"]),
+            "files_with_warnings": len([r for r in file_results.values() if r["status"] == "passed_with_warnings"]),
+            "total_auto_corrections": sum(len(r.get("auto_corrections", [])) for r in file_results.values()),
+            "total_condition_failures": sum(len(r.get("condition_failures", [])) for r in file_results.values())  # ✅ ADD
+        }
+    }
+
+# ✅ ADD: Missing helper function
+def apply_validation_condition(column_data, operator, value, col_name):
+    """Apply a single validation condition and return list of failed row indices"""
+    failed_rows = []
+    
+    try:
+        if operator == "greater_than":
+            failed_mask = ~(column_data > value)
+        elif operator == "greater_than_or_equal":
+            failed_mask = ~(column_data >= value)
+        elif operator == "less_than":
+            failed_mask = ~(column_data < value)
+        elif operator == "less_than_or_equal":
+            failed_mask = ~(column_data <= value)
+        elif operator == "equal_to":
+            failed_mask = ~(column_data == value)
+        elif operator == "not_equal_to":
+            failed_mask = ~(column_data != value)
+        elif operator == "between":
+            if isinstance(value, list) and len(value) == 2:
+                failed_mask = ~((column_data >= value[0]) & (column_data <= value[1]))
+            else:
+                return []
+        elif operator == "contains":
+            failed_mask = ~column_data.astype(str).str.contains(str(value), na=False)
+        elif operator == "starts_with":
+            failed_mask = ~column_data.astype(str).str.startswith(str(value), na=False)
+        else:
+            return []
+        
+        failed_rows = column_data[failed_mask].index.tolist()
+        
+    except Exception as e:
+        print(f"Error applying condition {operator} to column {col_name}: {str(e)}")
+        return []
+    
+    return failed_rows
+
+
+# ✅ ADD: This function to your existing validation_utils.py file
+def validate_date_frequency_for_column(df_column, frequency, col_name):
+    """
+    Validate date frequency patterns for a specific column
+    """
+    frequency_issues = []
+    
+    try:
+        # Convert to datetime
+        dates = pd.to_datetime(df_column, errors='coerce')
+        dates = dates.dropna().sort_values()
+        
+        if len(dates) < 2:
+            return frequency_issues
+            
+        # Calculate differences between consecutive dates
+        date_diffs = dates.diff().dropna()
+        
+        # Set expected difference and tolerance based on frequency
+        if frequency.lower() == "daily":
+            expected_diff = pd.Timedelta(days=1)
+            tolerance = pd.Timedelta(hours=12)
+        elif frequency.lower() == "weekly":
+            expected_diff = pd.Timedelta(weeks=1)
+            tolerance = pd.Timedelta(days=1)
+        elif frequency.lower() == "monthly":
+            expected_diff = pd.Timedelta(days=30)  # Approximate
+            tolerance = pd.Timedelta(days=5)
+        else:
+            return frequency_issues
+        
+        # Check for irregular intervals and missing dates
+        irregular_intervals = []
+        missing_dates = []
+        
+        for i, diff in enumerate(date_diffs):
+            if abs(diff - expected_diff) > tolerance:
+                irregular_intervals.append({
+                    "index": i,
+                    "expected": str(expected_diff),
+                    "actual": str(diff),
+                    "date": str(dates.iloc[i])
+                })
+            
+            # Check for missing dates (gaps larger than expected)
+            if diff > expected_diff + tolerance:
+                gap_days = diff.days
+                expected_days = expected_diff.days
+                missing_count = (gap_days // expected_days) - 1
+                if missing_count > 0:
+                    missing_dates.append({
+                        "start_date": str(dates.iloc[i-1]),
+                        "end_date": str(dates.iloc[i]),
+                        "missing_count": missing_count
+                    })
+        
+        # Create frequency validation issues
+        if irregular_intervals:
+            frequency_issues.append({
+                "column": col_name,
+                "operator": "date_frequency",
+                "expected_value": frequency,
+                "error_message": f"Irregular {frequency} intervals found in {col_name} ({len(irregular_intervals)} occurrences)",
+                "severity": "warning",
+                "failed_rows": [item["index"] for item in irregular_intervals[:10]],
+                "failed_count": len(irregular_intervals),
+                "failed_percentage": round((len(irregular_intervals) / len(dates)) * 100, 2),
+                "details": {
+                    "type": "irregular_intervals",
+                    "irregular_intervals": irregular_intervals[:5]
+                }
+            })
+        
+        if missing_dates:
+            total_missing = sum(item["missing_count"] for item in missing_dates)
+            frequency_issues.append({
+                "column": col_name,
+                "operator": "date_frequency",
+                "expected_value": frequency,
+                "error_message": f"Missing {frequency} dates in {col_name} ({total_missing} missing dates)",
+                "severity": "error",
+                "failed_rows": [],
+                "failed_count": total_missing,
+                "failed_percentage": round((total_missing / (len(dates) + total_missing)) * 100, 2),
+                "details": {
+                    "type": "missing_dates",
+                    "missing_periods": missing_dates[:5]
+                }
+            })
+    
+    except Exception as e:
+        frequency_issues.append({
+            "column": col_name,
+            "operator": "date_frequency",
+            "expected_value": frequency,
+            "error_message": f"Error validating date frequency in {col_name}: {str(e)}",
+            "severity": "warning",
+            "failed_rows": [],
+            "failed_count": 0,
+            "failed_percentage": 0
+        })
+    
+    return frequency_issues

--- a/TrinityBackendFastAPI/app/features/data_upload_validate/Validate_Atom/app/validators/mmm.py
+++ b/TrinityBackendFastAPI/app/features/data_upload_validate/Validate_Atom/app/validators/mmm.py
@@ -1,0 +1,441 @@
+# app/validators/mmm.py
+import pandas as pd
+from typing import Dict, Any, List, Set, Tuple
+
+class ValidationReport:
+    """Simple validation report class for MMM validation"""
+    
+    def __init__(self):
+        self.results = []
+        self.status = "success"
+    
+    def pass_(self, check_name: str, message: str = ""):
+        """Record a passing validation"""
+        self.results.append({
+            "check": check_name,
+            "status": "passed",
+            "message": message,
+            "type": "success"
+        })
+    
+    def fail(self, check_name: str, message: str):
+        """Record a failing validation"""
+        self.results.append({
+            "check": check_name,
+            "status": "failed", 
+            "message": message,
+            "type": "error"
+        })
+        self.status = "failed"
+    
+    def warn(self, check_name: str, message: str):
+        """Record a warning"""
+        self.results.append({
+            "check": check_name,
+            "status": "warning",
+            "message": message,
+            "type": "warning"
+        })
+    
+    def has_failures(self, dataset_prefix: str = "") -> bool:
+        """Check if there are any failures for a specific dataset"""
+        if dataset_prefix:
+            return any(r["status"] == "failed" and r["check"].startswith(dataset_prefix) for r in self.results)
+        return any(r["status"] == "failed" for r in self.results)
+    
+    def get_failures(self, dataset_prefix: str = "") -> List[str]:
+        """Get all failure messages for a specific dataset"""
+        failures = []
+        for r in self.results:
+            if r["status"] == "failed":
+                if not dataset_prefix or r["check"].startswith(dataset_prefix):
+                    failures.append(f"{r['check']}: {r['message']}")
+        return failures
+    
+    def get_warnings(self, dataset_prefix: str = "") -> List[str]:
+        """Get all warning messages for a specific dataset"""
+        warnings = []
+        for r in self.results:
+            if r["status"] == "warning":
+                if not dataset_prefix or r["check"].startswith(dataset_prefix):
+                    warnings.append(f"{r['check']}: {r['message']}")
+        return warnings
+    
+    def get_successes(self, dataset_prefix: str = "") -> List[str]:
+        """Get all success messages for a specific dataset"""
+        successes = []
+        for r in self.results:
+            if r["status"] == "passed":
+                if not dataset_prefix or r["check"].startswith(dataset_prefix):
+                    successes.append(f"{r['check']}: {r['message']}")
+        return successes
+    
+    def get_result(self, check_name: str) -> str:
+        """Get the status of a specific check"""
+        for r in self.results:
+            if r["check"] == check_name:
+                return r["status"]
+        return "not_found"
+
+# Configuration constants for MMM validation
+_MMM_MEDIA = {
+    "required": ["market", "channel", "region", "category", "subcategory", "brand",
+                 "variant", "pack_type", "ppg", "pack_size", "year", "month", "week",
+                 "media_category", "media_subcategory"],
+    "non_null": ["market", "region", "category", "subcategory", "brand", "year",
+                 "month", "media_category", "media_subcategory"],
+    "dtypes": {"amount_spent": "float64", "year": "object"},
+    "business_columns": ["amount_spent", "impressions", "reach", "frequency"]
+}
+
+_MMM_SALES = {
+    "required": ["market", "channel", "region", "category", "subcategory", "brand",
+                 "variant", "pack_type", "ppg", "pack_size", "year", "month", "week",
+                 "d1", "price"],
+    "non_null": ["market", "region", "category", "subcategory", "brand", "year", "month"],
+    "dtypes": {"d1": "float64", "volume": "float64", "sales": "float64",
+               "price": "float64", "year": "object"},
+    "business_columns": ["sales", "volume", "d1", "price"]
+}
+
+def find_column_variations(df: pd.DataFrame, target_column: str) -> str:
+    """
+    Find column variations - checks for multiple formats of the same column
+    """
+    # Generate possible variations of the target column
+    variations = [
+        target_column,  # exact match: "pack_size"
+        target_column.replace('_', ''),  # no underscore: "packsize"
+        target_column.replace('_', ' '),  # with space: "pack size"
+        target_column.replace('_', '-'),  # with hyphen: "pack-size"
+    ]
+    
+    # Check if any variation exists in the dataframe columns
+    for variation in variations:
+        if variation in df.columns:
+            return variation
+    
+    return None
+
+def check_required_columns_flexible(df: pd.DataFrame, rep: ValidationReport, dataset_name: str, required_columns: List[str]) -> List[str]:
+    """
+    Check for required columns with flexible matching
+    """
+    missing_columns = []
+    found_columns = []
+    column_mappings = {}
+    
+    for required_col in required_columns:
+        found_col = find_column_variations(df, required_col)
+        if found_col:
+            found_columns.append(required_col)
+            if found_col != required_col:
+                column_mappings[found_col] = required_col
+                # Rename the column to the expected name for consistency
+                df.rename(columns={found_col: required_col}, inplace=True)
+        else:
+            missing_columns.append(required_col)
+    
+    # Report column mappings
+    if column_mappings:
+        rep.pass_(f"{dataset_name}_column_mapping", f"Mapped columns: {column_mappings}")
+    
+    return missing_columns
+
+def clean_columns(df: pd.DataFrame, rep: ValidationReport, dataset_name: str) -> None:
+    """Enhanced column cleaning with flexible preprocessing"""
+    original_columns = df.columns.tolist()
+    
+    # Step 1: Remove leading/trailing whitespace
+    renamed_cols = {c: c.strip() for c in df.columns if c != c.strip()}
+    if renamed_cols:
+        df.rename(columns=renamed_cols, inplace=True)
+        rep.pass_(f"{dataset_name}_cleanup", f"Cleaned whitespace from columns: {list(renamed_cols.keys())}")
+    
+    # Step 2: Convert to lowercase first
+    lowercase_cols = {c: c.lower() for c in df.columns if c != c.lower()}
+    if lowercase_cols:
+        df.rename(columns=lowercase_cols, inplace=True)
+        rep.pass_(f"{dataset_name}_lowercase", f"Converted to lowercase: {list(lowercase_cols.keys())}")
+    
+    # Step 3: Create both formats (with and without underscores) 
+    # This allows flexible matching later
+    standardized_cols = {}
+    for col in df.columns:
+        # Handle spaces -> underscores, but keep original format info
+        if ' ' in col or '-' in col:
+            new_col = col.replace(' ', '_').replace('-', '_').replace('__', '_').strip('_')
+            if col != new_col:
+                standardized_cols[col] = new_col
+    
+    if standardized_cols:
+        df.rename(columns=standardized_cols, inplace=True)
+        rep.pass_(f"{dataset_name}_standardization", f"Standardized columns: {list(standardized_cols.keys())} → {list(standardized_cols.values())}")
+
+def check_missing(df: pd.DataFrame, rep: ValidationReport, dataset_name: str, critical: List[str] = None) -> None:
+    """Check for missing values in critical columns"""
+    if critical is None:
+        critical = []
+    
+    total_missing = df.isnull().sum().sum()
+    if total_missing == 0:
+        rep.pass_(f"{dataset_name}_missing_values", "No missing values found")
+    else:
+        rep.warn(f"{dataset_name}_missing_values", f"Total missing values: {total_missing}")
+    
+    # Check critical columns specifically
+    for col in critical:
+        if col in df.columns:
+            missing_count = df[col].isnull().sum()
+            if missing_count > 0:
+                rep.fail(f"{dataset_name}_missing_{col}", f"Critical column '{col}' has {missing_count} missing values")
+            else:
+                rep.pass_(f"{dataset_name}_missing_{col}", f"No missing values in critical column '{col}'")
+        else:
+            rep.fail(f"{dataset_name}_missing_{col}", f"Critical column '{col}' not found in dataset")
+
+def check_dtypes(df: pd.DataFrame, rep: ValidationReport, dataset_name: str, expected_dtypes: Dict[str, str]) -> None:
+    """Check and attempt to convert data types"""
+    for col, expected_dtype in expected_dtypes.items():
+        if col in df.columns:
+            current_dtype = str(df[col].dtype)
+            
+            if expected_dtype == "float64":
+                if not pd.api.types.is_numeric_dtype(df[col]):
+                    try:
+                        # Try to convert to numeric
+                        df[col] = pd.to_numeric(df[col], errors='coerce')
+                        
+                        # Check if conversion introduced NaN values
+                        nan_count = df[col].isna().sum()
+                        if nan_count > 0:
+                            rep.warn(f"{dataset_name}_dtype_{col}", f"Converted '{col}' to numeric, {nan_count} values became NaN")
+                        else:
+                            rep.pass_(f"{dataset_name}_dtype_{col}", f"Successfully converted '{col}' to numeric")
+                    except Exception as e:
+                        rep.fail(f"{dataset_name}_dtype_{col}", f"Failed to convert '{col}' to numeric: {str(e)}")
+                else:
+                    rep.pass_(f"{dataset_name}_dtype_{col}", f"Column '{col}' is already numeric")
+            
+            elif expected_dtype == "object":
+                if current_dtype != "object":
+                    try:
+                        df[col] = df[col].astype(str)
+                        rep.pass_(f"{dataset_name}_dtype_{col}", f"Converted '{col}' to string")
+                    except Exception as e:
+                        rep.fail(f"{dataset_name}_dtype_{col}", f"Failed to convert '{col}' to string: {str(e)}")
+                else:
+                    rep.pass_(f"{dataset_name}_dtype_{col}", f"Column '{col}' is already string")
+        else:
+            rep.warn(f"{dataset_name}_dtype_{col}", f"Expected column '{col}' not found for data type validation")
+
+def validate_business_logic(df: pd.DataFrame, rep: ValidationReport, dataset_name: str, business_columns: List[str]) -> None:
+    """Validate business-specific logic for MMM data"""
+    
+    # Check for negative values in business metrics
+    for col in business_columns:
+        if col in df.columns and pd.api.types.is_numeric_dtype(df[col]):
+            negative_count = (df[col] < 0).sum()
+            if negative_count > 0:
+                rep.warn(f"{dataset_name}_negative_{col}", f"Column '{col}' has {negative_count} negative values")
+            else:
+                rep.pass_(f"{dataset_name}_negative_{col}", f"No negative values in '{col}'")
+    
+    # Dataset-specific business logic
+    if dataset_name == "media":
+        # Check for zero values in spend columns
+        if "amount_spent" in df.columns:
+            zero_spend = (df["amount_spent"] == 0).sum()
+            if zero_spend > 0:
+                rep.warn(f"{dataset_name}_zero_spend", f"Media data has {zero_spend} rows with zero spend")
+            else:
+                rep.pass_(f"{dataset_name}_zero_spend", "No zero spend periods found")
+        
+        # Check for unrealistic spend values
+        if "amount_spent" in df.columns:
+            max_spend = df["amount_spent"].max()
+            if max_spend > 1000000:  # 1 million threshold
+                rep.warn(f"{dataset_name}_high_spend", f"Maximum spend value is very high: {max_spend:,.0f}")
+            else:
+                rep.pass_(f"{dataset_name}_spend_range", f"Spend values are within reasonable range (max: {max_spend:,.0f})")
+    
+    elif dataset_name == "sales":
+        # Check for zero values in sales columns
+        if "sales" in df.columns:
+            zero_sales = (df["sales"] == 0).sum()
+            if zero_sales > 0:
+                rep.warn(f"{dataset_name}_zero_sales", f"Sales data has {zero_sales} rows with zero sales")
+            else:
+                rep.pass_(f"{dataset_name}_zero_sales", "No zero sales periods found")
+        
+        # Check price consistency
+        if all(col in df.columns for col in ["sales", "volume", "price"]):
+            # Calculate implied price and compare with actual price
+            df['implied_price'] = df['sales'] / df['volume']
+            price_diff = abs(df['price'] - df['implied_price'])
+            inconsistent_prices = (price_diff > 0.01).sum()  # Allow 1 cent difference
+            
+            if inconsistent_prices > 0:
+                rep.warn(f"{dataset_name}_price_consistency", f"{inconsistent_prices} rows have inconsistent price calculations")
+            else:
+                rep.pass_(f"{dataset_name}_price_consistency", "Price calculations are consistent (Sales = Volume × Price)")
+
+def validate_time_periods(df: pd.DataFrame, rep: ValidationReport, dataset_name: str) -> Set[Tuple[str, int]]:
+    """Validate time period data and return set of periods"""
+    periods = set()
+    
+    if all(col in df.columns for col in ["year", "month"]):
+        try:
+            # Convert year to string and month to int for consistency
+            df["year"] = df["year"].astype(str)
+            df["month"] = pd.to_numeric(df["month"], errors='coerce').astype(int)
+            
+            # Create set of (year, month) tuples
+            periods = set(zip(df["year"], df["month"]))
+            
+            years = sorted(df["year"].unique())
+            months = sorted(df["month"].unique())
+            
+            rep.pass_(f"{dataset_name}_time_coverage", 
+                     f"Years: {years}, Months: {months}, Total periods: {len(periods)}")
+            
+            # Check for valid months (1-12)
+            invalid_months = df[(df["month"] < 1) | (df["month"] > 12)]["month"].unique()
+            if len(invalid_months) > 0:
+                rep.fail(f"{dataset_name}_invalid_months", f"Invalid month values: {invalid_months}")
+            else:
+                rep.pass_(f"{dataset_name}_valid_months", "All month values are valid (1-12)")
+            
+            # Check for time continuity
+            if len(periods) > 1:
+                period_list = sorted(list(periods))
+                gaps = []
+                for i in range(len(period_list) - 1):
+                    current_year, current_month = period_list[i]
+                    next_year, next_month = period_list[i + 1]
+                    
+                    # Calculate expected next period
+                    if current_month == 12:
+                        expected_year, expected_month = str(int(current_year) + 1), 1
+                    else:
+                        expected_year, expected_month = current_year, current_month + 1
+                    
+                    if (next_year, next_month) != (expected_year, expected_month):
+                        gaps.append(f"{current_year}-{current_month:02d} to {next_year}-{next_month:02d}")
+                
+                if gaps:
+                    rep.warn(f"{dataset_name}_time_gaps", f"Time gaps found: {gaps[:3]}...")  # Show first 3 gaps
+                else:
+                    rep.pass_(f"{dataset_name}_time_continuity", "No gaps in time series")
+            
+        except Exception as e:
+            rep.fail(f"{dataset_name}_time_periods", f"Error processing time periods: {str(e)}")
+    else:
+        rep.fail(f"{dataset_name}_time_columns", "Missing required time columns (year, month)")
+    
+    return periods
+
+def add_main_failure_summary(rep: ValidationReport) -> None:
+    """Add main failure summary at the start of results if there are failures"""
+    failures = [r for r in rep.results if r['status'] == 'failed']
+    
+    if failures:
+        # Extract main failure categories
+        main_reasons = []
+        
+        # Check for common failure patterns
+        media_failures = [f for f in failures if 'media_' in f['check']]
+        sales_failures = [f for f in failures if 'sales_' in f['check']]
+        alignment_failures = [f for f in failures if 'time_alignment' in f['check']]
+        
+        if media_failures:
+            main_reasons.append(f"Media dataset issues ({len(media_failures)} problems)")
+        if sales_failures:
+            main_reasons.append(f"Sales dataset issues ({len(sales_failures)} problems)")
+        if alignment_failures:
+            main_reasons.append("Time period alignment issues")
+        
+        # Add other critical failures
+        critical_failures = [f for f in failures if 'required_columns' in f['check'] or 'data_empty' in f['check']]
+        if critical_failures:
+            main_reasons.append(f"Critical data structure issues ({len(critical_failures)} problems)")
+        
+        # Create summary message
+        if main_reasons:
+            summary_message = "MMM Validation Failed - " + "; ".join(main_reasons)
+        else:
+            # Fallback to first 2 failure messages
+            summary_message = "MMM Validation Failed - " + "; ".join([f['message'] for f in failures[:2]])
+        
+        # Insert summary at the start
+        rep.results.insert(0, {
+            "check": "mmm_main_failure_summary",
+            "status": "failed",
+            "message": summary_message,
+            "type": "error"
+        })
+
+
+def validate_mmm(
+    media_df: pd.DataFrame,
+    sales_df: pd.DataFrame,
+    *,
+    media_rules: Dict[str, Any] = _MMM_MEDIA,
+    sales_rules: Dict[str, Any] = _MMM_SALES,
+) -> ValidationReport:
+    """
+    Simplified MMM validation - no cross data alignment checks
+    """
+    rep = ValidationReport()
+    rep.media_rules = media_rules
+    rep.sales_rules = sales_rules
+
+    def _validate_dataset_simple(df: pd.DataFrame, dataset_name: str, rules: Dict[str, Any]) -> None:
+        """Simplified dataset validation - individual dataset only"""
+        
+        # Clean column names (keep your preprocessing logic)
+        clean_columns(df, rep, dataset_name)
+        
+        # Check required columns with flexible matching
+        missing_columns = check_required_columns_flexible(df, rep, dataset_name, rules["required"])
+        
+        if not missing_columns:
+            rep.pass_(f"{dataset_name}_required_columns", f"All {len(rules['required'])} required columns found")
+        else:
+            rep.fail(f"{dataset_name}_required_columns", f"Missing columns: {missing_columns}")
+        
+        # Check missing values in critical columns only
+        check_missing(df, rep, dataset_name, critical=rules["non_null"])
+        
+        # Check data types only
+        check_dtypes(df, rep, dataset_name, rules["dtypes"])
+        
+        # Record count
+        if df.empty:
+            rep.fail(f"{dataset_name}_data_empty", "Dataset is empty")
+        else:
+            rep.pass_(f"{dataset_name}_records_count", f"{len(df)} records")
+
+    # Validate both datasets independently
+    rep.pass_("validation_start", "Starting MMM validation process")
+    _validate_dataset_simple(media_df, "media", media_rules)
+    _validate_dataset_simple(sales_df, "sales", sales_rules)
+    
+    # ❌ REMOVED: All cross data alignment validation
+    # ❌ REMOVED: Time period matching
+    # ❌ REMOVED: Dataset consistency checks
+    # ❌ REMOVED: Overlap validation
+    
+    # Simple summary
+    failed_checks = len([r for r in rep.results if r["status"] == "failed"])
+    warning_checks = len([r for r in rep.results if r["status"] == "warning"])
+    
+    if failed_checks == 0:
+        if warning_checks == 0:
+            rep.pass_("mmm_validation_summary", "Perfect! MMM validation passed - all requirements met")
+        else:
+            rep.warn("mmm_validation_summary", f"MMM validation completed with {warning_checks} warnings")
+    else:
+        rep.fail("mmm_validation_summary", f"MMM validation failed: {failed_checks} critical issues")
+    
+    return rep

--- a/TrinityBackendFastAPI/app/features/data_upload_validate/Validate_Atom/app/validators/promo.py
+++ b/TrinityBackendFastAPI/app/features/data_upload_validate/Validate_Atom/app/validators/promo.py
@@ -1,0 +1,377 @@
+# app/validators/promo.py
+import pandas as pd
+from typing import List, Optional
+
+class ValidationReport:
+    """Simple validation report class for Promo validation"""
+    
+    def __init__(self):
+        self.results = []
+        self.status = "success"
+    
+    def pass_(self, check_name: str, message: str = ""):
+        """Record a passing validation"""
+        self.results.append({
+            "check": check_name,
+            "status": "passed",
+            "message": message,
+            "type": "success"
+        })
+    
+    def fail(self, check_name: str, message: str):
+        """Record a failing validation"""
+        self.results.append({
+            "check": check_name,
+            "status": "failed", 
+            "message": message,
+            "type": "error"
+        })
+        self.status = "failed"
+    
+    def warn(self, check_name: str, message: str):
+        """Record a warning"""
+        self.results.append({
+            "check": check_name,
+            "status": "warning",
+            "message": message,
+            "type": "warning"
+        })
+    
+    def has_failures(self, dataset_prefix: str = "") -> bool:
+        """Check if there are any failures"""
+        return any(r["status"] == "failed" for r in self.results)
+    
+    def get_failures(self) -> List[str]:
+        """Get all failure messages"""
+        return [f"{r['check']}: {r['message']}" for r in self.results if r["status"] == "failed"]
+    
+    def get_warnings(self) -> List[str]:
+        """Get all warning messages"""
+        return [f"{r['check']}: {r['message']}" for r in self.results if r["status"] == "warning"]
+    
+    def get_successes(self) -> List[str]:
+        """Get all success messages"""
+        return [f"{r['check']}: {r['message']}" for r in self.results if r["status"] == "passed"]
+
+def clean_columns(df: pd.DataFrame, rep: ValidationReport) -> None:
+    """Clean column names by removing whitespace and standardizing case"""
+    # Remove leading/trailing whitespace
+    renamed_cols = {c: c.strip() for c in df.columns if c != c.strip()}
+    if renamed_cols:
+        df.rename(columns=renamed_cols, inplace=True)
+        rep.pass_("cleanup", f"Cleaned whitespace from columns: {list(renamed_cols.keys())}")
+
+def check_missing(df: pd.DataFrame, rep: ValidationReport, critical: List[str] = None) -> None:
+    """Check for missing values in dataframe"""
+    if critical is None:
+        critical = []
+    
+    total_missing = df.isnull().sum().sum()
+    if total_missing == 0:
+        rep.pass_("missing_values", "No missing values found")
+    else:
+        rep.warn("missing_values", f"Total missing values: {total_missing}")
+    
+    # Check critical columns
+    for col in critical:
+        if col in df.columns:
+            missing_count = df[col].isnull().sum()
+            if missing_count > 0:
+                rep.fail(f"missing_{col}", f"Critical column '{col}' has {missing_count} missing values")
+
+def find_column_variations(df: pd.DataFrame, target_column: str) -> str:
+    """Find column variations - checks for multiple formats of the same column"""
+    variations = [
+        target_column,  # exact match
+        target_column.replace('_', ''),  # no underscore: "salesvalue"
+        target_column.replace('_', ' '),  # with space: "sales value"
+        target_column.replace('_', '-'),  # with hyphen: "sales-value"
+        target_column.lower(),  # lowercase
+        target_column.title(),  # title case
+        target_column.upper(),  # uppercase
+        # Common variations for promo data
+        target_column.replace('value', 'val'),  # "salesval"
+        target_column.replace('sales', 'sale'),  # "salevalue"
+        target_column.replace('Price', 'price'),  # case variations
+        target_column.replace('price', 'Price'),  # case variations
+    ]
+    
+    # Additional variations for price columns
+    if 'price' in target_column.lower():
+        base_name = target_column.lower().replace('price', '').replace('_', '').replace(' ', '')
+        variations.extend([
+            f"{base_name}price",
+            f"{base_name}_price", 
+            f"{base_name} price",
+            f"{base_name}Price",
+            f"{base_name}_Price"
+        ])
+    
+    for variation in variations:
+        if variation in df.columns:
+            return variation
+    
+    return None
+
+def check_required_columns_flexible(df: pd.DataFrame, rep: ValidationReport, required_columns: List[str]) -> List[str]:
+    """Check for required columns with flexible matching"""
+    missing_columns = []
+    found_columns = []
+    column_mappings = {}
+    
+    for required_col in required_columns:
+        found_col = find_column_variations(df, required_col)
+        if found_col:
+            found_columns.append(required_col)
+            if found_col != required_col:
+                column_mappings[found_col] = required_col
+                # Rename the column to the expected name for consistency
+                df.rename(columns={found_col: required_col}, inplace=True)
+        else:
+            missing_columns.append(required_col)
+    
+    # Report column mappings
+    if column_mappings:
+        rep.pass_("column_mapping", f"Mapped columns: {column_mappings}")
+    
+    return missing_columns
+
+# ✅ Configuration constants for Promo Intensity validation (PromoPrice removed from mandatory)
+_PI_REQUIRED = ["Channel", "Brand", "PPG", "SalesValue", "Volume", "Price", "BasePrice"]
+_PI_AGG = ["Variant", "PackType", "PackSize"]
+
+def validate_promo_intensity(
+    df: pd.DataFrame,
+    *,
+    required: List[str] = _PI_REQUIRED,
+    aggregators: List[str] = _PI_AGG,
+) -> ValidationReport:
+    """
+    Validates data for Promotional Intensity analysis.
+    PromoPrice is now optional (not mandatory).
+    
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame containing promotional data
+    required : List[str], optional
+        List of required columns (Price, BasePrice mandatory; PromoPrice optional)
+    aggregators : List[str], optional
+        List of potential aggregator columns
+        
+    Returns
+    -------
+    ValidationReport
+        Validation results
+    """
+    rep = ValidationReport()
+    
+    # Start validation
+    rep.pass_("validation_start", "Starting Promo Intensity validation with mandatory price columns (PromoPrice optional)")
+    
+    # Clean column names (remove whitespace)
+    clean_columns(df, rep)
+    
+    # Use flexible column matching for all required columns
+    missing_columns = check_required_columns_flexible(df, rep, required)
+    
+    if not missing_columns:
+        rep.pass_("required_cols", f"All {len(required)} required columns found (Price, BasePrice mandatory)")
+    else:
+        rep.fail("required_cols", f"Missing required columns: {missing_columns}. Available columns: {list(df.columns)}")
+
+    # Check for missing values in critical columns
+    check_missing(df, rep, critical=required)
+
+    # Enhanced price column validation (PromoPrice now optional)
+    mandatory_price_columns = ["Price", "BasePrice"]
+    optional_price_columns = ["PromoPrice"]
+    
+    # Validate mandatory price columns
+    for price_col in mandatory_price_columns:
+        if price_col in df.columns:
+            if pd.api.types.is_numeric_dtype(df[price_col]):
+                # Check for negative prices
+                negative_prices = (df[price_col] < 0).sum()
+                if negative_prices > 0:
+                    rep.fail(f"negative_{price_col}", f"'{price_col}' has {negative_prices} negative values - not allowed for pricing data")
+                else:
+                    rep.pass_(f"positive_{price_col}", f"'{price_col}' has no negative values")
+                
+                # Check for zero prices
+                zero_prices = (df[price_col] == 0).sum()
+                if zero_prices > 0:
+                    rep.warn(f"zero_{price_col}", f"'{price_col}' has {zero_prices} zero values")
+                else:
+                    rep.pass_(f"non_zero_{price_col}", f"'{price_col}' has no zero values")
+                
+                # Check price ranges for reasonableness
+                max_price = df[price_col].max()
+                min_price = df[price_col].min()
+                
+                if max_price > 10000:  # Threshold for unusually high prices
+                    rep.warn(f"high_{price_col}", f"'{price_col}' has very high values (max: {max_price:,.2f})")
+                
+                rep.pass_(f"numeric_{price_col}", f"'{price_col}' is numeric with range: {min_price:.2f} to {max_price:.2f}")
+            else:
+                rep.fail(f"non_numeric_{price_col}", f"'{price_col}' must be numeric for price analysis (current type: {df[price_col].dtype})")
+        else:
+            # This should not happen since we check required columns above, but just in case
+            rep.fail(f"missing_{price_col}", f"Mandatory price column '{price_col}' is missing from the dataset")
+    
+    # Validate optional price columns
+    for price_col in optional_price_columns:
+        found_price_col = find_column_variations(df, price_col)
+        if found_price_col:
+            if found_price_col != price_col:
+                df.rename(columns={found_price_col: price_col}, inplace=True)
+                rep.pass_(f"optional_price_mapping_{price_col}", f"Found and mapped '{found_price_col}' to '{price_col}'")
+            
+            if pd.api.types.is_numeric_dtype(df[price_col]):
+                # Check for negative prices
+                negative_prices = (df[price_col] < 0).sum()
+                if negative_prices > 0:
+                    rep.warn(f"negative_{price_col}", f"Optional column '{price_col}' has {negative_prices} negative values")
+                else:
+                    rep.pass_(f"positive_{price_col}", f"Optional column '{price_col}' has no negative values")
+                
+                # Check for zero prices
+                zero_prices = (df[price_col] == 0).sum()
+                if zero_prices > 0:
+                    rep.warn(f"zero_{price_col}", f"Optional column '{price_col}' has {zero_prices} zero values")
+                
+                rep.pass_(f"optional_numeric_{price_col}", f"Optional column '{price_col}' is numeric and available for analysis")
+            else:
+                rep.warn(f"non_numeric_{price_col}", f"Optional column '{price_col}' is not numeric (type: {df[price_col].dtype})")
+        else:
+            rep.pass_(f"optional_missing_{price_col}", f"Optional price column '{price_col}' not found - analysis will use available price columns")
+    
+
+    # Check time granularity with flexible matching
+    date_col = find_column_variations(df, "Date")
+    year_col = find_column_variations(df, "Year")
+    week_col = find_column_variations(df, "Week")
+    
+    has_date = date_col is not None
+    has_week = year_col is not None and week_col is not None
+    
+    if has_date:
+        if date_col != "Date":
+            df.rename(columns={date_col: "Date"}, inplace=True)
+            rep.pass_("date_mapping", f"Mapped '{date_col}' to 'Date'")
+        rep.pass_("granularity", "Time granularity check passed. Data is at daily level.")
+    elif has_week:
+        if year_col != "Year":
+            df.rename(columns={year_col: "Year"}, inplace=True)
+        if week_col != "Week":
+            df.rename(columns={week_col: "Week"}, inplace=True)
+        rep.pass_("granularity", "Time granularity check passed. Data is at weekly level.")
+    else:
+        rep.fail("granularity", "Missing time columns. Need either 'Date' column or both 'Year' and 'Week' columns.")
+
+    # Check for aggregator columns with flexible matching
+    found_aggregators = []
+    aggregator_mappings = {}
+    
+    for agg_col in aggregators:
+        found_agg = find_column_variations(df, agg_col)
+        if found_agg:
+            found_aggregators.append(agg_col)
+            if found_agg != agg_col:
+                aggregator_mappings[found_agg] = agg_col
+                df.rename(columns={found_agg: agg_col}, inplace=True)
+    
+    if aggregator_mappings:
+        rep.pass_("aggregator_mapping", f"Mapped aggregator columns: {aggregator_mappings}")
+    
+    if found_aggregators:
+        rep.pass_("aggregators", f"Found {len(found_aggregators)} aggregator columns: {found_aggregators}")
+    else:
+        rep.warn("aggregators", f"No aggregator columns found. Looked for: {aggregators}")
+
+    # Check for promotion indicators (excluding mandatory price columns)
+    promo_indicators = []
+    for col in df.columns:
+        col_lower = col.lower()
+        if any(keyword in col_lower for keyword in ['promo', 'promotion', 'discount', 'offer', 'deal']) and col not in mandatory_price_columns:
+            promo_indicators.append(col)
+    
+    if promo_indicators:
+        rep.pass_("promotion_indicator", f"Found promotion indicators: {promo_indicators}")
+        
+        # Analyze promotion indicators
+        for indicator in promo_indicators:
+            if pd.api.types.is_numeric_dtype(df[indicator]):
+                non_zero_promos = (df[indicator] != 0).sum()
+                promo_percentage = (non_zero_promos / len(df)) * 100
+                rep.pass_(f"promo_analysis_{indicator}", f"'{indicator}': {non_zero_promos} promotional periods ({promo_percentage:.1f}%)")
+            elif pd.api.types.is_bool_dtype(df[indicator]):
+                true_promos = df[indicator].sum()
+                promo_percentage = (true_promos / len(df)) * 100
+                rep.pass_(f"promo_analysis_{indicator}", f"'{indicator}': {true_promos} promotional periods ({promo_percentage:.1f}%)")
+    else:
+        rep.warn("promotion_indicator", "No additional promotion indicator columns found")
+
+    # Business logic validation for promo data
+    if "SalesValue" in df.columns and "Volume" in df.columns:
+        # Check for consistency between sales and volume
+        if pd.api.types.is_numeric_dtype(df["SalesValue"]) and pd.api.types.is_numeric_dtype(df["Volume"]):
+            # Calculate implied price
+            non_zero_volume = df["Volume"] > 0
+            if non_zero_volume.any():
+                df.loc[non_zero_volume, 'implied_price'] = df.loc[non_zero_volume, "SalesValue"] / df.loc[non_zero_volume, "Volume"]
+                
+                # Check for negative sales or volume
+                negative_sales = (df["SalesValue"] < 0).sum()
+                negative_volume = (df["Volume"] < 0).sum()
+                
+                if negative_sales > 0:
+                    rep.fail("negative_sales", f"SalesValue has {negative_sales} negative values - not allowed")
+                if negative_volume > 0:
+                    rep.fail("negative_volume", f"Volume has {negative_volume} negative values - not allowed")
+                
+                if negative_sales == 0 and negative_volume == 0:
+                    rep.pass_("sales_volume_validation", "SalesValue and Volume have no negative values")
+    
+    # Check if dataframe is empty
+    if df.empty:
+        rep.fail("data_empty", "Dataset is empty after validation")
+    else:
+        rep.pass_("records_count", f"Dataset contains {len(df)} records")
+        
+        # Check for sufficient data for promo analysis
+        if len(df) < 12:
+            rep.warn("data_sufficiency", f"Only {len(df)} records - may be insufficient for robust promotional analysis")
+        else:
+            rep.pass_("data_sufficiency", f"Sufficient data for promotional analysis: {len(df)} records")
+
+    # Enhanced date range analysis
+    if "Date" in df.columns:
+        try:
+            # Convert to datetime if not already
+            if not pd.api.types.is_datetime64_any_dtype(df["Date"]):
+                df["Date"] = pd.to_datetime(df["Date"], errors="coerce")
+            
+            if not df["Date"].isna().all():
+                min_date = df["Date"].min().date()
+                max_date = df["Date"].max().date()
+                date_range = (max_date - min_date).days + 1
+                
+                rep.pass_("date_range", f"Date range: {min_date} to {max_date} ({date_range} days)")
+        except Exception as e:
+            rep.warn("date_range", f"Error analyzing date range: {str(e)}")
+    
+    # Final validation summary
+    total_checks = len(rep.results)
+    failed_checks = len([r for r in rep.results if r["status"] == "failed"])
+    warning_checks = len([r for r in rep.results if r["status"] == "warning"])
+    
+    if failed_checks == 0:
+        if warning_checks == 0:
+            rep.pass_("promo_validation_summary", f"Perfect! All {total_checks} Promo validation checks passed (PromoPrice optional)")
+        else:
+            rep.warn("promo_validation_summary", f"Promo validation completed with {warning_checks} warnings out of {total_checks} checks")
+    else:
+        rep.fail("promo_validation_summary", f"Promo validation failed: {failed_checks} errors and {warning_checks} warnings out of {total_checks} total checks")
+    
+    return rep

--- a/TrinityFrontend/src/components/Header.tsx
+++ b/TrinityFrontend/src/components/Header.tsx
@@ -102,12 +102,12 @@ const Header = () => {
           const IconComp = appInfo.Icon;
           return (
             <div className="flex items-center space-x-2">
+              <span className="text-sm font-medium text-gray-800">{appInfo.title}</span>
               <div
                 className={`w-8 h-8 rounded-lg bg-gradient-to-r ${appInfo.color} flex items-center justify-center shadow-md`}
               >
                 <IconComp className="w-4 h-4 text-white" />
               </div>
-              <span className="text-sm font-medium text-gray-800">{appInfo.title}</span>
               <button type="button" onClick={handleGoBack} className="p-2" title="Back to Apps">
                 <TrinityAssets.BackToAppsIcon className="w-5 h-5" />
               </button>

--- a/TrinityFrontend/src/components/Header.tsx
+++ b/TrinityFrontend/src/components/Header.tsx
@@ -9,11 +9,13 @@ import {
   MyProfile,
   Navigation,
 } from '@/components/PrimaryMenu';
+import { Target, BarChart3, Zap, Plus } from 'lucide-react';
 
 const Header = () => {
   const location = useLocation();
   const navigate = useNavigate();
   const [projectName, setProjectName] = useState<string | null>(null);
+  const [appInfo, setAppInfo] = useState<{ title: string; Icon: any } | null>(null);
 
   useEffect(() => {
     const saved = localStorage.getItem('current-project');
@@ -25,15 +27,45 @@ const Header = () => {
         /* ignore corrupted project */
       }
     }
-  }, []);
+
+    if (location.pathname.startsWith('/projects')) {
+      try {
+        const appStr = localStorage.getItem('current-app');
+        if (appStr) {
+          const { slug } = JSON.parse(appStr);
+          switch (slug) {
+            case 'marketing-mix':
+              setAppInfo({ title: 'Marketing Mix Modeling', Icon: Target });
+              break;
+            case 'forecasting':
+              setAppInfo({ title: 'Forecasting Analysis', Icon: BarChart3 });
+              break;
+            case 'promo-effectiveness':
+              setAppInfo({ title: 'Promo Effectiveness', Icon: Zap });
+              break;
+            case 'blank':
+              setAppInfo({ title: 'Blank App', Icon: Plus });
+              break;
+            default:
+              setAppInfo(null);
+          }
+        }
+      } catch {
+        setAppInfo(null);
+      }
+    } else {
+      setAppInfo(null);
+    }
+  }, [location.pathname]);
 
   const handleGoBack = () => {
+    localStorage.removeItem('current-app');
     navigate('/apps');
   };
 
+  const isProjects = location.pathname.startsWith('/projects');
   const simpleHeader =
-    location.pathname.startsWith('/apps') ||
-    location.pathname.startsWith('/projects');
+    location.pathname.startsWith('/apps') || isProjects;
 
   return (
     <header className="bg-white border-b border-gray-200 px-8 py-4 flex items-center justify-between shadow-sm">
@@ -53,6 +85,17 @@ const Header = () => {
             <Searchbar />
           </>
         )}
+
+        {isProjects && appInfo && (() => { const IconComp = appInfo.Icon; return (
+          <>
+            <span className="text-sm text-gray-600 text-right">{appInfo.title}</span>
+            <IconComp className="w-5 h-5 text-gray-600" />
+            <button type="button" onClick={handleGoBack} className="p-2" title="Back to Apps">
+              <TrinityAssets.BackToAppsIcon className="w-5 h-5" />
+            </button>
+          </>
+        ); })()}
+
         <MyProfile.NotificationMenu />
         <MyProfile.SettingsMenu />
         <MyProfile.ProfileMenu />

--- a/TrinityFrontend/src/components/Header.tsx
+++ b/TrinityFrontend/src/components/Header.tsx
@@ -15,7 +15,7 @@ const Header = () => {
   const location = useLocation();
   const navigate = useNavigate();
   const [projectName, setProjectName] = useState<string | null>(null);
-  const [appInfo, setAppInfo] = useState<{ title: string; Icon: any } | null>(null);
+  const [appInfo, setAppInfo] = useState<{ title: string; Icon: any; color: string } | null>(null);
 
   useEffect(() => {
     const saved = localStorage.getItem('current-project');
@@ -35,16 +35,28 @@ const Header = () => {
           const { slug } = JSON.parse(appStr);
           switch (slug) {
             case 'marketing-mix':
-              setAppInfo({ title: 'Marketing Mix Modeling', Icon: Target });
+              setAppInfo({
+                title: 'Marketing Mix Modeling',
+                Icon: Target,
+                color: 'from-blue-500 to-purple-600'
+              });
               break;
             case 'forecasting':
-              setAppInfo({ title: 'Forecasting Analysis', Icon: BarChart3 });
+              setAppInfo({
+                title: 'Forecasting Analysis',
+                Icon: BarChart3,
+                color: 'from-green-500 to-teal-600'
+              });
               break;
             case 'promo-effectiveness':
-              setAppInfo({ title: 'Promo Effectiveness', Icon: Zap });
+              setAppInfo({
+                title: 'Promo Effectiveness',
+                Icon: Zap,
+                color: 'from-orange-500 to-red-600'
+              });
               break;
             case 'blank':
-              setAppInfo({ title: 'Blank App', Icon: Plus });
+              setAppInfo({ title: 'Blank App', Icon: Plus, color: 'from-gray-500 to-gray-700' });
               break;
             default:
               setAppInfo(null);
@@ -86,15 +98,22 @@ const Header = () => {
           </>
         )}
 
-        {isProjects && appInfo && (() => { const IconComp = appInfo.Icon; return (
-          <>
-            <span className="text-sm text-gray-600 text-right">{appInfo.title}</span>
-            <IconComp className="w-5 h-5 text-gray-600" />
-            <button type="button" onClick={handleGoBack} className="p-2" title="Back to Apps">
-              <TrinityAssets.BackToAppsIcon className="w-5 h-5" />
-            </button>
-          </>
-        ); })()}
+        {isProjects && appInfo && (() => {
+          const IconComp = appInfo.Icon;
+          return (
+            <div className="flex items-center space-x-2">
+              <div
+                className={`w-8 h-8 rounded-lg bg-gradient-to-r ${appInfo.color} flex items-center justify-center shadow-md`}
+              >
+                <IconComp className="w-4 h-4 text-white" />
+              </div>
+              <span className="text-sm font-medium text-gray-800">{appInfo.title}</span>
+              <button type="button" onClick={handleGoBack} className="p-2" title="Back to Apps">
+                <TrinityAssets.BackToAppsIcon className="w-5 h-5" />
+              </button>
+            </div>
+          );
+        })()}
 
         <MyProfile.NotificationMenu />
         <MyProfile.SettingsMenu />

--- a/TrinityFrontend/src/components/PrimaryMenu/AppIdentity/AppIdentity.tsx
+++ b/TrinityFrontend/src/components/PrimaryMenu/AppIdentity/AppIdentity.tsx
@@ -15,7 +15,7 @@ const AppIdentity: React.FC<AppIdentityProps> = ({ projectName, onGoBack }) => (
           type="button"
           onClick={onGoBack}
           className="p-2 text-black"
-          title="Go back to app menu"
+          title="Go back to projects menu"
         >
           <BackToAppsIcon className="w-5 h-5" />
         </button>

--- a/TrinityFrontend/src/components/ProtectedRoute.tsx
+++ b/TrinityFrontend/src/components/ProtectedRoute.tsx
@@ -17,14 +17,23 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
 
   // If user is authenticated but trying to access main routes without going through projects
   // redirect them to projects first (except if they're already on projects page)
-  if (location.pathname !== '/projects' && 
-      (location.pathname === '/' || 
-       location.pathname === '/workflow' || 
-       location.pathname === '/laboratory' || 
+  if (location.pathname !== '/projects' &&
+      (location.pathname === '/' ||
+       location.pathname === '/workflow' ||
+       location.pathname === '/laboratory' ||
        location.pathname === '/exhibition')) {
     const hasSelectedProject = localStorage.getItem('current-project');
     if (!hasSelectedProject) {
-      return <Navigate to="/projects" replace />;
+      const currentApp = localStorage.getItem('current-app');
+      if (currentApp) {
+        try {
+          const obj = JSON.parse(currentApp);
+          return <Navigate to={`/projects?app=${obj.slug}`} replace />;
+        } catch {
+          return <Navigate to="/apps" replace />;
+        }
+      }
+      return <Navigate to="/apps" replace />;
     }
   }
 

--- a/TrinityFrontend/src/pages/Apps.tsx
+++ b/TrinityFrontend/src/pages/Apps.tsx
@@ -1,9 +1,7 @@
 
 import React, { useRef, useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Card } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { ArrowLeft, Zap, BarChart3, Target, Plus, ChevronLeft, ChevronRight } from 'lucide-react';
+import { Zap, BarChart3, Target, Plus, ChevronLeft, ChevronRight } from 'lucide-react';
 import Header from '@/components/Header';
 import AppCard from '@/components/AppList/AppCard';
 import { REGISTRY_API } from '@/lib/api';
@@ -124,15 +122,15 @@ const handleAppSelect = async (appId: string) => {
 };
 
   return (
-    <div className="min-h-screen bg-white flex flex-col">
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-gray-100 flex flex-col">
 
       <Header />
 
       <div className="relative z-10 p-8">
         {/* Removed back navigation button per updated routing flow */}
         <div className="mt-4">
-          <h1 className="text-3xl font-light text-black">Choose Your Trinity App</h1>
-          <p className="text-black/60 text-sm">Select an application template to initialize</p>
+          <h1 className="text-3xl font-light text-gray-900">Choose Your Trinity App</h1>
+          <p className="text-gray-600 text-sm">Select an application template to initialize</p>
         </div>
       </div>
 
@@ -166,9 +164,7 @@ const handleAppSelect = async (appId: string) => {
 
           {/* Footer Message */}
           <div className="text-center mt-16">
-            <p className="text-black/50 text-sm">
-              "Choice is an illusion" - But we give you options anyway
-            </p>
+            <p className="text-gray-500 text-sm">"The Matrix has you" - pick your path</p>
           </div>
         </div>
       </div>

--- a/TrinityFrontend/src/pages/Apps.tsx
+++ b/TrinityFrontend/src/pages/Apps.tsx
@@ -1,12 +1,11 @@
 
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Zap, BarChart3, Target, Plus, ChevronLeft, ChevronRight } from 'lucide-react';
-import Header from '@/components/Header';
-import AppCard from '@/components/AppList/AppCard';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { BarChart3, Target, Zap, Plus, ArrowRight } from 'lucide-react';
 import { REGISTRY_API } from '@/lib/api';
-import { molecules } from '@/components/MoleculeList/data/molecules';
-import { safeStringify } from '@/utils/safeStringify';
+import { useAuth } from '@/contexts/AuthContext';
 
 interface BackendApp {
   id: number;
@@ -15,16 +14,9 @@ interface BackendApp {
 
 const Apps = () => {
   const navigate = useNavigate();
-  const scrollRef = useRef<HTMLDivElement>(null);
+  const { logout } = useAuth();
   const [appMap, setAppMap] = useState<Record<string, number>>({});
 
-  // Default molecules to preload for each app template
-  const templates: Record<string, string[]> = {
-    'marketing-mix': ['data-pre-process', 'build'],
-    forecasting: ['data-pre-process', 'explore'],
-    'promo-effectiveness': ['explore', 'build'],
-    blank: []
-  };
 
   const loadApps = async () => {
     console.log('Fetching apps from backend...');
@@ -58,36 +50,36 @@ const Apps = () => {
       title: 'Forecasting Analysis',
       description: 'Predict future trends and patterns with advanced time series analysis',
       icon: BarChart3,
-      templates: ['Explore', 'Build'],
-      color: 'bg-trinity-yellow',
-      borderColor: 'border-trinity-yellow/30'
+      color: 'from-green-500 to-teal-600',
+      bgGradient: 'from-green-50 to-teal-50',
+      molecules: ['Explore', 'Build']
     },
     {
       id: 'marketing-mix',
       title: 'Marketing Mix Modeling',
       description: 'Optimize marketing spend allocation across different channels',
       icon: Target,
-      templates: ['Data Pre-Process', 'Explore'],
-      color: 'bg-trinity-yellow',
-      borderColor: 'border-trinity-yellow/30'
+      color: 'from-blue-500 to-purple-600',
+      bgGradient: 'from-blue-50 to-purple-50',
+      molecules: ['Data Pre-Process', 'Explore']
     },
     {
       id: 'promo-effectiveness',
       title: 'Promo Effectiveness',
       description: 'Measure and analyze promotional campaign performance',
       icon: Zap,
-      templates: ['Data Pre-Process', 'Build'],
-      color: 'bg-trinity-yellow',
-      borderColor: 'border-trinity-yellow/30'
+      color: 'from-orange-500 to-red-600',
+      bgGradient: 'from-orange-50 to-red-50',
+      molecules: ['Data Pre-Process', 'Build']
     },
     {
       id: 'blank',
       title: 'Create Blank App',
       description: 'Start from scratch with a clean canvas',
       icon: Plus,
-      templates: [],
-      color: 'bg-trinity-yellow',
-      borderColor: 'border-trinity-yellow/30'
+      color: 'from-gray-500 to-gray-700',
+      bgGradient: 'from-gray-50 to-gray-100',
+      molecules: []
     }
   ];
 
@@ -121,51 +113,96 @@ const handleAppSelect = async (appId: string) => {
   navigate(`/projects?app=${appId}`);
 };
 
+  const handleLogout = () => {
+    logout();
+    navigate('/login');
+  };
+
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-gray-100 flex flex-col">
-
-      <Header />
-
-      <div className="relative z-10 p-8">
-        {/* Removed back navigation button per updated routing flow */}
-        <div className="mt-4">
-          <h1 className="text-3xl font-light text-gray-900">Choose Your Trinity App</h1>
-          <p className="text-gray-600 text-sm">Select an application template to initialize</p>
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-gray-100">
+      {/* Header */}
+      <div className="bg-white shadow-sm border-b">
+        <div className="max-w-7xl mx-auto px-6 py-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center space-x-3">
+              <div className="w-8 h-8 bg-gradient-to-r from-blue-600 to-purple-600 rounded-lg flex items-center justify-center">
+                <div className="w-4 h-4 bg-white rounded-sm" />
+              </div>
+              <h1 className="text-xl font-semibold text-gray-900">Trinity Analytics</h1>
+            </div>
+            <Button
+              variant="outline"
+              onClick={handleLogout}
+              className="text-gray-600 hover:text-gray-900"
+            >
+              Sign Out
+            </Button>
+          </div>
         </div>
       </div>
 
       {/* Main Content */}
-      <div className="relative z-10 flex-1 px-8 pb-8 flex items-center justify-center">
-        <div className="max-w-6xl mx-auto relative">
-          <button
-            type="button"
-            onClick={() => scrollRef.current?.scrollBy({ left: -scrollRef.current!.clientWidth, behavior: 'smooth' })}
-            className="absolute -left-12 top-1/2 -translate-y-1/2 p-3 bg-trinity-yellow text-white rounded-full shadow-lg hover:bg-trinity-yellow/90"
-          >
-            <ChevronLeft className="w-6 h-6" />
-          </button>
-          <button
-            type="button"
-            onClick={() => scrollRef.current?.scrollBy({ left: scrollRef.current!.clientWidth, behavior: 'smooth' })}
-            className="absolute -right-12 top-1/2 -translate-y-1/2 p-3 bg-trinity-yellow text-white rounded-full shadow-lg hover:bg-trinity-yellow/90"
-          >
-            <ChevronRight className="w-6 h-6" />
-          </button>
-          <div ref={scrollRef} className="flex overflow-x-auto space-x-6 pb-4 snap-x snap-mandatory scroll-smooth">
-            {apps.map((app) => (
-              <div key={app.id} className="w-1/2 flex-shrink-0 snap-center">
-                <AppCard
-                  app={app}
-                  onSelect={() => handleAppSelect(app.id)}
-                />
-              </div>
-            ))}
-          </div>
+      <div className="max-w-7xl mx-auto px-6 py-12">
+        <div className="text-center mb-12">
+          <h2 className="text-3xl font-bold text-gray-900 mb-4">Choose Your Analytics Application</h2>
+          <p className="text-lg text-gray-600 max-w-2xl mx-auto">
+            Select the type of analysis you want to perform. Each application comes with pre-configured templates and workflows.
+          </p>
+        </div>
 
-          {/* Footer Message */}
-          <div className="text-center mt-16">
-            <p className="text-gray-500 text-sm">"The Matrix has you" - pick your path</p>
-          </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-8 max-w-5xl mx-auto">
+          {apps.map((app) => {
+            const Icon = app.icon;
+            return (
+              <Card
+                key={app.id}
+                className="group cursor-pointer hover:shadow-lg transition-all duration-300 border-0 bg-white overflow-hidden"
+                onClick={() => handleAppSelect(app.id)}
+              >
+                <div className="p-8">
+                  <div className="flex items-start space-x-4">
+                    <div className={`w-16 h-16 rounded-xl bg-gradient-to-r ${app.color} flex items-center justify-center group-hover:scale-110 transition-transform duration-300 shadow-lg`}>
+                      <Icon className="w-8 h-8 text-white" />
+                    </div>
+
+                    <div className="flex-1 min-w-0">
+                      <h3 className="text-xl font-semibold text-gray-900 mb-2 group-hover:text-gray-700 transition-colors">
+                        {app.title}
+                      </h3>
+                      <p className="text-gray-600 text-sm leading-relaxed mb-4">
+                        {app.description}
+                      </p>
+
+                      {app.molecules.length > 0 && (
+                        <div className="mb-4">
+                          <p className="text-xs font-medium text-gray-500 mb-2">Pre-configured with:</p>
+                          <div className="flex flex-wrap gap-2">
+                            {app.molecules.map((molecule, index) => (
+                              <span
+                                key={index}
+                                className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800"
+                              >
+                                {molecule}
+                              </span>
+                            ))}
+                          </div>
+                        </div>
+                      )}
+
+                      <div className="flex items-center text-sm font-medium text-gray-600 group-hover:text-gray-900 transition-colors">
+                        Select Application
+                        <ArrowRight className="w-4 h-4 ml-2 group-hover:translate-x-1 transition-transform duration-300" />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </Card>
+            );
+          })}
+        </div>
+
+        <div className="text-center mt-16">
+          <p className="text-gray-500 text-sm">"The Matrix has you" - pick your path</p>
         </div>
       </div>
     </div>

--- a/TrinityFrontend/src/pages/Apps.tsx
+++ b/TrinityFrontend/src/pages/Apps.tsx
@@ -129,26 +129,7 @@ const handleAppSelect = async (appId: string) => {
       <Header />
 
       <div className="relative z-10 p-8">
-        <Button
-          variant="ghost"
-          onClick={() => {
-            const stored = localStorage.getItem('current-app');
-            if (stored) {
-              try {
-                const obj = JSON.parse(stored);
-                navigate(`/projects?app=${obj.slug}`);
-              } catch {
-                navigate('/projects');
-              }
-            } else {
-              navigate('/projects');
-            }
-          }}
-          className="text-black hover:bg-trinity-yellow/10"
-        >
-          <ArrowLeft className="w-4 h-4 mr-2" />
-          Back to Projects
-        </Button>
+        {/* Removed back navigation button per updated routing flow */}
         <div className="mt-4">
           <h1 className="text-3xl font-light text-black">Choose Your Trinity App</h1>
           <p className="text-black/60 text-sm">Select an application template to initialize</p>

--- a/TrinityFrontend/src/pages/Apps.tsx
+++ b/TrinityFrontend/src/pages/Apps.tsx
@@ -2,10 +2,9 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Card } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
+import Header from '@/components/Header';
 import { BarChart3, Target, Zap, Plus, ArrowRight } from 'lucide-react';
 import { REGISTRY_API } from '@/lib/api';
-import { useAuth } from '@/contexts/AuthContext';
 
 interface BackendApp {
   id: number;
@@ -14,7 +13,6 @@ interface BackendApp {
 
 const Apps = () => {
   const navigate = useNavigate();
-  const { logout } = useAuth();
   const [appMap, setAppMap] = useState<Record<string, number>>({});
 
 
@@ -113,33 +111,9 @@ const handleAppSelect = async (appId: string) => {
   navigate(`/projects?app=${appId}`);
 };
 
-  const handleLogout = () => {
-    logout();
-    navigate('/login');
-  };
-
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-gray-100">
-      {/* Header */}
-      <div className="bg-white shadow-sm border-b">
-        <div className="max-w-7xl mx-auto px-6 py-4">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center space-x-3">
-              <div className="w-8 h-8 bg-gradient-to-r from-blue-600 to-purple-600 rounded-lg flex items-center justify-center">
-                <div className="w-4 h-4 bg-white rounded-sm" />
-              </div>
-              <h1 className="text-xl font-semibold text-gray-900">Trinity Analytics</h1>
-            </div>
-            <Button
-              variant="outline"
-              onClick={handleLogout}
-              className="text-gray-600 hover:text-gray-900"
-            >
-              Sign Out
-            </Button>
-          </div>
-        </div>
-      </div>
+      <Header />
 
       {/* Main Content */}
       <div className="max-w-7xl mx-auto px-6 py-12">

--- a/TrinityFrontend/src/pages/Clients.tsx
+++ b/TrinityFrontend/src/pages/Clients.tsx
@@ -1,9 +1,32 @@
 import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import Header from '@/components/Header';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Input } from '@/components/ui/input';
+import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Trash2 } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Plus,
+  Search,
+  Building2,
+  Users,
+  Calendar,
+  MoreVertical,
+  Edit,
+  Trash2,
+  Eye,
+  ArrowUpRight,
+  Mail,
+  MapPin,
+  X,
+  Save,
+} from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { TENANTS_API, REGISTRY_API } from '@/lib/api';
 console.log('TENANTS_API', TENANTS_API);
 console.log('REGISTRY_API', REGISTRY_API);
@@ -24,6 +47,8 @@ interface App {
 const Clients = () => {
   const [tenants, setTenants] = useState<Tenant[]>([]);
   const [apps, setApps] = useState<App[]>([]);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [showAddForm, setShowAddForm] = useState(false);
   const [form, setForm] = useState({
     name: '',
     schema_name: '',
@@ -32,6 +57,8 @@ const Clients = () => {
     project_cap: '',
     apps_allowed: [] as number[],
   });
+
+  const navigate = useNavigate();
 
   const loadTenants = async () => {
     try {
@@ -152,81 +179,278 @@ const Clients = () => {
     }
   };
 
-  return (
-    <div className="min-h-screen bg-gray-50">
-      <Header />
-      <div className="max-w-3xl mx-auto p-8 space-y-8">
-        <Card>
-          <CardHeader>
-            <CardTitle>Create Client</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <form onSubmit={handleSubmit} className="space-y-4">
-              <Input name="name" placeholder="Client Name" value={form.name} onChange={handleChange} />
-              <Input
-                name="schema_name"
-                placeholder="Schema Name"
-                value={form.schema_name}
-                onChange={handleChange}
-              />
-              <Input name="domain" placeholder="Email Domain" value={form.domain} onChange={handleChange} />
-              <Input
-                name="seats_allowed"
-                type="number"
-                placeholder="Users Allowed"
-                value={form.seats_allowed}
-                onChange={handleChange}
-              />
-              <Input
-                name="project_cap"
-                type="number"
-                placeholder="Projects Allowed"
-                value={form.project_cap}
-                onChange={handleChange}
-              />
-              <select
-                name="apps_allowed"
-                multiple
-                value={form.apps_allowed.map(String)}
-                onChange={handleChange}
-                className="w-full border border-gray-300 rounded p-2 text-sm"
-              >
-                {apps.map((a) => (
-                  <option key={a.id} value={a.id}>
-                    {a.name}
-                  </option>
-                ))}
-              </select>
-              <Button type="submit">Add Client</Button>
-            </form>
-          </CardContent>
-        </Card>
+  const filteredTenants = tenants.filter((t) =>
+    t.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+    t.domain.toLowerCase().includes(searchTerm.toLowerCase())
+  );
 
-        <Card>
-          <CardHeader>
-            <CardTitle>Existing Clients</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <ul className="space-y-2">
-              {tenants.map((t) => (
-                <li
-                  key={t.id}
-                  className="border-b pb-1 last:border-none flex justify-between items-center"
-                >
-                  <span>
-                    {t.name} – {t.domain}
-                  </span>
-                  <button
-                    onClick={() => handleDelete(t.id)}
-                    className="text-red-600 hover:text-red-800"
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-gray-50">
+      <Header />
+
+      <div className="max-w-7xl mx-auto px-6 py-8">
+        {/* Header Section */}
+        <div className="mb-8">
+          <div className="flex items-center justify-between mb-6">
+            <div className="flex items-center space-x-4">
+              <div className="w-12 h-12 rounded-xl bg-gradient-to-r from-blue-500 to-purple-600 flex items-center justify-center shadow-lg">
+                <Building2 className="w-6 h-6 text-white" />
+              </div>
+              <div>
+                <h1 className="text-3xl font-bold text-gray-900 mb-1">Client Management</h1>
+                <p className="text-gray-600">Manage and monitor your client relationships</p>
+              </div>
+            </div>
+
+            <Button
+              onClick={() => setShowAddForm(!showAddForm)}
+              className="bg-gradient-to-r from-blue-500 to-purple-600 hover:opacity-90 shadow-lg hover:shadow-xl transition-all duration-300 px-6 py-3"
+            >
+              {showAddForm ? (
+                <>
+                  <X className="w-4 h-4 mr-2" />
+                  Cancel
+                </>
+              ) : (
+                <>
+                  <Plus className="w-4 h-4 mr-2" />
+                  Add New Client
+                </>
+              )}
+            </Button>
+          </div>
+
+          {showAddForm && (
+            <Card className="mb-8 p-6 bg-white border-0 shadow-lg">
+              <div className="mb-6">
+                <h2 className="text-xl font-semibold text-gray-900">Add New Client</h2>
+              </div>
+
+              <form onSubmit={handleSubmit} className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                <div className="space-y-2">
+                  <Label htmlFor="name" className="text-sm font-medium text-gray-700">Client Name *</Label>
+                  <Input
+                    id="name"
+                    name="name"
+                    value={form.name}
+                    onChange={handleChange}
+                    placeholder="Client Name"
+                    className="border-gray-200 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="schema_name" className="text-sm font-medium text-gray-700">Schema Name *</Label>
+                  <Input
+                    id="schema_name"
+                    name="schema_name"
+                    value={form.schema_name}
+                    onChange={handleChange}
+                    placeholder="schema"
+                    className="border-gray-200 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="domain" className="text-sm font-medium text-gray-700">Primary Domain</Label>
+                  <Input
+                    id="domain"
+                    name="domain"
+                    value={form.domain}
+                    onChange={handleChange}
+                    placeholder="client.example.com"
+                    className="border-gray-200 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="seats_allowed" className="text-sm font-medium text-gray-700">Users Allowed</Label>
+                  <Input
+                    id="seats_allowed"
+                    name="seats_allowed"
+                    type="number"
+                    value={form.seats_allowed}
+                    onChange={handleChange}
+                    placeholder="0"
+                    className="border-gray-200 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="project_cap" className="text-sm font-medium text-gray-700">Projects Allowed</Label>
+                  <Input
+                    id="project_cap"
+                    name="project_cap"
+                    type="number"
+                    value={form.project_cap}
+                    onChange={handleChange}
+                    placeholder="0"
+                    className="border-gray-200 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  />
+                </div>
+                <div className="space-y-2 md:col-span-2 lg:col-span-3">
+                  <Label htmlFor="apps_allowed" className="text-sm font-medium text-gray-700">Allowed Apps</Label>
+                  <select
+                    id="apps_allowed"
+                    name="apps_allowed"
+                    multiple
+                    value={form.apps_allowed.map(String)}
+                    onChange={handleChange}
+                    className="w-full px-3 py-2 border border-gray-200 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                   >
-                    <Trash2 className="w-4 h-4" />
-                  </button>
-                </li>
-              ))}
-            </ul>
-          </CardContent>
-        </Card>
+                    {apps.map((a) => (
+                      <option key={a.id} value={a.id}>
+                        {a.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div className="md:col-span-2 lg:col-span-3 flex justify-end">
+                  <Button type="submit" className="bg-gradient-to-r from-green-500 to-emerald-600 hover:opacity-90 shadow-md">
+                    <Save className="w-4 h-4 mr-2" />
+                    Save Client
+                  </Button>
+                </div>
+              </form>
+            </Card>
+          )}
+
+          {/* Stats Cards */}
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-8">
+            <Card className="p-6 bg-white border-0 shadow-md hover:shadow-lg transition-shadow">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm font-medium text-gray-600">Total Clients</p>
+                  <p className="text-2xl font-bold text-gray-900">{tenants.length}</p>
+                </div>
+                <div className="w-10 h-10 rounded-lg bg-blue-100 flex items-center justify-center">
+                  <Building2 className="w-5 h-5 text-blue-600" />
+                </div>
+              </div>
+            </Card>
+
+            <Card className="p-6 bg-white border-0 shadow-md hover:shadow-lg transition-shadow">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm font-medium text-gray-600">Active Clients</p>
+                  <p className="text-2xl font-bold text-green-600">{tenants.length}</p>
+                </div>
+                <div className="w-10 h-10 rounded-lg bg-green-100 flex items-center justify-center">
+                  <Users className="w-5 h-5 text-green-600" />
+                </div>
+              </div>
+            </Card>
+
+            <Card className="p-6 bg-white border-0 shadow-md hover:shadow-lg transition-shadow">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm font-medium text-gray-600">Pending</p>
+                  <p className="text-2xl font-bold text-yellow-600">0</p>
+                </div>
+                <div className="w-10 h-10 rounded-lg bg-yellow-100 flex items-center justify-center">
+                  <Calendar className="w-5 h-5 text-yellow-600" />
+                </div>
+              </div>
+            </Card>
+
+            <Card className="p-6 bg-white border-0 shadow-md hover:shadow-lg transition-shadow">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm font-medium text-gray-600">Total Projects</p>
+                  <p className="text-2xl font-bold text-purple-600">0</p>
+                </div>
+                <div className="w-10 h-10 rounded-lg bg-purple-100 flex items-center justify-center">
+                  <ArrowUpRight className="w-5 h-5 text-purple-600" />
+                </div>
+              </div>
+            </Card>
+          </div>
+
+          {/* Filters and Search */}
+          <div className="flex flex-col sm:flex-row gap-4 mb-6">
+            <div className="relative flex-1">
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4" />
+              <input
+                type="text"
+                placeholder="Search clients..."
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                className="pl-10 pr-4 py-3 w-full border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Clients Grid */}
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {filteredTenants.map((client) => (
+            <Card key={client.id} className="bg-white border-0 shadow-md hover:shadow-xl transition-all duration-300 overflow-hidden group">
+              <div className="p-6">
+                <div className="flex items-start justify-between mb-4">
+                  <div className="flex items-center space-x-3">
+                    <div className="w-12 h-12 rounded-lg bg-gradient-to-r from-gray-100 to-gray-200 flex items-center justify-center">
+                      <Building2 className="w-6 h-6 text-gray-600" />
+                    </div>
+                    <div>
+                      <h3 className="font-semibold text-gray-900 group-hover:text-blue-600 transition-colors">
+                        {client.name}
+                      </h3>
+                      <p className="text-sm text-gray-500">{client.domain}</p>
+                    </div>
+                  </div>
+
+                  <div className="flex items-center space-x-2">
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button variant="ghost" size="sm" className="p-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                          <MoreVertical className="w-4 h-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent className="bg-white border border-gray-200 shadow-lg">
+                        <DropdownMenuItem className="cursor-pointer" onSelect={() => navigate(`/clients/${client.id}`)}>
+                          <Eye className="w-4 h-4 mr-2" />
+                          View Details
+                        </DropdownMenuItem>
+                        <DropdownMenuItem className="cursor-pointer" onSelect={() => navigate(`/clients/${client.id}/edit`)}>
+                          <Edit className="w-4 h-4 mr-2" />
+                          Edit Client
+                        </DropdownMenuItem>
+                        <DropdownMenuItem className="cursor-pointer text-red-600" onSelect={() => handleDelete(client.id)}>
+                          <Trash2 className="w-4 h-4 mr-2" />
+                          Delete Client
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </div>
+                </div>
+
+                <div className="space-y-3 mb-4">
+                  <div className="flex items-center text-sm text-gray-600">
+                    <Mail className="w-4 h-4 mr-2" />
+                    <span>{client.domain}</span>
+                  </div>
+                  <div className="flex items-center text-sm text-gray-600">
+                    <MapPin className="w-4 h-4 mr-2" />
+                    <span>Schema: {client.schema_name}</span>
+                  </div>
+                </div>
+
+                <div className="mt-3 text-xs text-gray-400">Created on: {new Date(client.created_on).toLocaleDateString()}</div>
+              </div>
+            </Card>
+          ))}
+        </div>
+
+        {filteredTenants.length === 0 && (
+          <div className="text-center py-16">
+            <div className="w-32 h-32 rounded-3xl bg-gradient-to-br from-gray-50 to-gray-100 flex items-center justify-center mx-auto mb-8">
+              <Building2 className="w-16 h-16 text-gray-400" />
+            </div>
+            <h3 className="text-2xl font-semibold text-gray-900 mb-4">No clients found</h3>
+            <p className="text-gray-500 mb-8 max-w-md mx-auto">Try adjusting your search criteria.</p>
+            <Button onClick={() => setShowAddForm(true)} className="bg-gradient-to-r from-blue-500 to-purple-600 hover:opacity-90 shadow-lg hover:shadow-xl transition-all duration-300">
+              <Plus className="w-4 h-4 mr-2" />
+              Add Your First Client
+            </Button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/TrinityFrontend/src/pages/Login.tsx
+++ b/TrinityFrontend/src/pages/Login.tsx
@@ -28,7 +28,7 @@ const Login = () => {
 
     const success = await login(username, password);
     if (success) {
-      navigate('/projects');
+      navigate('/apps');
     } else {
       setError('Invalid credentials.');
       console.log('Login failed for', username);

--- a/TrinityFrontend/src/pages/Projects.tsx
+++ b/TrinityFrontend/src/pages/Projects.tsx
@@ -12,7 +12,8 @@ import {
   AlertDialogCancel,
   AlertDialogAction,
 } from '@/components/ui/alert-dialog';
-import { Plus, FolderOpen, Calendar, Pencil, Trash2 } from 'lucide-react';
+import { Plus, FolderOpen, Calendar, Pencil, Trash2, ArrowLeft } from 'lucide-react';
+import { Button } from '@/components/ui/button';
 import Header from '@/components/Header';
 import { REGISTRY_API } from '@/lib/api';
 import { safeStringify } from '@/utils/safeStringify';
@@ -267,6 +268,14 @@ const Projects = () => {
       <Header />
 
       <div className="relative z-10 p-8">
+        <Button
+          variant="ghost"
+          onClick={() => navigate('/apps')}
+          className="text-black hover:bg-trinity-yellow/10"
+        >
+          <ArrowLeft className="w-4 h-4 mr-2" />
+          Back to Apps
+        </Button>
         <h1 className="text-3xl font-light text-black">
           Trinity Projects{currentApp ? ` - ${currentApp.slug}` : ''}
         </h1>

--- a/TrinityFrontend/src/pages/Projects.tsx
+++ b/TrinityFrontend/src/pages/Projects.tsx
@@ -6,7 +6,6 @@ import {
   Plus,
   FolderOpen,
   Calendar,
-  ArrowLeft,
   Target,
   BarChart3,
   Zap
@@ -241,38 +240,11 @@ const Projects = () => {
     navigate('/workflow');
   };
 
-  const goBackToApps = () => {
-    localStorage.removeItem('current-app');
-    navigate('/apps');
-  };
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-gray-100">
       <Header />
 
-      {/* Header */}
-      <div className="bg-white shadow-sm border-b">
-        <div className="max-w-7xl mx-auto px-6 py-4">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center space-x-4">
-              <Button variant="ghost" onClick={goBackToApps} className="text-gray-600 hover:text-gray-900">
-                <ArrowLeft className="w-4 h-4 mr-2" />
-                Back to Apps
-              </Button>
-
-              <div className="flex items-center space-x-3">
-                <div className={`w-10 h-10 rounded-lg bg-gradient-to-r ${appDetails.color} flex items-center justify-center shadow-md`}>
-                  <Icon className="w-5 h-5 text-white" />
-                </div>
-                <div>
-                  <h1 className="text-xl font-semibold text-gray-900">{appDetails.title}</h1>
-                  <p className="text-sm text-gray-600">{appDetails.description}</p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
 
       {/* Main Content */}
       <div className="max-w-7xl mx-auto px-6 py-12">

--- a/TrinityFrontend/src/pages/Users.tsx
+++ b/TrinityFrontend/src/pages/Users.tsx
@@ -1,27 +1,53 @@
 import React, { useEffect, useState } from 'react';
 import Header from '@/components/Header';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
-import { Trash2 } from 'lucide-react';
+import { Card } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import {
+  Search,
+  Plus,
+  Users as UsersIcon,
+  Shield,
+  Mail,
+  Phone,
+  Calendar,
+  MoreVertical,
+  Edit,
+  Trash2,
+  X,
+  Save
+} from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { ACCOUNTS_API, TENANTS_API } from '@/lib/api';
 
 interface User {
   id: number;
   username: string;
   email: string;
-  first_name: string;
-  last_name: string;
-  mfa_enabled: boolean;
-  preferences: Record<string, unknown> | null;
+  first_name?: string;
+  last_name?: string;
   is_staff: boolean;
+  last_login?: string | null;
+  // optional custom fields
+  phone?: string;
+  department?: string;
 }
-
-import { ACCOUNTS_API, TENANTS_API } from '@/lib/api';
 
 const API_BASE = ACCOUNTS_API;
 
 const Users = () => {
   const [users, setUsers] = useState<User[]>([]);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [selectedRole, setSelectedRole] = useState<string>('All');
+  const [selectedStatus, setSelectedStatus] = useState<string>('All');
+
+  const [showAddForm, setShowAddForm] = useState(false);
   const [form, setForm] = useState({ username: '', password: '', email: '' });
   const [allowedDomains, setAllowedDomains] = useState<string[]>([]);
 
@@ -33,7 +59,7 @@ const Users = () => {
         setUsers(data);
       }
     } catch {
-      /* ignore errors for demo */
+      /* ignore */
     }
   };
 
@@ -54,11 +80,11 @@ const Users = () => {
     loadDomains();
   }, []);
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFormChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setForm({ ...form, [e.target.name]: e.target.value });
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleAddUser = async (e: React.FormEvent) => {
     e.preventDefault();
     const domain = form.email.split('@')[1]?.toLowerCase();
     if (domain && allowedDomains.length && !allowedDomains.includes(domain)) {
@@ -74,10 +100,11 @@ const Users = () => {
       });
       if (res.ok) {
         setForm({ username: '', password: '', email: '' });
+        setShowAddForm(false);
         await loadUsers();
       }
     } catch {
-      /* ignore errors for demo */
+      /* ignore */
     }
   };
 
@@ -92,62 +119,223 @@ const Users = () => {
         await loadUsers();
       }
     } catch {
-      /* ignore errors for demo */
+      /* ignore */
     }
   };
 
-  return (
-    <div className="min-h-screen bg-gray-50">
-      <Header />
-      <div className="max-w-3xl mx-auto p-8 space-y-8">
-        <Card>
-          <CardHeader>
-            <CardTitle>Create User</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <form onSubmit={handleSubmit} className="space-y-4">
-              <Input
-                name="username"
-                placeholder="Username"
-                value={form.username}
-                onChange={handleChange}
-              />
-              <Input
-                name="password"
-                type="password"
-                placeholder="Password"
-                value={form.password}
-                onChange={handleChange}
-              />
-              <Input
-                name="email"
-                type="email"
-                placeholder="Email"
-                value={form.email}
-                onChange={handleChange}
-              />
-              <Button type="submit">Add User</Button>
-            </form>
-          </CardContent>
-        </Card>
+  const getRole = (u: User) => (u.is_staff ? 'Admin' : 'Analyst');
+  const getStatus = (_u: User) => 'Active';
 
-        <Card>
-          <CardHeader>
-            <CardTitle>Existing Users</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <ul className="space-y-2">
-              {users.map((u) => (
-                <li key={u.id} className="border-b pb-1 last:border-none flex justify-between items-center">
-                  <span>{u.username} – {u.email}</span>
-                  <button onClick={() => handleDelete(u.id)} className="text-red-600 hover:text-red-800">
-                    <Trash2 className="w-4 h-4" />
-                  </button>
-                </li>
-              ))}
-            </ul>
-          </CardContent>
-        </Card>
+  const getRoleColor = (role: string) => {
+    switch (role) {
+      case 'Admin':
+        return 'bg-red-100 text-red-800 border-red-200';
+      case 'Analyst':
+        return 'bg-blue-100 text-blue-800 border-blue-200';
+      case 'Viewer':
+        return 'bg-gray-100 text-gray-800 border-gray-200';
+      default:
+        return 'bg-gray-100 text-gray-800 border-gray-200';
+    }
+  };
+
+  const getStatusColor = (status: string) => {
+    return status === 'Active'
+      ? 'bg-green-100 text-green-800 border-green-200'
+      : 'bg-gray-100 text-gray-800 border-gray-200';
+  };
+
+  const filteredUsers = users.filter((u) => {
+    const matchesSearch =
+      u.username.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      u.email.toLowerCase().includes(searchTerm.toLowerCase());
+    const role = getRole(u);
+    const status = getStatus(u);
+    const matchesRole = selectedRole === 'All' || role === selectedRole;
+    const matchesStatus = selectedStatus === 'All' || status === selectedStatus;
+    return matchesSearch && matchesRole && matchesStatus;
+  });
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-gray-50">
+      <Header />
+      <div className="max-w-7xl mx-auto px-6 py-8">
+        <div className="mb-8">
+          <div className="flex items-center justify-between mb-6">
+            <div className="flex items-center space-x-4">
+              <div className="w-12 h-12 rounded-xl bg-gradient-to-r from-purple-500 to-indigo-600 flex items-center justify-center shadow-lg">
+                <UsersIcon className="w-6 h-6 text-white" />
+              </div>
+              <div>
+                <h1 className="text-3xl font-bold text-gray-900">User Management</h1>
+                <p className="text-gray-600">Manage user accounts, roles, and permissions</p>
+              </div>
+            </div>
+            <Button
+              className="bg-gradient-to-r from-purple-500 to-indigo-600 hover:opacity-90 shadow-lg hover:shadow-xl transition-all duration-300"
+              onClick={() => setShowAddForm((v) => !v)}
+            >
+              {showAddForm ? (
+                <>
+                  <X className="w-4 h-4 mr-2" /> Cancel
+                </>
+              ) : (
+                <>
+                  <Plus className="w-4 h-4 mr-2" /> Add User
+                </>
+              )}
+            </Button>
+          </div>
+
+          {showAddForm && (
+            <Card className="mb-8 p-6 bg-white border-0 shadow-lg">
+              <form onSubmit={handleAddUser} className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <Input
+                  name="username"
+                  placeholder="Username"
+                  value={form.username}
+                  onChange={handleFormChange}
+                  className="border-gray-200"
+                />
+                <Input
+                  name="password"
+                  type="password"
+                  placeholder="Password"
+                  value={form.password}
+                  onChange={handleFormChange}
+                  className="border-gray-200"
+                />
+                <Input
+                  name="email"
+                  type="email"
+                  placeholder="Email"
+                  value={form.email}
+                  onChange={handleFormChange}
+                  className="border-gray-200"
+                />
+                <div className="md:col-span-3 flex justify-end">
+                  <Button type="submit" className="bg-gradient-to-r from-green-500 to-emerald-600">
+                    <Save className="w-4 h-4 mr-2" /> Save User
+                  </Button>
+                </div>
+              </form>
+            </Card>
+          )}
+
+          <div className="flex flex-col md:flex-row gap-4 mb-6">
+            <div className="relative flex-1">
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4" />
+              <Input
+                placeholder="Search users by name or email..."
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                className="pl-10 border-gray-200 focus:ring-2 focus:ring-purple-500 focus:border-transparent"
+              />
+            </div>
+
+            <div className="flex gap-2">
+              <select
+                value={selectedRole}
+                onChange={(e) => setSelectedRole(e.target.value)}
+                className="px-4 py-2 border border-gray-200 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent"
+              >
+                <option value="All">All Roles</option>
+                <option value="Admin">Admin</option>
+                <option value="Analyst">Analyst</option>
+                <option value="Viewer">Viewer</option>
+              </select>
+
+              <select
+                value={selectedStatus}
+                onChange={(e) => setSelectedStatus(e.target.value)}
+                className="px-4 py-2 border border-gray-200 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-transparent"
+              >
+                <option value="All">All Status</option>
+                <option value="Active">Active</option>
+                <option value="Inactive">Inactive</option>
+              </select>
+            </div>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {filteredUsers.map((user) => {
+            const role = getRole(user);
+            const status = getStatus(user);
+            const initials = (
+              user.first_name?.[0] || user.username[0]
+            ) + (user.last_name?.[0] || '');
+            return (
+              <Card key={user.id} className="p-6 hover:shadow-xl transition-all duration-300 border-0 bg-white/80 backdrop-blur-sm">
+                <div className="flex items-start justify-between mb-4">
+                  <div className="flex items-center space-x-3">
+                    <div className="w-12 h-12 rounded-full bg-gradient-to-r from-gray-200 to-gray-300 flex items-center justify-center">
+                      <span className="text-gray-700 font-semibold text-lg">{initials}</span>
+                    </div>
+                    <div>
+                      <h3 className="font-semibold text-gray-900">{user.username}</h3>
+                      {user.first_name && (
+                        <p className="text-sm text-gray-600">{user.first_name} {user.last_name}</p>
+                      )}
+                    </div>
+                  </div>
+
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="ghost" size="sm" className="p-2">
+                        <MoreVertical className="w-4 h-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end" className="bg-white border border-gray-200 shadow-lg">
+                      <DropdownMenuItem className="cursor-pointer" disabled>
+                        <Edit className="w-4 h-4 mr-2" /> Edit User
+                      </DropdownMenuItem>
+                      <DropdownMenuItem className="cursor-pointer text-red-600 focus:text-red-700" onSelect={() => handleDelete(user.id)}>
+                        <Trash2 className="w-4 h-4 mr-2" /> Delete User
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
+
+                <div className="space-y-3">
+                  <div className="flex items-center space-x-2 text-sm text-gray-600">
+                    <Mail className="w-4 h-4" />
+                    <span>{user.email}</span>
+                  </div>
+                  {user.phone && (
+                    <div className="flex items-center space-x-2 text-sm text-gray-600">
+                      <Phone className="w-4 h-4" />
+                      <span>{user.phone}</span>
+                    </div>
+                  )}
+                  {user.last_login && (
+                    <div className="flex items-center space-x-2 text-sm text-gray-600">
+                      <Calendar className="w-4 h-4" />
+                      <span>Last login: {new Date(user.last_login).toLocaleDateString()}</span>
+                    </div>
+                  )}
+                </div>
+
+                <div className="flex items-center justify-between mt-4 pt-4 border-t border-gray-100">
+                  <div className="flex space-x-2">
+                    <Badge className={`text-xs border ${getRoleColor(role)}`}>
+                      <Shield className="w-3 h-3 mr-1" /> {role}
+                    </Badge>
+                    <Badge className={`text-xs border ${getStatusColor(status)}`}>{status}</Badge>
+                  </div>
+                </div>
+              </Card>
+            );
+          })}
+        </div>
+
+        {filteredUsers.length === 0 && (
+          <div className="text-center py-16">
+            <UsersIcon className="w-16 h-16 text-gray-400 mx-auto mb-4" />
+            <h3 className="text-xl font-semibold text-gray-900 mb-2">No users found</h3>
+            <p className="text-gray-500 mb-6">Try adjusting your search or filter criteria</p>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- redirect login success to `/apps`
- navigate from app list to filtered projects page
- filter projects by app in the Django API
- adjust protected routes for new flow
- create projects from the projects page using the selected app

## Testing
- `npm run lint`
- `pytest -q TrinityBackendFastAPI/tests`

------
https://chatgpt.com/codex/tasks/task_e_685142a61eb083219f88e2ef7afa5e3a