### PR TITLE
Fix cloudflared credentials path and update host IP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ Desktop.ini
 TrinityAI/Agent_fetch_atom/models/
 
 arrow_data/
+cloudflared/credentials.json

--- a/TrinityBackendDjango/.env
+++ b/TrinityBackendDjango/.env
@@ -5,7 +5,7 @@ POSTGRES_PASSWORD=trinity_pass
 CELERY_BROKER_URL=redis://redis:6379/0
 CELERY_RESULT_BACKEND=redis://redis:6379/1
 # IP address where the frontend and backend will be reachable
-HOST_IP=10.2.1.242
+HOST_IP=10.2.1.65
 # MongoDB connection string
 MONGO_URI=mongodb://mongo:27017/trinity
 

--- a/TrinityBackendDjango/.env.example
+++ b/TrinityBackendDjango/.env.example
@@ -1,5 +1,5 @@
 # IP address where the frontend and backend will be reachable
-HOST_IP=10.2.1.242
+HOST_IP=10.2.1.65
 
 DEBUG=true
 POSTGRES_DB=trinity

--- a/TrinityBackendDjango/config/settings.py
+++ b/TrinityBackendDjango/config/settings.py
@@ -36,7 +36,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # ------------------------------------------------------------------
 # Security
 # ------------------------------------------------------------------
-HOST_IP = os.getenv("HOST_IP", "10.2.1.242")
+HOST_IP = os.getenv("HOST_IP", "10.2.1.65")
 FRONTEND_URL = os.getenv("FRONTEND_URL", f"http://{HOST_IP}:8080")
 SECRET_KEY = os.getenv("SECRET_KEY", "change-me-in-production")
 DEBUG = os.getenv("DEBUG", "False") == "True"

--- a/TrinityFrontend/.env.example
+++ b/TrinityFrontend/.env.example
@@ -1,6 +1,6 @@
 # Example values for running everything on a single machine.
 # Change VITE_HOST_IP if you deploy to another host.
-VITE_HOST_IP=10.2.1.242
+VITE_HOST_IP=10.2.1.65
 # Optional overrides for specific APIs. Leave empty to use VITE_HOST_IP.
 VITE_ACCOUNTS_API=
 VITE_REGISTRY_API=

--- a/cloudflared/credentials.json.example
+++ b/cloudflared/credentials.json.example
@@ -1,0 +1,6 @@
+{
+  "AccountTag": "YOUR_ACCOUNT_TAG",
+  "TunnelID": "YOUR_TUNNEL_UUID",
+  "TunnelName": "trinity-tunnel",
+  "TunnelSecret": "REPLACE_WITH_BASE64_SECRET"
+}

--- a/tunneling_guide.txt
+++ b/tunneling_guide.txt
@@ -1,6 +1,6 @@
 # Cloudflare Tunnel Setup for Trinity Platform
 
-This guide explains how to expose the Dockerized Trinity application using Cloudflare Tunnel so the services are reachable at **quantmatrixai.com** and its subdomains.
+This guide explains how to expose the Dockerized Trinity application using Cloudflare Tunnel so the services are reachable at **quantmatrixai.com** and its subdomains. The examples assume your host IP is `10.2.1.65`.
 
 ## 1. Install cloudflared
 
@@ -23,7 +23,12 @@ This guide explains how to expose the Dockerized Trinity application using Cloud
 cloudflared tunnel create trinity-tunnel
 ```
 
-Copy the generated tunnel UUID. Cloudflare also saves a credentials JSON for the tunnel. Move this JSON inside the repository so Docker can mount it, e.g. `cloudflared/credentials.json`.
+Copy the generated tunnel UUID. Cloudflare also saves a credentials JSON for the tunnel. Move this JSON into `cloudflared/credentials.json` within the repository so Docker can mount it. Ensure the file is readable only by you:
+
+```bash
+cp ~/.cloudflared/<UUID>.json cloudflared/credentials.json
+chmod 600 cloudflared/credentials.json
+```
 
 ## 3. Configure DNS routing
 
@@ -55,7 +60,7 @@ ingress:
     service: http://web:8000
   - service: http_status:404
 ```
-Replace `YOUR_TUNNEL_UUID` with the ID from step 2. Place `credentials.json` (generated when the tunnel was created) inside the repository's `cloudflared` directory.
+Replace `YOUR_TUNNEL_UUID` with the ID from step 2. Copy the generated credentials file into `cloudflared/credentials.json` (an example `credentials.json.example` is provided). The Docker container mounts this path so Cloudflared can authenticate.
 
 ## 5. Docker Compose service
 


### PR DESCRIPTION
## Summary
- update default HOST_IP and env examples to 10.2.1.65
- ignore `cloudflared/credentials.json`
- add sample `cloudflared/credentials.json.example`
- document credential setup and host IP in tunneling guide

## Testing
- `pip install fastapi uvicorn pymongo redis boto3 pandas minio motor python-multipart pyarrow asyncpg`
- `pip install httpx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ca5ed500883218a30519a410ef180