### PR TITLE
Auto populate Feature Overview via Arrow Flight

### DIFF
--- a/TrinityBackendFastAPI/app/features/data_upload_validate/app/routes.py
+++ b/TrinityBackendFastAPI/app/features/data_upload_validate/app/routes.py
@@ -3004,7 +3004,7 @@ async def save_dataframes(
             writer.write_table(table)
 
         result = upload_to_minio(arrow_buf.getvalue(), arrow_name, validator_atom_id, key)
-        flight_path = f"{validator_atom_id}/{key}"
+        flight_path = f"{validator_atom_id}/{Path(key).stem}.arrow"
         upload_dataframe(df, flight_path)
 
         set_ticket(

--- a/TrinityBackendFastAPI/app/features/data_upload_validate/app/routes.py
+++ b/TrinityBackendFastAPI/app/features/data_upload_validate/app/routes.py
@@ -3004,7 +3004,8 @@ async def save_dataframes(
             writer.write_table(table)
 
         result = upload_to_minio(arrow_buf.getvalue(), arrow_name, validator_atom_id, key)
-        flight_path = f"{validator_atom_id}/{Path(key).stem}.arrow"
+        saved_name = Path(result.get("object_name", "")).name or arrow_name
+        flight_path = f"{validator_atom_id}/{saved_name}"
         upload_dataframe(df, flight_path)
 
         set_ticket(

--- a/TrinityBackendFastAPI/app/features/feature_overview/routes.py
+++ b/TrinityBackendFastAPI/app/features/feature_overview/routes.py
@@ -192,10 +192,10 @@ async def cached_dataframe(object_name: str):
 
 
 @router.get("/flight_table")
-async def flight_table(object_name: str, flight_path: str | None = None):
+async def flight_table(object_name: str):
     """Return the Arrow IPC file for the given object via Arrow Flight."""
     object_name = unquote(object_name)
-    flight_path = unquote(flight_path) if flight_path else get_flight_path_for_csv(object_name)
+    flight_path = get_flight_path_for_csv(object_name)
     print(f"➡️ flight_table request: {object_name} path={flight_path}")
     if not flight_path:
         raise HTTPException(status_code=404, detail="Flight path not found")

--- a/TrinityBackendFastAPI/app/utils/arrow_client.py
+++ b/TrinityBackendFastAPI/app/utils/arrow_client.py
@@ -3,6 +3,7 @@ import logging
 import pandas as pd
 import pyarrow as pa
 import pyarrow.flight as flight
+import pyarrow.ipc as ipc
 
 _client: flight.FlightClient | None = None
 logger = logging.getLogger("trinity.flight")

--- a/TrinityBackendFastAPI/app/utils/arrow_client.py
+++ b/TrinityBackendFastAPI/app/utils/arrow_client.py
@@ -54,7 +54,8 @@ def download_table_bytes(path: str) -> bytes:
         sink = pa.BufferOutputStream()
         with ipc.new_file(sink, reader.schema) as writer:
             for chunk in reader:
-                writer.write_batch(chunk)
+                # each chunk is a FlightStreamChunk, so use its .data RecordBatch
+                writer.write_batch(chunk.data)
         logger.info("✔️ downloaded arrow bytes %s", path)
         return sink.getvalue().to_pybytes()
     except Exception as e:

--- a/TrinityFrontend/src/components/AtomList/atoms/data-upload-validate/DataFrameView.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/data-upload-validate/DataFrameView.tsx
@@ -40,7 +40,7 @@ const DataFrameView = () => {
           <TableBody>
             {rows.slice(1).map((r, i) => (
               <TableRow key={i}>
-                {r.map((c, j) => (
+                {(Array.isArray(r) ? r : []).map((c, j) => (
                   <TableCell key={j}>{c}</TableCell>
                 ))}
               </TableRow>

--- a/TrinityFrontend/src/components/AtomList/atoms/feature-overview/components/FeatureOverviewCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/feature-overview/components/FeatureOverviewCanvas.tsx
@@ -223,7 +223,7 @@ const FeatureOverviewCanvas: React.FC<FeatureOverviewCanvasProps> = ({ settings,
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {summaryList.map((c: ColumnInfo) => (
+                    {Array.isArray(summaryList) && summaryList.map((c: ColumnInfo) => (
                       <TableRow key={c.column} className="hover:bg-blue-50/50 transition-all duration-200 border-b border-gray-100">
                         <TableCell className="font-semibold text-gray-900 text-center py-4">{c.column}</TableCell>
                         <TableCell className="text-center py-4">

--- a/TrinityFrontend/src/components/AtomList/atoms/feature-overview/components/FeatureOverviewSettings.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/feature-overview/components/FeatureOverviewSettings.tsx
@@ -55,6 +55,9 @@ const FeatureOverviewSettings: React.FC<FeatureOverviewSettingsProps> = ({ setti
   }, [settings.allColumns, settings.selectedColumns]);
 
   const handleFrameChange = async (val: string) => {
+    if (!val.endsWith('.arrow')) {
+      val += '.arrow';
+    }
     setSelectedIds([]);
     const res = await fetch(
       `${FEATURE_OVERVIEW_API}/column_summary?object_name=${encodeURIComponent(val)}`

--- a/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea.tsx
@@ -111,7 +111,7 @@ const CanvasArea: React.FC<CanvasAreaProps> = ({ onAtomSelect, onCardSelect, sel
       if (flightPath) {
         console.log('✈️ fetching flight table', flightPath);
         const fr = await fetch(
-          `${FEATURE_OVERVIEW_API}/flight_table?object_name=${encodeURIComponent(name)}`
+          `${FEATURE_OVERVIEW_API}/flight_table?object_name=${encodeURIComponent(name)}&flight_path=${encodeURIComponent(flightPath)}`
         );
         if (fr.ok) {
           await fr.arrayBuffer();

--- a/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea.tsx
@@ -106,17 +106,15 @@ const CanvasArea: React.FC<CanvasAreaProps> = ({ onAtomSelect, onCardSelect, sel
     }
   };
 
-  const prefetchDataframe = async (name: string, flightPath?: string) => {
+  const prefetchDataframe = async (name: string) => {
     try {
-      if (flightPath) {
-        console.log('✈️ fetching flight table', flightPath);
-        const fr = await fetch(
-          `${FEATURE_OVERVIEW_API}/flight_table?object_name=${encodeURIComponent(name)}&flight_path=${encodeURIComponent(flightPath)}`
-        );
-        if (fr.ok) {
-          await fr.arrayBuffer();
-          console.log('✅ fetched flight table', name);
-        }
+      console.log('✈️ fetching flight table', name);
+      const fr = await fetch(
+        `${FEATURE_OVERVIEW_API}/flight_table?object_name=${encodeURIComponent(name)}`
+      );
+      if (fr.ok) {
+        await fr.arrayBuffer();
+        console.log('✅ fetched flight table', name);
       }
       console.log('🔎 prefetching dataframe', name);
       const res = await fetch(
@@ -147,7 +145,6 @@ const CanvasArea: React.FC<CanvasAreaProps> = ({ onAtomSelect, onCardSelect, sel
             csv: a.settings.dataSource,
             display: a.settings.csvDisplay || a.settings.dataSource,
             identifiers: a.settings.selectedColumns || [],
-            flightPath: undefined,
             ...(cols || {}),
           };
         }
@@ -166,7 +163,7 @@ const CanvasArea: React.FC<CanvasAreaProps> = ({ onAtomSelect, onCardSelect, sel
                 const ticket = await ticketRes.json();
                 if (ticket.arrow_name) {
                   console.log('✔️ using validated data source', ticket.arrow_name);
-                  await prefetchDataframe(ticket.arrow_name, ticket.flight_path);
+                  await prefetchDataframe(ticket.arrow_name);
                   const cols = await fetchColumnSummary(ticket.arrow_name);
                   let ids: string[] = [];
                   if (confRes && confRes.ok) {
@@ -178,7 +175,6 @@ const CanvasArea: React.FC<CanvasAreaProps> = ({ onAtomSelect, onCardSelect, sel
                     csv: ticket.arrow_name,
                     display: ticket.csv_name,
                     identifiers: ids,
-                    flightPath: ticket.flight_path,
                     ...(cols || {}),
                   };
                 }
@@ -217,7 +213,7 @@ const CanvasArea: React.FC<CanvasAreaProps> = ({ onAtomSelect, onCardSelect, sel
       return;
     }
     console.log('ℹ️ prefill data source details', prev);
-    await prefetchDataframe(prev.csv, prev.flightPath);
+    await prefetchDataframe(prev.csv);
     console.log('✅ pre-filling feature overview with', prev.csv);
     const summary = Array.isArray(prev.summary) ? prev.summary : [];
     const identifiers = Array.isArray(prev.identifiers) ? prev.identifiers : [];

--- a/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea.tsx
@@ -107,6 +107,7 @@ const CanvasArea: React.FC<CanvasAreaProps> = ({ onAtomSelect, onCardSelect, sel
   };
 
   const prefetchDataframe = async (name: string) => {
+    if (!name) return;
     try {
       console.log('✈️ fetching flight table', name);
       const fr = await fetch(

--- a/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea.tsx
@@ -678,9 +678,10 @@ const addNewCard = (moleculeId?: string, position?: number) => {
                   </div>
 
                   <div className="space-y-6 w-full">
-                    {layoutCards
-                      .filter(card => card.moleculeId === molecule.moleculeId)
-                      .map(card => {
+                    {Array.isArray(layoutCards) &&
+                      layoutCards
+                        .filter(card => card.moleculeId === molecule.moleculeId)
+                        .map(card => {
                         const cardTitle = card.moleculeTitle
                           ? card.atoms.length > 0
                             ? `${card.moleculeTitle} - ${card.atoms[0].title}`
@@ -815,7 +816,7 @@ const addNewCard = (moleculeId?: string, position?: number) => {
     <div className="h-full w-full bg-gradient-to-br from-gray-50 to-gray-100 rounded-xl border border-gray-200 shadow-sm overflow-auto">
       {/* Layout Cards Container */}
       <div className="p-6 space-y-6 w-full">
-        {layoutCards.map((card, index) => {
+        {Array.isArray(layoutCards) && layoutCards.map((card, index) => {
           const cardTitle = card.moleculeTitle
             ? (card.atoms.length > 0 ? `${card.moleculeTitle} - ${card.atoms[0].title}` : card.moleculeTitle)
             : card.atoms.length > 0


### PR DESCRIPTION
## Summary
- add `/flight_table` endpoint to stream Arrow tables through Flight
- prefetch feature overview data via Arrow Flight when dropping the atom
- ensure data source selector accepts `.arrow` files automatically

## Testing
- `pytest TrinityBackendFastAPI/tests/test_arrow_flight.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68668b71e0d08321bcf5a0d8bb057617