### PR TITLE
Consolidate tunnels with Traefik reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,21 +17,19 @@ Follow the steps below to run all services together.
    The frontend `.env` includes `VITE_SUBSCRIPTIONS_API` which should point to
    the Django subscription endpoints and `VITE_TRINITY_AI_API` for the AI
    service.
-   When exposing the app via Cloudflare Tunnel, set
-   `VITE_BACKEND_ORIGIN=https://admin.quantmatrixai.com` so login requests reach
-   the Django server. Rebuild the `frontend` service after changing this file so
-   Vite picks up the new value:
+  When exposing the app via Cloudflare Tunnel, set
+  `VITE_BACKEND_ORIGIN=https://trinity.quantmatrixai.com` so the frontend sends
+  API requests through Traefik. Rebuild the `frontend` service after changing
+  this file so Vite picks up the new value:
 
    ```bash
   docker-compose build frontend
   ```
 
   The frontend is exposed at `https://trinity.quantmatrixai.com` through
-  Cloudflare Tunnel while the APIs live on the `admin` subdomain. If `/api/`
-  paths are not proxied to Django, the frontend automatically uses
-  `https://admin.quantmatrixai.com` for API calls. Set
-  `VITE_BACKEND_ORIGIN` to override this behavior or when hosting the APIs on a
-  completely different domain.
+  Cloudflare Tunnel while Traefik proxies `/admin/` and `/api/` requests to the
+  backend containers on the same host. Set `VITE_BACKEND_ORIGIN` only if you
+  deploy the APIs on a different domain.
 
 Docker and Node.js must be installed locally. The Python dependencies listed in
 `TrinityBackendDjango/requirements.txt` and
@@ -137,7 +135,7 @@ python scripts/check_fastapi_tunnel.py
 A healthy tunnel prints the HTTP status and server header, for example:
 
 ```
-Checking https://admin.quantmatrixai.com/admin/login/
+Checking https://trinity.quantmatrixai.com/admin/login/
 Status 200
 Server cloudflare
 ```

--- a/TrinityBackendDjango/.env
+++ b/TrinityBackendDjango/.env
@@ -15,8 +15,8 @@ FRONTEND_URL=
 ALLOWED_HOSTS=*
 CSRF_TRUSTED_ORIGINS=
 # Comma separated list of origins for CORS. If left blank the defaults from
-# config/settings.py are used (quantmatrixai.com and subdomains).
-CORS_ALLOWED_ORIGINS=https://trinity.quantmatrixai.com,https://admin.quantmatrixai.com,https://api.quantmatrixai.com
+# config/settings.py is used (trinity.quantmatrixai.com).
+CORS_ALLOWED_ORIGINS=https://trinity.quantmatrixai.com
 ADDITIONAL_DOMAINS=
 FLIGHT_HOST=flight
 FLIGHT_PORT=8815

--- a/TrinityBackendDjango/.env.example
+++ b/TrinityBackendDjango/.env.example
@@ -22,9 +22,8 @@ ALLOWED_HOSTS=*
 # Set this to the IP or domain serving the frontend.
 CSRF_TRUSTED_ORIGINS=
 # Comma separated list of origins for CORS. If empty, defaults from
-# config/settings.py (trinity.quantmatrixai.com, admin.quantmatrixai.com,
-# api.quantmatrixai.com) are used.
-CORS_ALLOWED_ORIGINS=https://trinity.quantmatrixai.com,https://admin.quantmatrixai.com,https://api.quantmatrixai.com
+# config/settings.py (trinity.quantmatrixai.com) is used.
+CORS_ALLOWED_ORIGINS=https://trinity.quantmatrixai.com
 # Extra comma separated domain names or IP addresses that should map to the
 # default tenant when using django-tenants. Useful when accessing via a LAN IP.
 ADDITIONAL_DOMAINS=

--- a/TrinityBackendDjango/config/settings.py
+++ b/TrinityBackendDjango/config/settings.py
@@ -48,9 +48,7 @@ ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "*").split(",")
 # form. When deploying behind Cloudflare or another proxy, add your external
 # domain (e.g. "https://example.com") here so browser POSTs are accepted.
 _default_csrf = (
-    "https://trinity.quantmatrixai.com,"
-    "https://admin.quantmatrixai.com,"
-    "https://api.quantmatrixai.com"
+    "https://trinity.quantmatrixai.com"
 )
 _trusted = os.getenv("CSRF_TRUSTED_ORIGINS", _default_csrf)
 CSRF_TRUSTED_ORIGINS = [o.strip() for o in _trusted.split(",") if o.strip()]
@@ -60,9 +58,7 @@ ADDITIONAL_DOMAINS = os.getenv("ADDITIONAL_DOMAINS", HOST_IP)
 # CORS configuration
 # ------------------------------------------------------------------
 _default_cors = (
-    "https://trinity.quantmatrixai.com,"
-    "https://admin.quantmatrixai.com,"
-    "https://api.quantmatrixai.com"
+    "https://trinity.quantmatrixai.com",
 )
 CORS_ALLOWED_ORIGINS = [
     o.strip()

--- a/TrinityBackendDjango/docker-compose.yml
+++ b/TrinityBackendDjango/docker-compose.yml
@@ -70,7 +70,8 @@ services:
       - trinity-net
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.django.rule=Host(`admin.quantmatrixai.com`)"
+      - "traefik.http.routers.django.rule=Host(`trinity.quantmatrixai.com`) && PathPrefix(`/admin`)"
+      - "traefik.http.routers.django.entrypoints=web"
       - "traefik.http.services.django.loadbalancer.server.url=http://10.2.1.65:8000"
 
   celery:
@@ -112,7 +113,8 @@ services:
       - trinity-net
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.fastapi.rule=Host(`api.quantmatrixai.com`)"
+      - "traefik.http.routers.fastapi.rule=Host(`trinity.quantmatrixai.com`) && PathPrefix(`/api`)"
+      - "traefik.http.routers.fastapi.entrypoints=web"
       - "traefik.http.services.fastapi.loadbalancer.server.url=http://10.2.1.65:8001"
 
   flight:
@@ -147,6 +149,11 @@ services:
       - trinity-net
     depends_on:
       - web
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.frontend.rule=Host(`trinity.quantmatrixai.com`)"
+      - "traefik.http.routers.frontend.entrypoints=web"
+      - "traefik.http.services.frontend.loadbalancer.server.port=80"
   traefik:
     image: traefik:v2.11
     command:

--- a/TrinityBackendDjango/docker-compose.yml
+++ b/TrinityBackendDjango/docker-compose.yml
@@ -68,6 +68,10 @@ services:
       - minio
     networks:
       - trinity-net
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.django.rule=Host(`admin.quantmatrixai.com`)"
+      - "traefik.http.services.django.loadbalancer.server.url=http://10.2.1.65:8000"
 
   celery:
     build: .
@@ -106,6 +110,10 @@ services:
       - minio
     networks:
       - trinity-net
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.fastapi.rule=Host(`api.quantmatrixai.com`)"
+      - "traefik.http.services.fastapi.loadbalancer.server.url=http://10.2.1.65:8001"
 
   flight:
     build:
@@ -139,75 +147,28 @@ services:
       - trinity-net
     depends_on:
       - web
-  cloudflared-frontend:
-    image: cloudflare/cloudflared:latest
-    command: tunnel --config /etc/cloudflared/config_frontend.yml run
-    volumes:
-      - ../tunnelCreds:/etc/cloudflared:ro
-    depends_on:
-      - frontend
+  traefik:
+    image: traefik:v2.11
+    command:
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --entrypoints.web.address=:80
+    ports:
+      - "9080:80"
     networks:
       - trinity-net
-
-  cloudflared-admin:
-    image: cloudflare/cloudflared:latest
-    command: tunnel --config /etc/cloudflared/config_admin.yml run
-    volumes:
-      - ../tunnelCreds:/etc/cloudflared:ro
     depends_on:
       - web
-    networks:
-      - trinity-net
+      - fastapi
 
-  cloudflared-api:
+  cloudflared:
     image: cloudflare/cloudflared:latest
-    command: tunnel --config /etc/cloudflared/config_api.yml run
+    command: tunnel --config /etc/cloudflared/config.yml run
     volumes:
       - ../tunnelCreds:/etc/cloudflared:ro
     depends_on:
-      - fastapi
-    networks:
-      - trinity-net
-
-  check-admin:
-    image: python:3.10-slim
-    command: python /app/scripts/check_django_tunnel.py
-    volumes:
-      - ../:/app
-    working_dir: /app
-    environment:
-      BACKEND_URL: https://admin.quantmatrixai.com/admin/login/
-    depends_on:
-      - web
-      - cloudflared-admin
-    networks:
-      - trinity-net
-
-  check-frontend:
-    image: python:3.10-slim
-    command: python /app/scripts/check_frontend_tunnel.py
-    volumes:
-      - ../:/app
-    working_dir: /app
-    environment:
-      FRONTEND_URL: https://trinity.quantmatrixai.com/
-    depends_on:
+      - traefik
       - frontend
-      - cloudflared-frontend
-    networks:
-      - trinity-net
-
-  check-api:
-    image: python:3.10-slim
-    command: python /app/scripts/check_fastapi_tunnel.py
-    volumes:
-      - ../:/app
-    working_dir: /app
-    environment:
-      FASTAPI_URL: https://api.quantmatrixai.com/api/validator_atom/health
-    depends_on:
-      - fastapi
-      - cloudflared-api
     networks:
       - trinity-net
 

--- a/TrinityBackendDjango/docker-compose.yml
+++ b/TrinityBackendDjango/docker-compose.yml
@@ -162,6 +162,8 @@ services:
       - --entrypoints.web.address=:80
     ports:
       - "9080:80"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:
       - trinity-net
     depends_on:

--- a/TrinityFrontend/.env.example
+++ b/TrinityFrontend/.env.example
@@ -12,7 +12,7 @@ VITE_VALIDATE_API=
 # AI endpoint (defaults to port 8002 when using docker-compose)
 VITE_TRINITY_AI_API=
 # Base URL of the backend API if you don't want to use VITE_HOST_IP.
-VITE_BACKEND_ORIGIN=https://admin.quantmatrixai.com
+VITE_BACKEND_ORIGIN=https://trinity.quantmatrixai.com
 
 # When deploying, change these URLs to your external domain.
 

--- a/TrinityFrontend/src/lib/api.ts
+++ b/TrinityFrontend/src/lib/api.ts
@@ -4,13 +4,6 @@ let backendOrigin = import.meta.env.VITE_BACKEND_ORIGIN;
 if (!backendOrigin) {
   if (hostIp) {
     backendOrigin = `http://${hostIp}:8000`;
-  } else if (
-    typeof window !== 'undefined' &&
-    window.location.hostname === 'trinity.quantmatrixai.com'
-  ) {
-    // When the site is served from the Cloudflare domain the APIs live on the
-    // admin subdomain, so switch automatically unless overridden.
-    backendOrigin = 'https://admin.quantmatrixai.com';
   } else if (typeof window !== 'undefined') {
     backendOrigin = window.location.origin.replace(/:8080$/, ':8000');
   } else {
@@ -18,8 +11,9 @@ if (!backendOrigin) {
   }
 }
 
-// When hosting at trinity.quantmatrixai.com configure Nginx to proxy `/api/` paths
-// to the Django backend so the frontend and backend share the same origin. Set
+// When hosting at trinity.quantmatrixai.com configure the reverse proxy to route
+// `/api/` paths to the Django backend so the frontend and backend share the same
+// origin. Set
 // `VITE_BACKEND_ORIGIN` if the APIs live on a different domain.
 
 console.log('Using backend origin', backendOrigin);

--- a/scripts/check_django_tunnel.py
+++ b/scripts/check_django_tunnel.py
@@ -6,7 +6,7 @@ from urllib import request, error
 logging.basicConfig(level=logging.INFO, format='[%(levelname)s] %(message)s')
 logger = logging.getLogger(__name__)
 
-DEFAULT_URL = "https://admin.quantmatrixai.com/admin/login/"
+DEFAULT_URL = "http://10.2.1.65:8000/admin/login/"
 
 
 def get_url() -> str:

--- a/scripts/check_django_tunnel.py
+++ b/scripts/check_django_tunnel.py
@@ -6,7 +6,7 @@ from urllib import request, error
 logging.basicConfig(level=logging.INFO, format='[%(levelname)s] %(message)s')
 logger = logging.getLogger(__name__)
 
-DEFAULT_URL = "http://10.2.1.65:8000/admin/login/"
+DEFAULT_URL = "https://trinity.quantmatrixai.com/admin/login/"
 
 
 def get_url() -> str:

--- a/scripts/check_fastapi_tunnel.py
+++ b/scripts/check_fastapi_tunnel.py
@@ -6,7 +6,7 @@ from urllib import request, error
 logging.basicConfig(level=logging.INFO, format='[%(levelname)s] %(message)s')
 logger = logging.getLogger(__name__)
 
-DEFAULT_URL = "http://10.2.1.65:8001/api/validator_atom/health"
+DEFAULT_URL = "https://trinity.quantmatrixai.com/api/validator_atom/health"
 
 def get_url() -> str:
     if len(sys.argv) > 1:

--- a/scripts/check_fastapi_tunnel.py
+++ b/scripts/check_fastapi_tunnel.py
@@ -6,7 +6,7 @@ from urllib import request, error
 logging.basicConfig(level=logging.INFO, format='[%(levelname)s] %(message)s')
 logger = logging.getLogger(__name__)
 
-DEFAULT_URL = "https://api.quantmatrixai.com/api/validator_atom/health"
+DEFAULT_URL = "http://10.2.1.65:8001/api/validator_atom/health"
 
 def get_url() -> str:
     if len(sys.argv) > 1:

--- a/traefikTunnelGuide.txt
+++ b/traefikTunnelGuide.txt
@@ -14,16 +14,16 @@ This project uses a single Cloudflare Tunnel together with Traefik to expose the
 
 ## 2. Create a tunnel
 ```bash
-cloudflared tunnel create trinityapp
+cloudflared tunnel create trinity-frontend
 ```
-Copy the generated `<UUID>.json` and `cert.pem` into `tunnelCreds/`. Use the UUID in `tunnelCreds/config.yml`.
+Copy the generated `<UUID>.json` (for this project it is `e0a883c4-bc43-4742-b47a-96ef902e6bb3.json`) and `cert.pem` into `tunnelCreds/`. Use the UUID in `tunnelCreds/config.yml`.
 
 ## 3. Configure DNS
 Create DNS records pointing the subdomains to the tunnel:
 ```bash
-cloudflared tunnel route dns trinityapp trinity.quantmatrixai.com
-cloudflared tunnel route dns trinityapp admin.quantmatrixai.com
-cloudflared tunnel route dns trinityapp api.quantmatrixai.com
+cloudflared tunnel route dns trinity-frontend trinity.quantmatrixai.com
+cloudflared tunnel route dns trinity-frontend admin.quantmatrixai.com
+cloudflared tunnel route dns trinity-frontend api.quantmatrixai.com
 ```
 Ensure the records are **Proxied** in the Cloudflare dashboard.
 

--- a/traefikTunnelGuide.txt
+++ b/traefikTunnelGuide.txt
@@ -31,6 +31,8 @@ Ensure the record is **Proxied** in the Cloudflare dashboard.
 ## 4. Docker Compose
 `TrinityBackendDjango/docker-compose.yml` defines a `traefik` service and a single `cloudflared` container. Cloudflared forwards all traffic for `trinity.quantmatrixai.com` to Traefik (`service: http://traefik:80`). Traefik then routes `/`, `/admin/` and `/api/` to the appropriate containers.
 
+Traefik requires access to the Docker socket to read the labels. The compose file mounts `/var/run/docker.sock` into the Traefik container.
+
 Start all services from the `TrinityBackendDjango` directory:
 ```bash
 docker-compose up --build

--- a/traefikTunnelGuide.txt
+++ b/traefikTunnelGuide.txt
@@ -1,6 +1,9 @@
 # Cloudflare Tunnel with Traefik
 
-This project uses a single Cloudflare Tunnel together with Traefik to expose the services. The `frontend` container is reached directly through the tunnel while requests for the Django admin and FastAPI APIs are forwarded to Traefik. Traefik then proxies the traffic to the local endpoints `10.2.1.65:8000` (Django) and `10.2.1.65:8001` (FastAPI).
+This project exposes the React frontend to the public and keeps the backend services private. Cloudflare Tunnel forwards `https://trinity.quantmatrixai.com` into the Docker network. Traefik receives all requests and routes them by path:
+* `/` → React frontend
+* `/admin/` → Django on `10.2.1.65:8000`
+* `/api/` → FastAPI on `10.2.1.65:8001`
 
 ## 1. Install `cloudflared`
 1. Sign in to your Cloudflare account and add the desired domain.
@@ -19,16 +22,14 @@ cloudflared tunnel create trinity-frontend
 Copy the generated `<UUID>.json` (for this project it is `e0a883c4-bc43-4742-b47a-96ef902e6bb3.json`) and `cert.pem` into `tunnelCreds/`. Use the UUID in `tunnelCreds/config.yml`.
 
 ## 3. Configure DNS
-Create DNS records pointing the subdomains to the tunnel:
+Create a single DNS record for the frontend:
 ```bash
 cloudflared tunnel route dns trinity-frontend trinity.quantmatrixai.com
-cloudflared tunnel route dns trinity-frontend admin.quantmatrixai.com
-cloudflared tunnel route dns trinity-frontend api.quantmatrixai.com
 ```
-Ensure the records are **Proxied** in the Cloudflare dashboard.
+Ensure the record is **Proxied** in the Cloudflare dashboard.
 
 ## 4. Docker Compose
-`TrinityBackendDjango/docker-compose.yml` defines a `traefik` service and a single `cloudflared` container. Traefik listens on port `9080` inside the compose network and routes by hostname. The Cloudflared configuration (`tunnelCreds/config.yml`) forwards the frontend hostname directly to the `frontend` container and sends the admin and API hostnames to Traefik (`service: http://traefik:80`). Traefik in turn proxies to `10.2.1.65:8000` and `10.2.1.65:8001`.
+`TrinityBackendDjango/docker-compose.yml` defines a `traefik` service and a single `cloudflared` container. Cloudflared forwards all traffic for `trinity.quantmatrixai.com` to Traefik (`service: http://traefik:80`). Traefik then routes `/`, `/admin/` and `/api/` to the appropriate containers.
 
 Start all services from the `TrinityBackendDjango` directory:
 ```bash
@@ -36,8 +37,8 @@ docker-compose up --build
 ```
 Once the containers report "Connected" you can reach:
 - `https://trinity.quantmatrixai.com` – React frontend
-- `https://admin.quantmatrixai.com` – Django admin
-- `https://api.quantmatrixai.com` – FastAPI
+- `https://trinity.quantmatrixai.com/admin/` – Django admin
+- `https://trinity.quantmatrixai.com/api/` – FastAPI
 
 The other services (PostgreSQL, MongoDB, Redis, MinIO, etc.) remain accessible only inside the Docker network and through the codebase.
 

--- a/traefikTunnelGuide.txt
+++ b/traefikTunnelGuide.txt
@@ -1,0 +1,47 @@
+# Cloudflare Tunnel with Traefik
+
+This project uses a single Cloudflare Tunnel together with Traefik to expose the services. The `frontend` container is reached directly through the tunnel while requests for the Django admin and FastAPI APIs are forwarded to Traefik. Traefik then proxies the traffic to the local endpoints `10.2.1.65:8000` (Django) and `10.2.1.65:8001` (FastAPI).
+
+## 1. Install `cloudflared`
+1. Sign in to your Cloudflare account and add the desired domain.
+2. Install the tunnel client on the host:
+   ```bash
+   curl -L https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb -o cloudflared.deb
+   sudo dpkg -i cloudflared.deb
+   cloudflared login
+   ```
+   Authentication stores credentials under `~/.cloudflared`.
+
+## 2. Create a tunnel
+```bash
+cloudflared tunnel create trinityapp
+```
+Copy the generated `<UUID>.json` and `cert.pem` into `tunnelCreds/`. Use the UUID in `tunnelCreds/config.yml`.
+
+## 3. Configure DNS
+Create DNS records pointing the subdomains to the tunnel:
+```bash
+cloudflared tunnel route dns trinityapp trinity.quantmatrixai.com
+cloudflared tunnel route dns trinityapp admin.quantmatrixai.com
+cloudflared tunnel route dns trinityapp api.quantmatrixai.com
+```
+Ensure the records are **Proxied** in the Cloudflare dashboard.
+
+## 4. Docker Compose
+`TrinityBackendDjango/docker-compose.yml` defines a `traefik` service and a single `cloudflared` container. Traefik listens on port `9080` inside the compose network and routes by hostname. The Cloudflared configuration (`tunnelCreds/config.yml`) forwards the frontend hostname directly to the `frontend` container and sends the admin and API hostnames to Traefik (`service: http://traefik:80`). Traefik in turn proxies to `10.2.1.65:8000` and `10.2.1.65:8001`.
+
+Start all services from the `TrinityBackendDjango` directory:
+```bash
+docker-compose up --build
+```
+Once the containers report "Connected" you can reach:
+- `https://trinity.quantmatrixai.com` – React frontend
+- `https://admin.quantmatrixai.com` – Django admin
+- `https://api.quantmatrixai.com` – FastAPI
+
+The other services (PostgreSQL, MongoDB, Redis, MinIO, etc.) remain accessible only inside the Docker network and through the codebase.
+
+## 5. Troubleshooting
+- Confirm the `cloudflared` container logs show `Connected`.
+- Verify the DNS records are proxied and reference the same tunnel ID as `config.yml`.
+- Check `docker-compose logs traefik` to inspect routing if the admin or API endpoints fail.

--- a/tunnelBackendValidation.txt
+++ b/tunnelBackendValidation.txt
@@ -1,6 +1,6 @@
 # Django Backend Tunnel Validation
 
-Run the `scripts/check_django_tunnel.py` helper to confirm the admin subdomain
+Run the `scripts/check_django_tunnel.py` helper to confirm the admin interface
 is reachable through the Cloudflare tunnel:
 
 ```bash
@@ -11,7 +11,7 @@ The script prints the HTTP status and `Server` header. A typical successful
 check looks like this:
 
 ```
-Checking https://admin.quantmatrixai.com/admin/login/
+Checking https://trinity.quantmatrixai.com/admin/login/
 Status 200
 Server cloudflare
 ```

--- a/tunnelCreds/config.yml
+++ b/tunnelCreds/config.yml
@@ -3,9 +3,5 @@ credentials-file: /etc/cloudflared/e0a883c4-bc43-4742-b47a-96ef902e6bb3.json
 
 ingress:
   - hostname: trinity.quantmatrixai.com
-    service: http://frontend:80
-  - hostname: api.quantmatrixai.com
-    service: http://traefik:80
-  - hostname: admin.quantmatrixai.com
     service: http://traefik:80
   - service: http_status:404

--- a/tunnelCreds/config.yml
+++ b/tunnelCreds/config.yml
@@ -5,7 +5,7 @@ ingress:
   - hostname: trinity.quantmatrixai.com
     service: http://frontend:80
   - hostname: api.quantmatrixai.com
-    service: http://fastapi:8001
+    service: http://traefik:80
   - hostname: admin.quantmatrixai.com
-    service: http://web:8000
+    service: http://traefik:80
   - service: http_status:404

--- a/tunnelCreds/config.yml
+++ b/tunnelCreds/config.yml
@@ -1,5 +1,5 @@
-tunnel: d53d4b08-f2ee-4be2-98b0-ac7a733a648c
-credentials-file: /etc/cloudflared/d53d4b08-f2ee-4be2-98b0-ac7a733a648c.json
+tunnel: e0a883c4-bc43-4742-b47a-96ef902e6bb3
+credentials-file: /etc/cloudflared/e0a883c4-bc43-4742-b47a-96ef902e6bb3.json
 
 ingress:
   - hostname: trinity.quantmatrixai.com

--- a/tunnelCreds/credentials.json.example
+++ b/tunnelCreds/credentials.json.example
@@ -1,6 +1,6 @@
 {
   "AccountTag": "YOUR_ACCOUNT_TAG",
-  "TunnelID": "d53d4b08-f2ee-4be2-98b0-ac7a733a648c",
-  "TunnelName": "trinityapp",
+  "TunnelID": "e0a883c4-bc43-4742-b47a-96ef902e6bb3",
+  "TunnelName": "trinity-frontend",
   "TunnelSecret": "REPLACE_WITH_BASE64_SECRET"
 }

--- a/tunnelValidationGuide.txt
+++ b/tunnelValidationGuide.txt
@@ -27,13 +27,13 @@ python scripts/check_django_tunnel.py
 To check a different host, pass the URL as an argument or set `BACKEND_URL`:
 
 ```bash
-python scripts/check_django_tunnel.py https://admin.quantmatrixai.com/admin/login/
+python scripts/check_django_tunnel.py https://trinity.quantmatrixai.com/admin/login/
 ```
 
 A healthy tunnel prints output similar to:
 
 ```
-[INFO] Checking https://admin.quantmatrixai.com/admin/login/
+[INFO] Checking https://trinity.quantmatrixai.com/admin/login/
 [INFO] Status 200
 [INFO] Server cloudflare
 [INFO] Tunnel appears healthy
@@ -70,7 +70,7 @@ If the script reports an error:
 6. Restart a tunnel if needed:
 
    ```bash
-   docker-compose restart cloudflared-admin cloudflared-frontend cloudflared-api
+   docker-compose restart cloudflared
    ```
 
-Use these logs to identify whether the request is reaching the tunnel or failing earlier. Once the script shows a 200 status, the frontend should be able to access the backend through `https://admin.quantmatrixai.com`.
+Use these logs to identify whether the request is reaching the tunnel or failing earlier. Once the script shows a 200 status, the frontend should be able to access the backend through `https://trinity.quantmatrixai.com/admin/`.

--- a/tunneling_guide.txt
+++ b/tunneling_guide.txt
@@ -67,12 +67,17 @@ The `docker-compose.yml` inside `TrinityBackendDjango` already exposes all conta
     command: tunnel run
     volumes:
       - ../tunnelCreds:/etc/cloudflared:ro
+  traefik:
+    image: traefik:v2.11
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
     depends_on:
       - frontend
     networks:
       - trinity-net
 ```
-This container runs the tunnel using the configuration from `tunnelCreds/config.yml`.
+The `cloudflared` container runs the tunnel using the configuration from `tunnelCreds/config.yml`.
+Traefik watches the other containers via the mounted Docker socket.
 If running Docker on Windows, use an absolute path such as:
 `C:/TrinityFastAPIDjangoReact/tunnelCreds:/etc/cloudflared:ro`.
 

--- a/tunneling_guide.txt
+++ b/tunneling_guide.txt
@@ -20,16 +20,16 @@ This guide explains how to expose the Dockerized Trinity application using Cloud
 ## 2. Create a named tunnel
 
 ```bash
-cloudflared tunnel create trinityapp
+cloudflared tunnel create trinity-frontend
 ```
 
 Copy the generated tunnel UUID. Cloudflare also saves a credentials JSON for the tunnel and updates your `cert.pem`. Copy both files into `tunnelCreds` so Docker can mount them. Ensure they are readable only by you:
 
 ```bash
-cp ~/.cloudflared/d53d4b08-f2ee-4be2-98b0-ac7a733a648c.json \
-  tunnelCreds/d53d4b08-f2ee-4be2-98b0-ac7a733a648c.json
+cp ~/.cloudflared/e0a883c4-bc43-4742-b47a-96ef902e6bb3.json \
+  tunnelCreds/e0a883c4-bc43-4742-b47a-96ef902e6bb3.json
 cp ~/.cloudflared/cert.pem tunnelCreds/cert.pem
-chmod 600 tunnelCreds/d53d4b08-f2ee-4be2-98b0-ac7a733a648c.json \
+chmod 600 tunnelCreds/e0a883c4-bc43-4742-b47a-96ef902e6bb3.json \
   tunnelCreds/cert.pem
 ```
 
@@ -42,23 +42,23 @@ Set up DNS records in Cloudflare to point to the tunnel:
 
 These can be created automatically using:
 ```bash
-cloudflared tunnel route dns trinityapp trinity.quantmatrixai.com
-cloudflared tunnel route dns trinityapp api.quantmatrixai.com
-cloudflared tunnel route dns trinityapp admin.quantmatrixai.com
+cloudflared tunnel route dns trinity-frontend trinity.quantmatrixai.com
+cloudflared tunnel route dns trinity-frontend api.quantmatrixai.com
+cloudflared tunnel route dns trinity-frontend admin.quantmatrixai.com
 ```
 You can also run them from inside the container:
 ```bash
-docker-compose exec cloudflared cloudflared tunnel route dns trinityapp trinity.quantmatrixai.com
-docker-compose exec cloudflared cloudflared tunnel route dns trinityapp api.quantmatrixai.com
-docker-compose exec cloudflared cloudflared tunnel route dns trinityapp admin.quantmatrixai.com
+docker-compose exec cloudflared cloudflared tunnel route dns trinity-frontend trinity.quantmatrixai.com
+docker-compose exec cloudflared cloudflared tunnel route dns trinity-frontend api.quantmatrixai.com
+docker-compose exec cloudflared cloudflared tunnel route dns trinity-frontend admin.quantmatrixai.com
 ```
 
 ## 4. Cloudflared configuration
 
 Create `tunnelCreds/config.yml`:
 ```yaml
-tunnel: d53d4b08-f2ee-4be2-98b0-ac7a733a648c
-credentials-file: /etc/cloudflared/d53d4b08-f2ee-4be2-98b0-ac7a733a648c.json
+tunnel: e0a883c4-bc43-4742-b47a-96ef902e6bb3
+credentials-file: /etc/cloudflared/e0a883c4-bc43-4742-b47a-96ef902e6bb3.json
 
 ingress:
   - hostname: trinity.quantmatrixai.com
@@ -69,7 +69,7 @@ ingress:
     service: http://web:8000
   - service: http_status:404
 ```
-The values above use the real tunnel ID. Copy the generated credentials file into `tunnelCreds/d53d4b08-f2ee-4be2-98b0-ac7a733a648c.json` (an example `credentials.json.example` is provided). The Docker container mounts this path so Cloudflared can authenticate.
+The values above use the real tunnel ID. Copy the generated credentials file into `tunnelCreds/e0a883c4-bc43-4742-b47a-96ef902e6bb3.json` (an example `credentials.json.example` is provided). The Docker container mounts this path so Cloudflared can authenticate.
 
 ## 5. Docker Compose service
 
@@ -123,9 +123,9 @@ If visiting `https://trinity.quantmatrixai.com` or the backend subdomains return
 origin. Common causes are missing DNS records or incorrect IDs in `tunnelCreds/config.yml`.
 
 1. Verify your DNS entries in Cloudflare are **Proxied** (orange cloud) and point to the tunnel using
-   `cloudflared tunnel route dns trinityapp <hostname>`.
+   `cloudflared tunnel route dns trinity-frontend <hostname>`.
 2. Check that `tunnelCreds/config.yml` contains your actual tunnel UUID and that
-   `tunnelCreds/d53d4b08-f2ee-4be2-98b0-ac7a733a648c.json` matches the same ID.
+   `tunnelCreds/e0a883c4-bc43-4742-b47a-96ef902e6bb3.json` matches the same ID.
 3. Ensure the `cloudflared` container is running by inspecting the output of `docker-compose logs cloudflared`.
    It should report "Connected" after startup.
 

--- a/tunneling_guide.txt
+++ b/tunneling_guide.txt
@@ -1,6 +1,6 @@
 # Cloudflare Tunnel Setup for Trinity Platform
 
-This guide explains how to expose the Dockerized Trinity application using Cloudflare Tunnel so the services are reachable at **trinity.quantmatrixai.com** and the backend subdomains. The examples assume your host IP is `10.2.1.65`.
+This guide explains how to expose the Dockerized Trinity application using a single Cloudflare Tunnel so the public accesses **trinity.quantmatrixai.com** while the backend services remain private. All traffic is routed to Traefik inside the Docker network. The examples assume your host IP is `10.2.1.65`.
 
 ## 1. Install cloudflared
 
@@ -35,22 +35,13 @@ chmod 600 tunnelCreds/e0a883c4-bc43-4742-b47a-96ef902e6bb3.json \
 
 ## 3. Configure DNS routing
 
-Set up DNS records in Cloudflare to point to the tunnel:
-- `trinity.quantmatrixai.com` -> tunnel
-- `api.quantmatrixai.com` -> tunnel
-- `admin.quantmatrixai.com` -> tunnel
-
-These can be created automatically using:
+Set up a DNS record in Cloudflare for the frontend:
 ```bash
 cloudflared tunnel route dns trinity-frontend trinity.quantmatrixai.com
-cloudflared tunnel route dns trinity-frontend api.quantmatrixai.com
-cloudflared tunnel route dns trinity-frontend admin.quantmatrixai.com
 ```
-You can also run them from inside the container:
+Ensure the record is **Proxied**. You can also run the command from inside the container:
 ```bash
 docker-compose exec cloudflared cloudflared tunnel route dns trinity-frontend trinity.quantmatrixai.com
-docker-compose exec cloudflared cloudflared tunnel route dns trinity-frontend api.quantmatrixai.com
-docker-compose exec cloudflared cloudflared tunnel route dns trinity-frontend admin.quantmatrixai.com
 ```
 
 ## 4. Cloudflared configuration
@@ -62,11 +53,7 @@ credentials-file: /etc/cloudflared/e0a883c4-bc43-4742-b47a-96ef902e6bb3.json
 
 ingress:
   - hostname: trinity.quantmatrixai.com
-    service: http://frontend:80
-  - hostname: api.quantmatrixai.com
-    service: http://fastapi:8001
-  - hostname: admin.quantmatrixai.com
-    service: http://web:8000
+    service: http://traefik:80
   - service: http_status:404
 ```
 The values above use the real tunnel ID. Copy the generated credentials file into `tunnelCreds/e0a883c4-bc43-4742-b47a-96ef902e6bb3.json` (an example `credentials.json.example` is provided). The Docker container mounts this path so Cloudflared can authenticate.
@@ -96,7 +83,7 @@ tunnel:
 
 ```bash
 cp TrinityFrontend/.env.example TrinityFrontend/.env
-echo "VITE_BACKEND_ORIGIN=https://admin.quantmatrixai.com" >> TrinityFrontend/.env
+echo "VITE_BACKEND_ORIGIN=https://trinity.quantmatrixai.com" >> TrinityFrontend/.env
 ```
 This ensures `fetch()` requests like `/api/accounts/login/` hit the correct host
 instead of the frontend container.
@@ -112,8 +99,8 @@ docker-compose build frontend
    ```bash
    docker-compose up --build
    ```
-2. Cloudflared establishes the tunnel and routes requests for the configured hostnames to the correct containers.
-3. Visit `https://trinity.quantmatrixai.com` for the frontend, `https://api.quantmatrixai.com` for FastAPI and `https://admin.quantmatrixai.com` for Django.
+2. Cloudflared establishes the tunnel and routes all requests for `trinity.quantmatrixai.com` to Traefik.
+3. Visit `https://trinity.quantmatrixai.com` for the frontend. Use the `/api/` and `/admin/` paths for the backend services.
 
 The services remain reachable on the local network as before, while Cloudflare Tunnel provides secure public access.
 


### PR DESCRIPTION
## Summary
- add Traefik reverse proxy and single cloudflared service
- update config.yml for tunnel to send admin and api hostnames through Traefik
- document new setup in `traefikTunnelGuide.txt`
- use local IPs for FastAPI and Django admin

## Testing
- `python scripts/check_django_tunnel.py` *(fails: HTTP error 403 Forbidden)*
- `python scripts/check_fastapi_tunnel.py` *(fails: HTTP error 403 Forbidden)*
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686dff23bcb88321a74c064b4f72370e