### PR TITLE
Fix pip timeout in Docker builds

### DIFF
--- a/TrinityAI/Agent_fetch_atom/Dockerfile
+++ b/TrinityAI/Agent_fetch_atom/Dockerfile
@@ -1,7 +1,9 @@
 FROM python:3.11-slim
 WORKDIR /app
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+# Increase pip's network timeout to avoid timeouts when
+# downloading large dependencies like PyTorch
+RUN pip install --no-cache-dir --timeout 1000 -r requirements.txt
 COPY . .
 RUN python download_model.py
 CMD ["uvicorn", "main_api:app", "--host", "0.0.0.0", "--port", "8002"]

--- a/TrinityBackendDjango/Dockerfile
+++ b/TrinityBackendDjango/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && \
 # 5. Copy and install Python deps into venv
 COPY requirements.txt .
 RUN pip install --upgrade pip \
-    && pip install -r requirements.txt \
+    && pip install --timeout 1000 -r requirements.txt \
     && pip install gunicorn django-guardian  # ensure guardian & gunicorn are present
 
 # 6. Copy project files

--- a/TrinityBackendFastAPI/Dockerfile
+++ b/TrinityBackendFastAPI/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y \
 # Copy requirements and install them
 COPY requirements.txt .
 RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir -r requirements.txt
+    pip install --no-cache-dir --timeout 1000 -r requirements.txt
 
 # Copy application code
 COPY . .


### PR DESCRIPTION
## Summary
- avoid read timeouts when installing dependencies
- extend pip timeout in the AI, Django and FastAPI Dockerfiles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864d0944a3483219240ad8a8ee7a307