### PR TITLE
Fix feature overview disappearing

### DIFF
--- a/TrinityFrontend/src/components/AtomList/atoms/feature-overview/FeatureOverviewAtom.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/feature-overview/FeatureOverviewAtom.tsx
@@ -12,7 +12,7 @@ const FeatureOverviewAtom: React.FC<Props> = ({ atomId }) => {
   const settings: SettingsType = (atom?.settings as SettingsType) || { ...DEFAULT_FEATURE_OVERVIEW_SETTINGS };
 
   return (
-    <div className="w-full h-full bg-white rounded-lg overflow-hidden flex flex-col">
+    <div className="w-full h-full bg-white rounded-lg overflow-hidden flex flex-col mb-2">
       <FeatureOverviewCanvas
         settings={settings}
         onUpdateSettings={s => updateSettings(atomId, s)}

--- a/TrinityFrontend/src/components/AtomList/atoms/feature-overview/FeatureOverviewAtom.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/feature-overview/FeatureOverviewAtom.tsx
@@ -12,7 +12,7 @@ const FeatureOverviewAtom: React.FC<Props> = ({ atomId }) => {
   const settings: SettingsType = (atom?.settings as SettingsType) || { ...DEFAULT_FEATURE_OVERVIEW_SETTINGS };
 
   return (
-    <div className="w-full h-full bg-white rounded-lg overflow-hidden flex flex-col mb-2">
+    <div className="w-full h-full bg-white rounded-lg overflow-hidden flex flex-col mb-[18px]">
       <FeatureOverviewCanvas
         settings={settings}
         onUpdateSettings={s => updateSettings(atomId, s)}

--- a/TrinityFrontend/src/components/AtomList/atoms/feature-overview/FeatureOverviewAtom.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/feature-overview/FeatureOverviewAtom.tsx
@@ -12,7 +12,7 @@ const FeatureOverviewAtom: React.FC<Props> = ({ atomId }) => {
   const settings: SettingsType = (atom?.settings as SettingsType) || { ...DEFAULT_FEATURE_OVERVIEW_SETTINGS };
 
   return (
-    <div className="w-full h-full bg-white rounded-lg overflow-hidden flex flex-col mb-[50px]">
+    <div className="w-full h-full bg-white rounded-lg overflow-hidden flex flex-col">
       <FeatureOverviewCanvas
         settings={settings}
         onUpdateSettings={s => updateSettings(atomId, s)}

--- a/TrinityFrontend/src/components/AtomList/atoms/feature-overview/FeatureOverviewAtom.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/feature-overview/FeatureOverviewAtom.tsx
@@ -12,10 +12,11 @@ const FeatureOverviewAtom: React.FC<Props> = ({ atomId }) => {
   const settings: SettingsType = (atom?.settings as SettingsType) || { ...DEFAULT_FEATURE_OVERVIEW_SETTINGS };
 
   return (
-    <div className="w-full h-full bg-white">
-      <div className="h-full flex flex-col">
-        <FeatureOverviewCanvas settings={settings} onUpdateSettings={(s)=>updateSettings(atomId,s)} />
-      </div>
+    <div className="w-full h-full bg-white rounded-lg overflow-hidden flex flex-col">
+      <FeatureOverviewCanvas
+        settings={settings}
+        onUpdateSettings={s => updateSettings(atomId, s)}
+      />
     </div>
   );
 };

--- a/TrinityFrontend/src/components/AtomList/atoms/feature-overview/FeatureOverviewAtom.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/feature-overview/FeatureOverviewAtom.tsx
@@ -12,7 +12,7 @@ const FeatureOverviewAtom: React.FC<Props> = ({ atomId }) => {
   const settings: SettingsType = (atom?.settings as SettingsType) || { ...DEFAULT_FEATURE_OVERVIEW_SETTINGS };
 
   return (
-    <div className="w-full h-full bg-white rounded-lg overflow-hidden flex flex-col mb-[18px]">
+    <div className="w-full h-full bg-white rounded-lg overflow-hidden flex flex-col mb-[50px]">
       <FeatureOverviewCanvas
         settings={settings}
         onUpdateSettings={s => updateSettings(atomId, s)}

--- a/TrinityFrontend/src/components/AtomList/atoms/feature-overview/components/FeatureOverviewCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/feature-overview/components/FeatureOverviewCanvas.tsx
@@ -197,7 +197,7 @@ const FeatureOverviewCanvas: React.FC<FeatureOverviewCanvasProps> = ({ settings,
   };
 
   return (
-    <div className="w-full h-full p-6 bg-gradient-to-br from-slate-50 to-blue-50 overflow-y-auto">
+    <div className="w-full h-full p-6 pb-[50px] bg-gradient-to-br from-slate-50 to-blue-50 overflow-y-auto">
       {error && (
         <div className="mb-4 text-sm text-red-600 font-medium" data-testid="fo-error">
           {error}

--- a/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea.tsx
@@ -682,7 +682,7 @@ const addNewCard = (moleculeId?: string, position?: number) => {
                         return (
                         <Card
                           key={card.id}
-                          className={`w-full min-h-[200px] bg-white rounded-2xl border-2 transition-all duration-300 flex flex-col ${
+                          className={`w-full min-h-[200px] bg-white rounded-2xl border-2 transition-all duration-300 flex flex-col overflow-hidden ${
                             dragOver === card.id
                               ? 'border-[#458EE2] bg-gradient-to-br from-blue-50 to-blue-100 shadow-lg'
                               : 'border-gray-200 shadow-sm hover:shadow-md'
@@ -741,7 +741,7 @@ const addNewCard = (moleculeId?: string, position?: number) => {
                                 {card.atoms.map(atom => (
                                   <AtomBox
                                     key={atom.id}
-                                    className="p-4 cursor-pointer hover:shadow-lg transition-all duration-200 group border border-gray-200 bg-white"
+                                    className="p-4 cursor-pointer hover:shadow-lg transition-all duration-200 group border border-gray-200 bg-white overflow-hidden"
                                     onClick={(e) => handleAtomClick(e, atom.id)}
                                   >
                                     <div className="flex items-center justify-between mb-3">
@@ -877,7 +877,7 @@ const addNewCard = (moleculeId?: string, position?: number) => {
                   {card.atoms.map((atom) => (
                     <AtomBox
                       key={atom.id}
-                      className="p-4 cursor-pointer hover:shadow-lg transition-all duration-200 group border border-gray-200 bg-white"
+                      className="p-4 cursor-pointer hover:shadow-lg transition-all duration-200 group border border-gray-200 bg-white overflow-hidden"
                       onClick={(e) => handleAtomClick(e, atom.id)}
                     >
                       {/* Atom Header */}

--- a/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea.tsx
@@ -228,34 +228,34 @@ const CanvasArea: React.FC<CanvasAreaProps> = ({ onAtomSelect, onCardSelect, sel
         ? identifiers
         : (Array.isArray(summary) ? summary : []).map(cc => cc.column);
 
-    setLayoutCards(cards =>
-      cards.map(c =>
-        c.id === cardId
-          ? {
-              ...c,
-              atoms: c.atoms.map(a =>
-                a.id === atomId
-                  ? {
-                      ...a,
-                      settings: {
-                        ...(a.settings || {}),
-                        dataSource: prev.csv,
-                        csvDisplay: prev.display || prev.csv,
-                        allColumns: summary,
-                        columnSummary: filtered,
-                        selectedColumns: selected,
-                        numericColumns: Array.isArray(prev.numeric)
-                          ? prev.numeric
-                          : [],
-                        xAxis: prev.xField || 'date',
-                      },
-                    }
-                  : a
-              ),
-            }
-          : c
-      )
+    const currentCards = useLaboratoryStore.getState().cards;
+    const updatedCards = (Array.isArray(currentCards) ? currentCards : []).map(c =>
+      c.id === cardId
+        ? {
+            ...c,
+            atoms: c.atoms.map(a =>
+              a.id === atomId
+                ? {
+                    ...a,
+                    settings: {
+                      ...(a.settings || {}),
+                      dataSource: prev.csv,
+                      csvDisplay: prev.display || prev.csv,
+                      allColumns: summary,
+                      columnSummary: filtered,
+                      selectedColumns: selected,
+                      numericColumns: Array.isArray(prev.numeric)
+                        ? prev.numeric
+                        : [],
+                      xAxis: prev.xField || 'date',
+                    },
+                  }
+                : a
+            ),
+          }
+        : c
     );
+    setLayoutCards(updatedCards);
   };
 
   // Load saved layout and workflow rendering

--- a/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea.tsx
@@ -732,7 +732,7 @@ const addNewCard = (moleculeId?: string, position?: number) => {
                               </div>
                             ) : (
                               <div
-                                className={`grid gap-4 w-full ${
+                                className={`grid gap-4 w-full pb-4 ${
                                   card.atoms.length === 1
                                     ? 'grid-cols-1'
                                     : 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3'
@@ -868,7 +868,7 @@ const addNewCard = (moleculeId?: string, position?: number) => {
                 </div>
               ) : (
                 <div
-                  className={`grid gap-4 w-full ${
+                  className={`grid gap-4 w-full pb-4 ${
                     card.atoms.length === 1
                       ? 'grid-cols-1'
                       : 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3'

--- a/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea.tsx
@@ -732,7 +732,7 @@ const addNewCard = (moleculeId?: string, position?: number) => {
                               </div>
                             ) : (
                               <div
-                                className={`grid gap-4 w-full pb-4 ${
+                                className={`grid gap-4 w-full pb-[50px] ${
                                   card.atoms.length === 1
                                     ? 'grid-cols-1'
                                     : 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3'
@@ -868,7 +868,7 @@ const addNewCard = (moleculeId?: string, position?: number) => {
                 </div>
               ) : (
                 <div
-                  className={`grid gap-4 w-full pb-4 ${
+                  className={`grid gap-4 w-full pb-[50px] ${
                     card.atoms.length === 1
                       ? 'grid-cols-1'
                       : 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3'

--- a/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea.tsx
@@ -228,34 +228,15 @@ const CanvasArea: React.FC<CanvasAreaProps> = ({ onAtomSelect, onCardSelect, sel
         ? identifiers
         : (Array.isArray(summary) ? summary : []).map(cc => cc.column);
 
-    const currentCards = useLaboratoryStore.getState().cards;
-    const updatedCards = (Array.isArray(currentCards) ? currentCards : []).map(c =>
-      c.id === cardId
-        ? {
-            ...c,
-            atoms: c.atoms.map(a =>
-              a.id === atomId
-                ? {
-                    ...a,
-                    settings: {
-                      ...(a.settings || {}),
-                      dataSource: prev.csv,
-                      csvDisplay: prev.display || prev.csv,
-                      allColumns: summary,
-                      columnSummary: filtered,
-                      selectedColumns: selected,
-                      numericColumns: Array.isArray(prev.numeric)
-                        ? prev.numeric
-                        : [],
-                      xAxis: prev.xField || 'date',
-                    },
-                  }
-                : a
-            ),
-          }
-        : c
-    );
-    setLayoutCards(updatedCards);
+    updateAtomSettings(atomId, {
+      dataSource: prev.csv,
+      csvDisplay: prev.display || prev.csv,
+      allColumns: summary,
+      columnSummary: filtered,
+      selectedColumns: selected,
+      numericColumns: Array.isArray(prev.numeric) ? prev.numeric : [],
+      xAxis: prev.xField || 'date',
+    });
   };
 
   // Load saved layout and workflow rendering

--- a/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea.tsx
@@ -732,7 +732,7 @@ const addNewCard = (moleculeId?: string, position?: number) => {
                               </div>
                             ) : (
                               <div
-                                className={`grid gap-4 w-full pb-[50px] ${
+                                className={`grid gap-4 w-full ${
                                   card.atoms.length === 1
                                     ? 'grid-cols-1'
                                     : 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3'
@@ -868,7 +868,7 @@ const addNewCard = (moleculeId?: string, position?: number) => {
                 </div>
               ) : (
                 <div
-                  className={`grid gap-4 w-full pb-[50px] ${
+                  className={`grid gap-4 w-full ${
                     card.atoms.length === 1
                       ? 'grid-cols-1'
                       : 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3'

--- a/dataFrameViewHelper.txt
+++ b/dataFrameViewHelper.txt
@@ -1,0 +1,64 @@
+Viewing Saved DataFrames
+=========================
+
+The platform allows you to open any dataframe saved through the **Data Upload & Validate** atom in a dedicated viewer tab. The viewer is implemented in React and styled using Tailwind CSS with shadcn/ui components.
+
+Libraries Used
+--------------
+- **React 18** with TypeScript
+- **react-router-dom** to parse the `name` query parameter
+- **lucide-react** for icons
+- **shadcn/ui** components (`Badge`, `Input`, `Table`, `Pagination`, etc.)
+- **Tailwind CSS** for utility classes
+
+Opening a Saved DataFrame
+-------------------------
+1. In Laboratory Mode, upload your dataset via the **Data Upload & Validate** atom and click **Save DataFrames**. The backend stores an Arrow file in MinIO.
+2. Open the auxiliary menu and click the database icon to reveal the **Saved DataFrames** panel.
+3. Each saved file is listed with its display name. Clicking a filename triggers `window.open('/dataframe?name=<object>', '_blank')` in `SavedDataFramesPanel.tsx` so the viewer opens in a new browser tab.
+4. The new tab renders `DataFrameView.tsx`. During `useEffect`, it fetches the CSV text from `${FEATURE_OVERVIEW_API}/cached_dataframe?object_name=<name>` and parses it into rows:
+
+```
+useEffect(() => {
+  if (!name) return;
+  fetch(`${FEATURE_OVERVIEW_API}/cached_dataframe?object_name=${encodeURIComponent(name)}`)
+    .then(res => res.text())
+    .then(text => {
+      const parsed = parseCSV(text);
+      const tableData: DataTableData = {
+        headers: parsed.headers,
+        rows: parsed.rows,
+        fileName: name.split('/').pop() || name,
+      };
+      setData(tableData);
+      setSettings(prev => ({ ...prev, selectedColumns: parsed.headers }));
+      setColumnFilters({});
+      setCurrentPage(1);
+    })
+    .catch(() => {
+      setData(null);
+    });
+}, [name]);
+```
+
+Replicating the Viewer
+----------------------
+1. Create a route `/dataframe` that renders the `DataFrameView` component.
+2. Read the `name` search parameter and fetch the CSV text from the backend endpoint above.
+3. Parse the text into headers and rows (see `parseCSV` in the source). Store the result in state.
+4. Render a table with sticky headers. The table supports:
+   - Sorting by clicking headers (`handleSort`).
+   - Search across all columns.
+   - Per-column filter menus with checkboxes.
+   - Pagination with a default of 25 rows per page.
+5. Use Tailwind classes to style elements (`bg-white`, `border-gray-200`, `rounded-lg`, etc.) so it matches the rest of the app.
+6. Icons like `Search`, `Grid3X3`, `Eye`, `Filter` come from `lucide-react` and appear in the toolbar.
+
+Style Guide
+-----------
+- Keep the outer container `min-h-screen bg-gray-50 flex flex-col` with a white header.
+- The table itself sits inside a `bg-white rounded-lg border` element for clarity.
+- Use gradients (e.g., `bg-gradient-to-r from-blue-50 to-purple-50`) for the header strip as in the original code.
+- Maintain consistent spacing using Tailwind’s `p-4`, `space-x-*` and `space-y-*` utilities.
+
+By following these steps and using the same libraries the Trinity interface uses, you can reproduce the saved dataframe viewer exactly.

--- a/dataFrameViewHelper.txt
+++ b/dataFrameViewHelper.txt
@@ -62,3 +62,16 @@ Style Guide
 - Maintain consistent spacing using Tailwind’s `p-4`, `space-x-*` and `space-y-*` utilities.
 
 By following these steps and using the same libraries the Trinity interface uses, you can reproduce the saved dataframe viewer exactly.
+
+Table Logic and Use of TanStack
+------------------------------
+The viewer does **not** rely on TanStack React Table or any other table library.
+Instead, it uses shadcn's lightweight `Table` components which are thin wrappers
+around the native `<table>` element styled with Tailwind CSS. All table
+behaviour—sorting, searching, per-column filtering and pagination—is coded
+manually in `DataFrameView.tsx` using React state.
+
+TanStack React Query **is** included for data fetching elsewhere in the app, but
+it plays no part in the table logic here. The shadcn components simply provide
+the markup structure, while the logic is built with custom React hooks and
+utility functions.


### PR DESCRIPTION
## Summary
- keep feature overview atom in store when filling with cached data

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6869806639d48321a102c9caed32f827