### PR TITLE
Fix flight dataframe fallback

### DIFF
--- a/TrinityBackendFastAPI/app/DataStorageRetrieval/db.py
+++ b/TrinityBackendFastAPI/app/DataStorageRetrieval/db.py
@@ -253,3 +253,28 @@ async def arrow_dataset_exists(project_id: int, atom_id: str, file_key: str) -> 
 
     return exists
 
+
+async def get_dataset_info(arrow_object: str):
+    """Return dataset info for a stored Arrow object if available."""
+    if asyncpg is None:
+        return None
+    try:
+        conn = await asyncpg.connect(
+            host=POSTGRES_HOST,
+            user=POSTGRES_USER,
+            password=POSTGRES_PASSWORD,
+            database=POSTGRES_DB,
+        )
+    except Exception:
+        return None
+    try:
+        row = await conn.fetchrow(
+            "SELECT file_key, flight_path, original_csv FROM registry_arrowdataset WHERE arrow_object=$1",
+            arrow_object,
+        )
+        if row:
+            return row["file_key"], row["flight_path"], row["original_csv"]
+    finally:
+        await conn.close()
+    return None
+

--- a/TrinityBackendFastAPI/app/features/feature_overview/routes.py
+++ b/TrinityBackendFastAPI/app/features/feature_overview/routes.py
@@ -209,7 +209,8 @@ async def flight_table(object_name: str):
     flight_path = get_flight_path_for_csv(object_name)
     print(f"➡️ flight_table request: {object_name} path={flight_path}")
     if not flight_path:
-        raise HTTPException(status_code=404, detail="Flight path not found")
+        print(f"⚠️ flight path not found for {object_name}; using object name")
+        flight_path = object_name
     try:
         data = download_table_bytes(flight_path)
         return Response(data, media_type="application/vnd.apache.arrow.file")

--- a/TrinityBackendFastAPI/app/features/feature_overview/routes.py
+++ b/TrinityBackendFastAPI/app/features/feature_overview/routes.py
@@ -37,7 +37,11 @@ from app.DataStorageRetrieval.arrow_client import (
     download_dataframe,
     download_table_bytes,
 )
-from app.DataStorageRetrieval.flight_registry import get_flight_path_for_csv
+from app.DataStorageRetrieval.flight_registry import (
+    get_flight_path_for_csv,
+    set_ticket,
+)
+from app.DataStorageRetrieval.db import get_dataset_info
 import asyncio
 
 
@@ -111,6 +115,12 @@ async def column_summary(object_name: str):
         )
     try:
         flight_path = get_flight_path_for_csv(object_name)
+        if not flight_path:
+            info = await get_dataset_info(object_name)
+            if info:
+                file_key, flight_path, original_csv = info
+                set_ticket(file_key, object_name, flight_path, original_csv)
+                print(f"🗄 restored ticket for {object_name}: {flight_path}")
         df = None
         if flight_path:
             print(f"📡 trying flight download {flight_path}")
@@ -207,6 +217,12 @@ async def flight_table(object_name: str):
     """Return the Arrow IPC file for the given object via Arrow Flight."""
     object_name = unquote(object_name)
     flight_path = get_flight_path_for_csv(object_name)
+    if not flight_path:
+        info = await get_dataset_info(object_name)
+        if info:
+            file_key, flight_path, original_csv = info
+            set_ticket(file_key, object_name, flight_path, original_csv)
+            print(f"🗄 restored ticket for {object_name}: {flight_path}")
     print(f"➡️ flight_table request: {object_name} path={flight_path}")
     if not flight_path:
         print(f"⚠️ flight path not found for {object_name}; using object name")
@@ -235,6 +251,12 @@ async def sku_stats(
 
     try:
         flight_path = get_flight_path_for_csv(object_name)
+        if not flight_path:
+            info = await get_dataset_info(object_name)
+            if info:
+                file_key, flight_path, original_csv = info
+                set_ticket(file_key, object_name, flight_path, original_csv)
+                print(f"🗄 restored ticket for {object_name}: {flight_path}")
         df = None
         if flight_path:
             print(f"📡 trying flight download {flight_path}")


### PR DESCRIPTION
## Summary
- allow fetching Arrow data via Flight even if registry is missing
- fall back to using the object name as the flight path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f73377bc483218d82f04ad6bc3c27