### PR TITLE
Use separate tunnels per service

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,16 +120,18 @@ a duplicate domain. Ensure the request is sent to the public host (e.g.
 With these steps the Django orchestration layer, FastAPI features and the
 React frontend are fully connected.
 
-## 5. Validate the backend tunnel
+## 5. Validate the tunnels
 
-After exposing the services through Cloudflare Tunnel you can verify that the
-Django backend responds on the public hostname. Docker Compose automatically
-launches a short‑lived `tunnel-check` container. This container runs the
-validation helper once during `docker-compose up` and then exits. You can also
-run the same helper manually from the repository root:
+After exposing the services through Cloudflare Tunnels you can verify that each
+public hostname responds. Docker Compose automatically launches short‑lived
+`check-*` containers. These run the validation helpers once during
+`docker-compose up` and then exit. You can also run the helpers manually from
+the repository root:
 
 ```bash
 python scripts/check_django_tunnel.py
+python scripts/check_frontend_tunnel.py
+python scripts/check_fastapi_tunnel.py
 ```
 
 A healthy tunnel prints the HTTP status and server header, for example:
@@ -144,7 +146,8 @@ If you see a 4xx or 5xx status code the request reached the server but
 returned an error. Double‑check the URL and that the Django container is
 running. A 404 response usually means the endpoint path is wrong while a 5xx
 status indicates the tunnel or backend might be down. Use `docker-compose logs
-cloudflared` to confirm the tunnel is connected if you suspect connectivity
+cloudflared-admin` (and the other tunnel containers) to confirm they are
+connected if you suspect connectivity
 issues.
 
 

--- a/TrinityBackendDjango/docker-compose.yml
+++ b/TrinityBackendDjango/docker-compose.yml
@@ -139,9 +139,9 @@ services:
       - trinity-net
     depends_on:
       - web
-  cloudflared:
+  cloudflared-frontend:
     image: cloudflare/cloudflared:latest
-    command: tunnel run
+    command: tunnel --config /etc/cloudflared/config_frontend.yml run
     volumes:
       - ../tunnelCreds:/etc/cloudflared:ro
     depends_on:
@@ -149,7 +149,27 @@ services:
     networks:
       - trinity-net
 
-  tunnel-check:
+  cloudflared-admin:
+    image: cloudflare/cloudflared:latest
+    command: tunnel --config /etc/cloudflared/config_admin.yml run
+    volumes:
+      - ../tunnelCreds:/etc/cloudflared:ro
+    depends_on:
+      - web
+    networks:
+      - trinity-net
+
+  cloudflared-api:
+    image: cloudflare/cloudflared:latest
+    command: tunnel --config /etc/cloudflared/config_api.yml run
+    volumes:
+      - ../tunnelCreds:/etc/cloudflared:ro
+    depends_on:
+      - fastapi
+    networks:
+      - trinity-net
+
+  check-admin:
     image: python:3.10-slim
     command: python /app/scripts/check_django_tunnel.py
     volumes:
@@ -159,7 +179,35 @@ services:
       BACKEND_URL: https://admin.quantmatrixai.com/admin/login/
     depends_on:
       - web
-      - cloudflared
+      - cloudflared-admin
+    networks:
+      - trinity-net
+
+  check-frontend:
+    image: python:3.10-slim
+    command: python /app/scripts/check_frontend_tunnel.py
+    volumes:
+      - ../:/app
+    working_dir: /app
+    environment:
+      FRONTEND_URL: https://trinity.quantmatrixai.com/
+    depends_on:
+      - frontend
+      - cloudflared-frontend
+    networks:
+      - trinity-net
+
+  check-api:
+    image: python:3.10-slim
+    command: python /app/scripts/check_fastapi_tunnel.py
+    volumes:
+      - ../:/app
+    working_dir: /app
+    environment:
+      FASTAPI_URL: https://api.quantmatrixai.com/api/validator_atom/health
+    depends_on:
+      - fastapi
+      - cloudflared-api
     networks:
       - trinity-net
 

--- a/scripts/check_fastapi_tunnel.py
+++ b/scripts/check_fastapi_tunnel.py
@@ -1,0 +1,45 @@
+import logging
+import os
+import sys
+from urllib import request, error
+
+logging.basicConfig(level=logging.INFO, format='[%(levelname)s] %(message)s')
+logger = logging.getLogger(__name__)
+
+DEFAULT_URL = "https://api.quantmatrixai.com/api/validator_atom/health"
+
+def get_url() -> str:
+    if len(sys.argv) > 1:
+        return sys.argv[1]
+    return os.getenv("FASTAPI_URL", DEFAULT_URL)
+
+def main() -> int:
+    """Return 0 if the FastAPI health endpoint is reachable."""
+    url = get_url()
+    logger.info("Checking %s", url)
+    try:
+        with request.urlopen(url, timeout=10) as resp:
+            status = resp.status
+            headers = resp.headers
+            logger.info("Status %s", status)
+            logger.info("Server %s", headers.get('Server'))
+            if status >= 400:
+                logger.error("FAILURE: endpoint responded with an error (%s)", status)
+                print("FAILURE")
+                return 1
+            logger.info("SUCCESS: tunnel appears healthy")
+            print("SUCCESS")
+            return 0
+    except error.HTTPError as e:
+        logger.error("FAILURE: HTTP error %s - %s", e.code, e.reason)
+        if e.code == 530:
+            logger.error("Cloudflare 530 typically means the tunnel is not connected to the origin")
+        logger.debug("Headers: %s", e.headers)
+        print("FAILURE")
+    except Exception as exc:
+        logger.error("FAILURE: request failed: %s", exc)
+        print("FAILURE")
+    return 1
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_frontend_tunnel.py
+++ b/scripts/check_frontend_tunnel.py
@@ -1,0 +1,45 @@
+import logging
+import os
+import sys
+from urllib import request, error
+
+logging.basicConfig(level=logging.INFO, format='[%(levelname)s] %(message)s')
+logger = logging.getLogger(__name__)
+
+DEFAULT_URL = "https://trinity.quantmatrixai.com/"
+
+def get_url() -> str:
+    if len(sys.argv) > 1:
+        return sys.argv[1]
+    return os.getenv("FRONTEND_URL", DEFAULT_URL)
+
+def main() -> int:
+    """Return 0 if the frontend URL is reachable."""
+    url = get_url()
+    logger.info("Checking %s", url)
+    try:
+        with request.urlopen(url, timeout=10) as resp:
+            status = resp.status
+            headers = resp.headers
+            logger.info("Status %s", status)
+            logger.info("Server %s", headers.get('Server'))
+            if status >= 400:
+                logger.error("FAILURE: endpoint responded with an error (%s)", status)
+                print("FAILURE")
+                return 1
+            logger.info("SUCCESS: tunnel appears healthy")
+            print("SUCCESS")
+            return 0
+    except error.HTTPError as e:
+        logger.error("FAILURE: HTTP error %s - %s", e.code, e.reason)
+        if e.code == 530:
+            logger.error("Cloudflare 530 typically means the tunnel is not connected to the origin")
+        logger.debug("Headers: %s", e.headers)
+        print("FAILURE")
+    except Exception as exc:
+        logger.error("FAILURE: request failed: %s", exc)
+        print("FAILURE")
+    return 1
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tunnelCreds/config_admin.yml
+++ b/tunnelCreds/config_admin.yml
@@ -1,0 +1,7 @@
+tunnel: TUNNEL_ID_ADMIN
+credentials-file: /etc/cloudflared/TUNNEL_ID_ADMIN.json
+
+ingress:
+  - hostname: admin.quantmatrixai.com
+    service: http://web:8000
+  - service: http_status:404

--- a/tunnelCreds/config_api.yml
+++ b/tunnelCreds/config_api.yml
@@ -1,0 +1,7 @@
+tunnel: TUNNEL_ID_API
+credentials-file: /etc/cloudflared/TUNNEL_ID_API.json
+
+ingress:
+  - hostname: api.quantmatrixai.com
+    service: http://fastapi:8001
+  - service: http_status:404

--- a/tunnelCreds/config_frontend.yml
+++ b/tunnelCreds/config_frontend.yml
@@ -1,0 +1,7 @@
+tunnel: TUNNEL_ID_FRONTEND
+credentials-file: /etc/cloudflared/TUNNEL_ID_FRONTEND.json
+
+ingress:
+  - hostname: trinity.quantmatrixai.com
+    service: http://frontend:80
+  - service: http_status:404

--- a/tunnelValidationGuide.txt
+++ b/tunnelValidationGuide.txt
@@ -66,8 +66,8 @@ If the script reports an error:
    ```
 
 4. Confirm the DNS records in Cloudflare point to the correct tunnel and are set to **Proxied**.
-
-5. Restart a tunnel if needed:
+5. Double-check that the credential JSON files in `tunnelCreds/` match the UUID listed in each config file. If the file name or ID is wrong the tunnel cannot authenticate.
+6. Restart a tunnel if needed:
 
    ```bash
    docker-compose restart cloudflared-admin cloudflared-frontend cloudflared-api

--- a/tunnelValidationGuide.txt
+++ b/tunnelValidationGuide.txt
@@ -1,6 +1,6 @@
 # Tunnel Validation Guide
 
-Follow these steps to confirm that the Django backend is reachable via the Cloudflare tunnel.
+Follow these steps to confirm that the services are reachable via their Cloudflare tunnels.
 
 ## 1. Start the stack
 
@@ -11,10 +11,10 @@ cd TrinityBackendDjango
 docker-compose up --build
 ```
 
-Wait until the `web` (Django) and `cloudflared` containers report `Connected`.
-Docker Compose also starts a short‑lived `tunnel-check` service that
-executes the helper script automatically. It prints **SUCCESS** or **FAILURE**
-in the logs based on the response from the admin URL.
+Wait until the `cloudflared-*` containers report `Connected`.
+Docker Compose also starts short‑lived `check-*` services that
+execute the helper scripts automatically. They print **SUCCESS** or **FAILURE**
+in the logs based on the response from each public URL.
 
 ## 2. Check the tunnel
 
@@ -46,15 +46,17 @@ If the script reports an error:
 1. Inspect the tunnel logs:
 
    ```bash
-   docker-compose logs cloudflared
+   docker-compose logs cloudflared-admin
+   docker-compose logs cloudflared-frontend
+   docker-compose logs cloudflared-api
    ```
 
    Look for messages like `Connected` or any errors indicating authentication or DNS issues.
 
-2. Ensure the `cloudflared` container is running:
+2. Ensure the `cloudflared-*` containers are running:
 
    ```bash
-   docker-compose ps cloudflared
+   docker-compose ps cloudflared-admin cloudflared-frontend cloudflared-api
    ```
 
 3. Verify the Django container is healthy:
@@ -65,10 +67,10 @@ If the script reports an error:
 
 4. Confirm the DNS records in Cloudflare point to the correct tunnel and are set to **Proxied**.
 
-5. Restart the tunnel if needed:
+5. Restart a tunnel if needed:
 
    ```bash
-   docker-compose restart cloudflared
+   docker-compose restart cloudflared-admin cloudflared-frontend cloudflared-api
    ```
 
 Use these logs to identify whether the request is reaching the tunnel or failing earlier. Once the script shows a 200 status, the frontend should be able to access the backend through `https://admin.quantmatrixai.com`.

--- a/updatedTunnelGuide.txt
+++ b/updatedTunnelGuide.txt
@@ -1,0 +1,62 @@
+# Separate Cloudflare Tunnels Setup
+
+The project now expects three individual Cloudflare tunnels so each service is reachable on its own subdomain:
+
+- **trinity.quantmatrixai.com** → React frontend
+- **admin.quantmatrixai.com** → Django admin
+- **api.quantmatrixai.com** → FastAPI backend
+
+Follow the steps below on your host machine.
+
+## 1. Install `cloudflared`
+1. Create or sign in to your Cloudflare account and add the `quantmatrixai.com` domain.
+2. Install the Cloudflare Tunnel client:
+   ```bash
+   curl -L https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb -o cloudflared.deb
+   sudo dpkg -i cloudflared.deb
+   cloudflared login
+   ```
+   Authentication places credentials under `~/.cloudflared`.
+
+## 2. Create three tunnels
+Create a tunnel for each service and record the generated UUID:
+```bash
+cloudflared tunnel create trinity-frontend
+cloudflared tunnel create trinity-admin
+cloudflared tunnel create trinity-api
+```
+Copy the corresponding `<UUID>.json` files and `cert.pem` into `tunnelCreds/`.
+Three example config files (`config_frontend.yml`, `config_admin.yml`, `config_api.yml`) are provided. Replace `TUNNEL_ID_*` with the real IDs in each file.
+
+## 3. Configure DNS
+Point the subdomains to their respective tunnels:
+```bash
+cloudflared tunnel route dns trinity-frontend trinity.quantmatrixai.com
+cloudflared tunnel route dns trinity-admin admin.quantmatrixai.com
+cloudflared tunnel route dns trinity-api api.quantmatrixai.com
+```
+Ensure the records are **Proxied** (orange cloud) in the Cloudflare dashboard.
+
+## 4. Docker Compose services
+The `docker-compose.yml` inside `TrinityBackendDjango` defines three `cloudflared-*` services. They mount `tunnelCreds` and run with their dedicated config files. Build and start the stack:
+```bash
+cd TrinityBackendDjango
+docker-compose up --build
+```
+Each tunnel container should report `Connected` shortly after startup.
+
+## 5. Validate connectivity
+Short‑lived `check-*` containers automatically run a script verifying that each public URL responds:
+```bash
+docker-compose logs check-admin
+docker-compose logs check-frontend
+docker-compose logs check-api
+```
+You can run the helpers manually from the repository root:
+```bash
+python scripts/check_django_tunnel.py
+python scripts/check_frontend_tunnel.py
+python scripts/check_fastapi_tunnel.py
+```
+All commands should print `SUCCESS` when the tunnels and services are working.
+

--- a/updatedTunnelGuide.txt
+++ b/updatedTunnelGuide.txt
@@ -60,3 +60,27 @@ python scripts/check_fastapi_tunnel.py
 ```
 All commands should print `SUCCESS` when the tunnels and services are working.
 
+## 6. Troubleshooting
+
+If a script prints a **530** status the tunnel is not connected to your
+containers. Common causes are:
+
+1. The credentials JSON file does not match the `tunnel:` ID in the config
+   (`config_admin.yml`, `config_frontend.yml`, or `config_api.yml`). Ensure the
+   file name is `<UUID>.json` and that the same UUID appears in the `tunnel:`
+   field of the config.
+2. DNS records may be missing or not proxied. Verify the `cloudflared tunnel`
+   `route dns` commands completed successfully and that the orange cloud is
+   enabled in the Cloudflare dashboard.
+3. The origin containers might not be running. Check the logs with
+   `docker-compose logs web fastapi frontend` and confirm the `cloudflared-*`
+   containers show `Connected`.
+
+After correcting any issues restart the tunnel service:
+
+```bash
+docker-compose restart cloudflared-admin cloudflared-frontend cloudflared-api
+```
+
+Once the logs show **Connected** re-run the check scripts.
+


### PR DESCRIPTION
## Summary
- configure three different Cloudflare tunnels
- add health check scripts for frontend and FastAPI
- update Docker compose to run cloudflared for each service
- update docs and add instructions for new tunnels
- include example configs and validation guide updates

## Testing
- `python -m py_compile scripts/*.py`
- `python scripts/check_frontend_tunnel.py` *(fails: Tunnel connection failed)*
- `python scripts/check_fastapi_tunnel.py` *(fails: Tunnel connection failed)*
- `python scripts/check_django_tunnel.py` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_686d288abe2083219fd4fafed8d793c4