### PR TITLE
Fix login path and add debug logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Follow the steps below to run all services together.
   ```
 
   The root domain (`quantmatrixai.com`) only serves the static frontend via
-  Nginx. When `VITE_BACKEND_ORIGIN` is not provided the frontend automatically
-  switches API calls to the `admin` subdomain. Configure Nginx as shown in
-  `TrinityFrontend/nginx.conf` if you want to proxy `/api/` paths instead.
+  Nginx. Configure Nginx as shown in `TrinityFrontend/nginx.conf` so `/api/`
+  paths are proxied to the Django container. Set `VITE_BACKEND_ORIGIN` only if
+  the APIs live on a different domain such as the `admin` subdomain.
 
 Docker and Node.js must be installed locally. The Python dependencies listed in
 `TrinityBackendDjango/requirements.txt` and

--- a/README.md
+++ b/README.md
@@ -28,10 +28,9 @@ Follow the steps below to run all services together.
 
   The root domain (`quantmatrixai.com`) only serves the static frontend via
   Nginx. Requests to `/api/` paths will return **405** unless they are proxied to
-  the Django backend or you use the `admin` subdomain. The frontend automatically
-  switches to `https://admin.quantmatrixai.com` when loaded from
-  `quantmatrixai.com`, but you can also set `VITE_BACKEND_ORIGIN` explicitly or
-  configure Nginx as shown in `TrinityFrontend/nginx.conf`.
+  the Django backend or you use the `admin` subdomain. Configure Nginx as shown
+  in `TrinityFrontend/nginx.conf` if hosting at the root domain, or set
+  `VITE_BACKEND_ORIGIN` explicitly when using a separate backend domain.
 
 Docker and Node.js must be installed locally. The Python dependencies listed in
 `TrinityBackendDjango/requirements.txt` and

--- a/README.md
+++ b/README.md
@@ -23,8 +23,14 @@ Follow the steps below to run all services together.
    Vite picks up the new value:
 
    ```bash
-   docker-compose build frontend
-   ```
+  docker-compose build frontend
+  ```
+
+  The root domain (`quantmatrixai.com`) only serves the static frontend via
+  Nginx. Requests to `/api/` paths will return **405** unless they are proxied to
+  the Django backend or you use the `admin` subdomain. Ensure your login requests
+  hit `https://admin.quantmatrixai.com/api/accounts/` or configure Nginx as in
+  `TrinityFrontend/nginx.conf`.
 
 Docker and Node.js must be installed locally. The Python dependencies listed in
 `TrinityBackendDjango/requirements.txt` and

--- a/README.md
+++ b/README.md
@@ -27,10 +27,9 @@ Follow the steps below to run all services together.
   ```
 
   The root domain (`quantmatrixai.com`) only serves the static frontend via
-  Nginx. Requests to `/api/` paths will return **405** unless they are proxied to
-  the Django backend or you use the `admin` subdomain. Configure Nginx as shown
-  in `TrinityFrontend/nginx.conf` if hosting at the root domain, or set
-  `VITE_BACKEND_ORIGIN` explicitly when using a separate backend domain.
+  Nginx. When `VITE_BACKEND_ORIGIN` is not provided the frontend automatically
+  switches API calls to the `admin` subdomain. Configure Nginx as shown in
+  `TrinityFrontend/nginx.conf` if you want to proxy `/api/` paths instead.
 
 Docker and Node.js must be installed locally. The Python dependencies listed in
 `TrinityBackendDjango/requirements.txt` and

--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ Follow the steps below to run all services together.
 
   The root domain (`quantmatrixai.com`) only serves the static frontend via
   Nginx. Requests to `/api/` paths will return **405** unless they are proxied to
-  the Django backend or you use the `admin` subdomain. Ensure your login requests
-  hit `https://admin.quantmatrixai.com/api/accounts/` or configure Nginx as in
-  `TrinityFrontend/nginx.conf`.
+  the Django backend or you use the `admin` subdomain. The frontend automatically
+  switches to `https://admin.quantmatrixai.com` when loaded from
+  `quantmatrixai.com`, but you can also set `VITE_BACKEND_ORIGIN` explicitly or
+  configure Nginx as shown in `TrinityFrontend/nginx.conf`.
 
 Docker and Node.js must be installed locally. The Python dependencies listed in
 `TrinityBackendDjango/requirements.txt` and

--- a/README.md
+++ b/README.md
@@ -27,9 +27,10 @@ Follow the steps below to run all services together.
   ```
 
   The root domain (`quantmatrixai.com`) only serves the static frontend via
-  Nginx. Configure Nginx as shown in `TrinityFrontend/nginx.conf` so `/api/`
-  paths are proxied to the Django container. Set `VITE_BACKEND_ORIGIN` only if
-  the APIs live on a different domain such as the `admin` subdomain.
+  Nginx. If `/api/` paths are not proxied to Django, the frontend automatically
+  uses `https://admin.quantmatrixai.com` for API calls. Set
+  `VITE_BACKEND_ORIGIN` to override this behavior or when hosting the APIs on a
+  completely different domain.
 
 Docker and Node.js must be installed locally. The Python dependencies listed in
 `TrinityBackendDjango/requirements.txt` and

--- a/TrinityBackendDjango/config/settings.py
+++ b/TrinityBackendDjango/config/settings.py
@@ -54,12 +54,15 @@ ADDITIONAL_DOMAINS = os.getenv("ADDITIONAL_DOMAINS", HOST_IP)
 # ------------------------------------------------------------------
 # CORS configuration
 # ------------------------------------------------------------------
-_cors = os.getenv("CORS_ALLOWED_ORIGINS")
-if _cors:
-    CORS_ALLOWED_ORIGINS = [o.strip() for o in _cors.split(",")]
-    CORS_ALLOW_ALL_ORIGINS = False
-else:
-    CORS_ALLOW_ALL_ORIGINS = True            # wildcard access for dev
+_default_cors = (
+    "https://quantmatrixai.com,"
+    "https://admin.quantmatrixai.com,"
+    "https://api.quantmatrixai.com"
+)
+CORS_ALLOWED_ORIGINS = [
+    o.strip() for o in os.getenv("CORS_ALLOWED_ORIGINS", _default_cors).split(",")
+]
+CORS_ALLOW_ALL_ORIGINS = False
 
 CORS_ALLOW_CREDENTIALS = True            # echo origin when cookies/auth supplied
 CORS_ALLOW_HEADERS = list(default_headers) + [

--- a/TrinityBackendDjango/config/settings.py
+++ b/TrinityBackendDjango/config/settings.py
@@ -47,8 +47,13 @@ ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "*").split(",")
 # Explicitly trust these origins for CSRF-protected requests such as the login
 # form. When deploying behind Cloudflare or another proxy, add your external
 # domain (e.g. "https://example.com") here so browser POSTs are accepted.
-_trusted = os.getenv("CSRF_TRUSTED_ORIGINS", FRONTEND_URL)
-CSRF_TRUSTED_ORIGINS = _trusted.split(",") if _trusted else []
+_default_csrf = (
+    "https://quantmatrixai.com,"
+    "https://admin.quantmatrixai.com,"
+    "https://api.quantmatrixai.com"
+)
+_trusted = os.getenv("CSRF_TRUSTED_ORIGINS", _default_csrf)
+CSRF_TRUSTED_ORIGINS = [o.strip() for o in _trusted.split(",") if o.strip()]
 ADDITIONAL_DOMAINS = os.getenv("ADDITIONAL_DOMAINS", HOST_IP)
 
 # ------------------------------------------------------------------

--- a/TrinityFrontend/nginx.conf
+++ b/TrinityFrontend/nginx.conf
@@ -4,6 +4,14 @@ server {
     server_name _;
     root /usr/share/nginx/html;
 
+    location /api/ {
+        proxy_pass http://web:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location / {
         try_files $uri $uri/ /index.html;
     }

--- a/TrinityFrontend/nginx.conf
+++ b/TrinityFrontend/nginx.conf
@@ -10,6 +10,18 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        # Allow CORS preflight requests to succeed when the frontend and backend
+        # share the same domain via this proxy
+        if ($request_method = 'OPTIONS') {
+            add_header Access-Control-Allow-Origin "$http_origin";
+            add_header Access-Control-Allow-Credentials true;
+            add_header Access-Control-Allow-Methods "GET,POST,PUT,DELETE,OPTIONS";
+            add_header Access-Control-Allow-Headers "Authorization,Content-Type";
+            add_header Access-Control-Max-Age 86400;
+            return 204;
+        }
+        add_header Access-Control-Allow-Origin "$http_origin";
+        add_header Access-Control-Allow-Credentials true;
     }
 
     location / {

--- a/TrinityFrontend/src/contexts/AuthContext.tsx
+++ b/TrinityFrontend/src/contexts/AuthContext.tsx
@@ -70,6 +70,13 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const login = async (username: string, password: string) => {
     console.log('Attempting login for', username);
     console.log('API base is', API_BASE);
+    console.log('Checking backend availability at', `${API_BASE}/users/me/`);
+    try {
+      const ping = await fetch(`${API_BASE}/users/me/`, { credentials: 'include' });
+      console.log('Backend check status', ping.status);
+    } catch (err) {
+      console.log('Backend check failed', err);
+    }
     console.log('Posting to', `${API_BASE}/login/`);
     const options = {
       method: 'POST',

--- a/TrinityFrontend/src/contexts/AuthContext.tsx
+++ b/TrinityFrontend/src/contexts/AuthContext.tsx
@@ -71,13 +71,15 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     console.log('Attempting login for', username);
     console.log('API base is', API_BASE);
     console.log('Posting to', `${API_BASE}/login/`);
+    const options = {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ username, password }),
+    };
+    console.log('Login fetch options', options);
     try {
-      const res = await fetch(`${API_BASE}/login/`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ username, password }),
-      });
+      const res = await fetch(`${API_BASE}/login/`, options);
       console.log('Login response headers', Array.from(res.headers.entries()));
       console.log('Login response status', res.status);
       if (res.ok) {

--- a/TrinityFrontend/src/contexts/AuthContext.tsx
+++ b/TrinityFrontend/src/contexts/AuthContext.tsx
@@ -69,6 +69,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   const login = async (username: string, password: string) => {
     console.log('Attempting login for', username);
+    console.log('API base is', API_BASE);
+    console.log('Posting to', `${API_BASE}/login/`);
     try {
       const res = await fetch(`${API_BASE}/login/`, {
         method: 'POST',
@@ -76,6 +78,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         credentials: 'include',
         body: JSON.stringify({ username, password }),
       });
+      console.log('Login response headers', Array.from(res.headers.entries()));
       console.log('Login response status', res.status);
       if (res.ok) {
         const data = await res.json();

--- a/TrinityFrontend/src/lib/api.ts
+++ b/TrinityFrontend/src/lib/api.ts
@@ -1,11 +1,22 @@
 const hostIp = import.meta.env.VITE_HOST_IP;
-let backendOrigin =
-  import.meta.env.VITE_BACKEND_ORIGIN ||
-  (hostIp
-    ? `http://${hostIp}:8000`
-    : typeof window !== 'undefined'
-      ? window.location.origin.replace(/:8080$/, ':8000')
-      : 'http://localhost:8000');
+let backendOrigin = import.meta.env.VITE_BACKEND_ORIGIN;
+
+if (!backendOrigin) {
+  if (hostIp) {
+    backendOrigin = `http://${hostIp}:8000`;
+  } else if (typeof window !== 'undefined') {
+    const origin = window.location.origin.replace(/:8080$/, ':8000');
+    const host = window.location.hostname;
+    if (host === 'quantmatrixai.com' || host === 'www.quantmatrixai.com') {
+      backendOrigin = 'https://admin.quantmatrixai.com';
+      console.log('Root domain detected, using admin subdomain', backendOrigin);
+    } else {
+      backendOrigin = origin;
+    }
+  } else {
+    backendOrigin = 'http://localhost:8000';
+  }
+}
 
 // When hosting at quantmatrixai.com without `VITE_BACKEND_ORIGIN`, Nginx should
 // proxy `/api/` paths to the backend so we keep the origin unchanged to avoid

--- a/TrinityFrontend/src/lib/api.ts
+++ b/TrinityFrontend/src/lib/api.ts
@@ -1,11 +1,23 @@
 const hostIp = import.meta.env.VITE_HOST_IP;
-const backendOrigin =
+let backendOrigin =
   import.meta.env.VITE_BACKEND_ORIGIN ||
   (hostIp
     ? `http://${hostIp}:8000`
     : typeof window !== 'undefined'
       ? window.location.origin.replace(/:8080$/, ':8000')
       : 'http://localhost:8000');
+
+// When running the frontend from the public domain without VITE_BACKEND_ORIGIN
+// set, default to the admin subdomain so API requests reach Django.
+if (
+  !import.meta.env.VITE_BACKEND_ORIGIN &&
+  typeof window !== 'undefined' &&
+  window.location.hostname === 'quantmatrixai.com'
+) {
+  backendOrigin = 'https://admin.quantmatrixai.com';
+}
+
+console.log('Using backend origin', backendOrigin);
 
 export const ACCOUNTS_API =
   import.meta.env.VITE_ACCOUNTS_API || `${backendOrigin}/api/accounts`;

--- a/TrinityFrontend/src/lib/api.ts
+++ b/TrinityFrontend/src/lib/api.ts
@@ -4,6 +4,13 @@ let backendOrigin = import.meta.env.VITE_BACKEND_ORIGIN;
 if (!backendOrigin) {
   if (hostIp) {
     backendOrigin = `http://${hostIp}:8000`;
+  } else if (
+    typeof window !== 'undefined' &&
+    window.location.hostname === 'quantmatrixai.com'
+  ) {
+    // When the site is served from the root domain the APIs live on the
+    // admin subdomain, so switch automatically unless overridden.
+    backendOrigin = 'https://admin.quantmatrixai.com';
   } else if (typeof window !== 'undefined') {
     backendOrigin = window.location.origin.replace(/:8080$/, ':8000');
   } else {

--- a/TrinityFrontend/src/lib/api.ts
+++ b/TrinityFrontend/src/lib/api.ts
@@ -7,15 +7,9 @@ let backendOrigin =
       ? window.location.origin.replace(/:8080$/, ':8000')
       : 'http://localhost:8000');
 
-// When running the frontend from the public domain without VITE_BACKEND_ORIGIN
-// set, default to the admin subdomain so API requests reach Django.
-if (
-  !import.meta.env.VITE_BACKEND_ORIGIN &&
-  typeof window !== 'undefined' &&
-  window.location.hostname === 'quantmatrixai.com'
-) {
-  backendOrigin = 'https://admin.quantmatrixai.com';
-}
+// When hosting at quantmatrixai.com without `VITE_BACKEND_ORIGIN`, Nginx should
+// proxy `/api/` paths to the backend so we keep the origin unchanged to avoid
+// CORS issues. Set `VITE_BACKEND_ORIGIN` if using a separate domain.
 
 console.log('Using backend origin', backendOrigin);
 

--- a/TrinityFrontend/src/lib/api.ts
+++ b/TrinityFrontend/src/lib/api.ts
@@ -5,22 +5,15 @@ if (!backendOrigin) {
   if (hostIp) {
     backendOrigin = `http://${hostIp}:8000`;
   } else if (typeof window !== 'undefined') {
-    const origin = window.location.origin.replace(/:8080$/, ':8000');
-    const host = window.location.hostname;
-    if (host === 'quantmatrixai.com' || host === 'www.quantmatrixai.com') {
-      backendOrigin = 'https://admin.quantmatrixai.com';
-      console.log('Root domain detected, using admin subdomain', backendOrigin);
-    } else {
-      backendOrigin = origin;
-    }
+    backendOrigin = window.location.origin.replace(/:8080$/, ':8000');
   } else {
     backendOrigin = 'http://localhost:8000';
   }
 }
 
-// When hosting at quantmatrixai.com without `VITE_BACKEND_ORIGIN`, Nginx should
-// proxy `/api/` paths to the backend so we keep the origin unchanged to avoid
-// CORS issues. Set `VITE_BACKEND_ORIGIN` if using a separate domain.
+// When hosting at quantmatrixai.com configure Nginx to proxy `/api/` paths
+// to the Django backend so the frontend and backend share the same origin. Set
+// `VITE_BACKEND_ORIGIN` if the APIs live on a different domain.
 
 console.log('Using backend origin', backendOrigin);
 

--- a/scripts/validate_backend.py
+++ b/scripts/validate_backend.py
@@ -1,0 +1,18 @@
+import urllib.request
+import sys
+
+URL = 'https://admin.quantmatrixai.com/admin/login/'
+
+def main():
+    print('Checking', URL)
+    try:
+        with urllib.request.urlopen(URL, timeout=5) as resp:
+            print('Status', resp.status)
+            print('Server', resp.headers.get('Server'))
+            sys.exit(0 if resp.status < 500 else 1)
+    except Exception as e:
+        print('Request failed:', e)
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()

--- a/tunnelBackendValidation.txt
+++ b/tunnelBackendValidation.txt
@@ -1,0 +1,11 @@
+# Django Backend Tunnel Validation
+
+Run the `scripts/validate_backend.py` helper to confirm the admin subdomain
+is reachable through the Cloudflare tunnel:
+
+```bash
+python scripts/validate_backend.py
+```
+
+A successful request prints the HTTP status and server header returned by
+`https://admin.quantmatrixai.com/admin/login/`.


### PR DESCRIPTION
## Summary
- forward `/api/` requests from Nginx container to Django backend so POST logins work
- include extra debug console logs for the login routine
- document requirement to use the admin subdomain or proxy `/api/`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686cc8e6838c8321b2c8b6e470236e3d