### PR TITLE
Separate cloudflared service

### DIFF
--- a/TrinityBackendDjango/docker-compose.yml
+++ b/TrinityBackendDjango/docker-compose.yml
@@ -173,16 +173,6 @@ services:
       - web
       - fastapi
 
-  cloudflared:
-    image: cloudflare/cloudflared:latest
-    command: tunnel --config /etc/cloudflared/config.yml run
-    volumes:
-      - ../tunnelCreds:/etc/cloudflared:ro
-    depends_on:
-      - traefik
-      - frontend
-    networks:
-      - trinity-net
 
 
 volumes:

--- a/cloudflared/README.md
+++ b/cloudflared/README.md
@@ -1,0 +1,13 @@
+# Cloudflared Tunnel
+
+This directory contains a standalone compose file for running the
+Cloudflare Tunnel used by the Trinity stack.
+
+From this folder run:
+
+```bash
+docker-compose up -d
+```
+
+The service mounts `../tunnelCreds` which should contain `config.yml` and
+your credential JSON.

--- a/cloudflared/docker-compose.yml
+++ b/cloudflared/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    command: tunnel --config /etc/cloudflared/config.yml run
+    volumes:
+      - ../tunnelCreds:/etc/cloudflared:ro
+    networks:
+      - trinity-net
+
+networks:
+  trinity-net:
+    external: true


### PR DESCRIPTION
## Summary
- remove cloudflared from primary docker compose
- add standalone compose in `/cloudflared`
- document how to start the tunnel

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686e79964de08321a0799eb120d22e28