### PR TITLE
Integrate data upload validate atom

### DIFF
--- a/TrinityBackendFastAPI/app/features/data_upload_validate/app/routes.py
+++ b/TrinityBackendFastAPI/app/features/data_upload_validate/app/routes.py
@@ -1869,6 +1869,23 @@ async def delete_validator_atom(validator_atom_id: str):
     }
 
 
+# GET: GET_VALIDATOR_CONFIG - return validator setup with MongoDB details
+@router.get("/get_validator_config/{validator_atom_id}")
+async def get_validator_config(validator_atom_id: str):
+    """Retrieve stored validator atom configuration along with any
+    classification or dimension information."""
+
+    validator_data = get_validator_atom_from_mongo(validator_atom_id)
+    if not validator_data:
+        validator_data = get_validator_from_memory_or_disk(validator_atom_id)
+
+    if not validator_data:
+        raise HTTPException(status_code=404, detail=f"Validator atom '{validator_atom_id}' not found")
+
+    extra = load_all_non_validation_data(validator_atom_id)
+    return {**validator_data, **extra}
+
+
 ############################prebuild
 
 # # ✅ UPDATED: Complete MMM Validation Endpoint with MinIO Upload

--- a/TrinityFrontend/src/components/AtomList/atoms/data-upload-validate/DataUploadPage.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/data-upload-validate/DataUploadPage.tsx
@@ -101,7 +101,7 @@ const DataUploadPage: React.FC = () => {
       form.append('validator_atom_id', 'demo-validator');
       form.append('files', file);
       form.append('file_keys', JSON.stringify(['data']));
-      const res = await fetch(`${VALIDATE_API}/create_new`, {
+      const res = await fetch(`${VALIDATE_API}/validate`, {
         method: 'POST',
         body: form,
       });

--- a/TrinityFrontend/src/components/AtomList/atoms/data-upload-validate/components/FileUploadInterface.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/data-upload-validate/components/FileUploadInterface.tsx
@@ -57,7 +57,7 @@ const FileUploadInterface: React.FC<FileUploadInterfaceProps> = ({
       form.append('validator_atom_id', 'demo-validator');
       uploadedFiles.forEach((f) => form.append('files', f));
       form.append('file_keys', JSON.stringify(['data']));
-      const res = await fetch(`${VALIDATE_API}/create_new`, {
+      const res = await fetch(`${VALIDATE_API}/validate`, {
         method: 'POST',
         body: form,
       });

--- a/data_upload_validation.txt
+++ b/data_upload_validation.txt
@@ -1,0 +1,36 @@
+The Data Upload & Validate atom connects the React frontend under
+`TrinityFrontend/src/components/AtomList/atoms/data-upload-validate`
+with the FastAPI service in
+`TrinityBackendFastAPI/app/features/data_upload_validate`.
+
+User flow
+---------
+1. In the atom property panel the user uploads master/template files.
+   The component posts the files to `POST /api/data-upload-validate/create_new`
+   which returns the generated validator id. Column types are fetched from
+   `GET /api/data-upload-validate/get_validator_config/<id>`.
+2. After selecting a master file the user can modify data types, value ranges
+   and frequency requirements. Clicking **Save Configuration** sends
+   `POST /api/data-upload-validate/update_column_types` followed by
+   `POST /api/data-upload-validate/configure_validation_config` to persist the
+   validation rules.
+3. Required master files appear in the UI. When data files are uploaded the
+   **Validate Files** action posts the files to `POST /api/data-upload-validate/validate`.
+   Each file response is displayed as success or failure.
+
+Endpoints
+---------
+- `POST /api/data-upload-validate/create_new` – create validator from master files.
+- `GET  /api/data-upload-validate/get_validator_config/{validator_id}` – return
+  stored schemas, column types and saved metadata.
+- `POST /api/data-upload-validate/update_column_types` – update detected column
+  types for a file key.
+- `POST /api/data-upload-validate/configure_validation_config` – store custom
+  conditions and date frequency checks.
+- `POST /api/data-upload-validate/validate` – validate uploaded files using the
+  configured rules.
+- `DELETE /api/data-upload-validate/delete_validator_atom/{validator_id}` –
+  remove a validator and all associated metadata.
+
+The frontend uses `VALIDATE_API` from `src/lib/api.ts` to resolve the base URL
+for these endpoints.


### PR DESCRIPTION
## Summary
- add backend endpoint for fetching validator configuration
- update file upload interface to use `/validate`
- call `/validate` from the standalone page
- hook properties panel to backend for creating validators and saving config
- document upload & validation flow

## Testing
- `npm run lint`
- `python -m py_compile TrinityBackendFastAPI/app/features/data_upload_validate/app/routes.py`


------
https://chatgpt.com/codex/tasks/task_e_685400995c0c8321907168665114336d