### PR TITLE
Fix quantmatrix domain references

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Follow the steps below to run all services together.
   docker-compose build frontend
   ```
 
-  The frontend is exposed at `https://trinity.quanmatrixai.com` through
+  The frontend is exposed at `https://trinity.quantmatrixai.com` through
   Cloudflare Tunnel while the APIs live on the `admin` subdomain. If `/api/`
   paths are not proxied to Django, the frontend automatically uses
   `https://admin.quantmatrixai.com` for API calls. Set

--- a/TrinityBackendDjango/.env
+++ b/TrinityBackendDjango/.env
@@ -16,7 +16,7 @@ ALLOWED_HOSTS=*
 CSRF_TRUSTED_ORIGINS=
 # Comma separated list of origins for CORS. If left blank the defaults from
 # config/settings.py are used (quantmatrixai.com and subdomains).
-CORS_ALLOWED_ORIGINS=https://trinity.quanmatrixai.com,https://admin.quantmatrixai.com,https://api.quantmatrixai.com
+CORS_ALLOWED_ORIGINS=https://trinity.quantmatrixai.com,https://admin.quantmatrixai.com,https://api.quantmatrixai.com
 ADDITIONAL_DOMAINS=
 FLIGHT_HOST=flight
 FLIGHT_PORT=8815

--- a/TrinityBackendDjango/.env.example
+++ b/TrinityBackendDjango/.env.example
@@ -22,9 +22,9 @@ ALLOWED_HOSTS=*
 # Set this to the IP or domain serving the frontend.
 CSRF_TRUSTED_ORIGINS=
 # Comma separated list of origins for CORS. If empty, defaults from
-# config/settings.py (trinity.quanmatrixai.com, admin.quantmatrixai.com,
+# config/settings.py (trinity.quantmatrixai.com, admin.quantmatrixai.com,
 # api.quantmatrixai.com) are used.
-CORS_ALLOWED_ORIGINS=https://trinity.quanmatrixai.com,https://admin.quantmatrixai.com,https://api.quantmatrixai.com
+CORS_ALLOWED_ORIGINS=https://trinity.quantmatrixai.com,https://admin.quantmatrixai.com,https://api.quantmatrixai.com
 # Extra comma separated domain names or IP addresses that should map to the
 # default tenant when using django-tenants. Useful when accessing via a LAN IP.
 ADDITIONAL_DOMAINS=

--- a/TrinityBackendDjango/config/settings.py
+++ b/TrinityBackendDjango/config/settings.py
@@ -48,7 +48,7 @@ ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "*").split(",")
 # form. When deploying behind Cloudflare or another proxy, add your external
 # domain (e.g. "https://example.com") here so browser POSTs are accepted.
 _default_csrf = (
-    "https://trinity.quanmatrixai.com,"
+    "https://trinity.quantmatrixai.com,"
     "https://admin.quantmatrixai.com,"
     "https://api.quantmatrixai.com"
 )
@@ -60,7 +60,7 @@ ADDITIONAL_DOMAINS = os.getenv("ADDITIONAL_DOMAINS", HOST_IP)
 # CORS configuration
 # ------------------------------------------------------------------
 _default_cors = (
-    "https://trinity.quanmatrixai.com,"
+    "https://trinity.quantmatrixai.com,"
     "https://admin.quantmatrixai.com,"
     "https://api.quantmatrixai.com"
 )

--- a/TrinityFrontend/src/lib/api.ts
+++ b/TrinityFrontend/src/lib/api.ts
@@ -6,7 +6,7 @@ if (!backendOrigin) {
     backendOrigin = `http://${hostIp}:8000`;
   } else if (
     typeof window !== 'undefined' &&
-    window.location.hostname === 'trinity.quanmatrixai.com'
+    window.location.hostname === 'trinity.quantmatrixai.com'
   ) {
     // When the site is served from the Cloudflare domain the APIs live on the
     // admin subdomain, so switch automatically unless overridden.
@@ -18,7 +18,7 @@ if (!backendOrigin) {
   }
 }
 
-// When hosting at trinity.quanmatrixai.com configure Nginx to proxy `/api/` paths
+// When hosting at trinity.quantmatrixai.com configure Nginx to proxy `/api/` paths
 // to the Django backend so the frontend and backend share the same origin. Set
 // `VITE_BACKEND_ORIGIN` if the APIs live on a different domain.
 

--- a/tunnelCreds/config.yml
+++ b/tunnelCreds/config.yml
@@ -2,7 +2,7 @@ tunnel: d53d4b08-f2ee-4be2-98b0-ac7a733a648c
 credentials-file: /etc/cloudflared/d53d4b08-f2ee-4be2-98b0-ac7a733a648c.json
 
 ingress:
-  - hostname: trinity.quanmatrixai.com
+  - hostname: trinity.quantmatrixai.com
     service: http://frontend:80
   - hostname: api.quantmatrixai.com
     service: http://fastapi:8001

--- a/tunneling_guide.txt
+++ b/tunneling_guide.txt
@@ -1,6 +1,6 @@
 # Cloudflare Tunnel Setup for Trinity Platform
 
-This guide explains how to expose the Dockerized Trinity application using Cloudflare Tunnel so the services are reachable at **trinity.quanmatrixai.com** and the backend subdomains. The examples assume your host IP is `10.2.1.65`.
+This guide explains how to expose the Dockerized Trinity application using Cloudflare Tunnel so the services are reachable at **trinity.quantmatrixai.com** and the backend subdomains. The examples assume your host IP is `10.2.1.65`.
 
 ## 1. Install cloudflared
 
@@ -36,19 +36,19 @@ chmod 600 tunnelCreds/d53d4b08-f2ee-4be2-98b0-ac7a733a648c.json \
 ## 3. Configure DNS routing
 
 Set up DNS records in Cloudflare to point to the tunnel:
-- `trinity.quanmatrixai.com` -> tunnel
+- `trinity.quantmatrixai.com` -> tunnel
 - `api.quantmatrixai.com` -> tunnel
 - `admin.quantmatrixai.com` -> tunnel
 
 These can be created automatically using:
 ```bash
-cloudflared tunnel route dns trinityapp trinity.quanmatrixai.com
+cloudflared tunnel route dns trinityapp trinity.quantmatrixai.com
 cloudflared tunnel route dns trinityapp api.quantmatrixai.com
 cloudflared tunnel route dns trinityapp admin.quantmatrixai.com
 ```
 You can also run them from inside the container:
 ```bash
-docker-compose exec cloudflared cloudflared tunnel route dns trinityapp trinity.quanmatrixai.com
+docker-compose exec cloudflared cloudflared tunnel route dns trinityapp trinity.quantmatrixai.com
 docker-compose exec cloudflared cloudflared tunnel route dns trinityapp api.quantmatrixai.com
 docker-compose exec cloudflared cloudflared tunnel route dns trinityapp admin.quantmatrixai.com
 ```
@@ -61,7 +61,7 @@ tunnel: d53d4b08-f2ee-4be2-98b0-ac7a733a648c
 credentials-file: /etc/cloudflared/d53d4b08-f2ee-4be2-98b0-ac7a733a648c.json
 
 ingress:
-  - hostname: trinity.quanmatrixai.com
+  - hostname: trinity.quantmatrixai.com
     service: http://frontend:80
   - hostname: api.quantmatrixai.com
     service: http://fastapi:8001
@@ -113,13 +113,13 @@ docker-compose build frontend
    docker-compose up --build
    ```
 2. Cloudflared establishes the tunnel and routes requests for the configured hostnames to the correct containers.
-3. Visit `https://trinity.quanmatrixai.com` for the frontend, `https://api.quantmatrixai.com` for FastAPI and `https://admin.quantmatrixai.com` for Django.
+3. Visit `https://trinity.quantmatrixai.com` for the frontend, `https://api.quantmatrixai.com` for FastAPI and `https://admin.quantmatrixai.com` for Django.
 
 The services remain reachable on the local network as before, while Cloudflare Tunnel provides secure public access.
 
 ## 8. Troubleshooting
 
-If visiting `https://trinity.quanmatrixai.com` or the backend subdomains returns a Cloudflare **530** error, the tunnel is not connected to the
+If visiting `https://trinity.quantmatrixai.com` or the backend subdomains returns a Cloudflare **530** error, the tunnel is not connected to the
 origin. Common causes are missing DNS records or incorrect IDs in `tunnelCreds/config.yml`.
 
 1. Verify your DNS entries in Cloudflare are **Proxied** (orange cloud) and point to the tunnel using
@@ -135,17 +135,17 @@ external domain will load over HTTPS without additional changes.
 ## 9. Switching the frontend domain
 
 Follow these steps if you need to rename the frontend tunnel endpoint to
-`trinity.quanmatrixai.com`:
+`trinity.quantmatrixai.com`:
 
-1. Purchase or configure the `quanmatrixai.com` domain in Cloudflare if you do
+1. Purchase or configure the `quantmatrixai.com` domain in Cloudflare if you do
    not already control it.
 2. Under *DNS* add a **CNAME** record for `trinity` pointing to your Cloudflare
    tunnel. Enable the orange proxy icon.
 3. Edit `tunnelCreds/config.yml` and replace the original `quantmatrixai.com`
-   hostname with `trinity.quanmatrixai.com` for the frontend service.
+   hostname with `trinity.quantmatrixai.com` for the frontend service.
 4. Update CORS settings by editing `TrinityBackendDjango/.env`,
    `.env.example` and `config/settings.py` to include
-   `https://trinity.quanmatrixai.com`.
+   `https://trinity.quantmatrixai.com`.
 5. Rebuild the containers so the new configuration is applied:
 
    ```bash
@@ -154,5 +154,5 @@ Follow these steps if you need to rename the frontend tunnel endpoint to
    ```
 
 When Cloudflared reports **Connected** you can access the React application at
-`https://trinity.quanmatrixai.com` while API calls continue to go to the
+`https://trinity.quantmatrixai.com` while API calls continue to go to the
 `admin` and `api` subdomains.


### PR DESCRIPTION
## Summary
- replace all mentions of `trinity.quanmatrixai.com` with `trinity.quantmatrixai.com`
- keep environment examples and configs consistent

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686d250e26c083219cbcc857c497b8d6