### PR TITLE
Add collapse toggle and atom settings icon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ build/
 *.sqlite3
 .env
 .env.*
+**/.env
 
 # Byte-compiled / optimized / DLL files
 *.pyc

--- a/TrinityFrontend/src/components/AtomList/AtomLibrary.tsx
+++ b/TrinityFrontend/src/components/AtomList/AtomLibrary.tsx
@@ -2,16 +2,17 @@
 import React, { useState } from 'react';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
-import { Search, ChevronDown, ChevronRight } from 'lucide-react';
+import { Search, ChevronDown, ChevronRight, ChevronLeft } from 'lucide-react';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import AtomCard from './AtomCard';
 import { atomCategories } from '../AtomCategory/data/atomCategories';
 
 interface AtomLibraryProps {
   onAtomDragStart?: (e: React.DragEvent, atomId: string) => void;
+  onCollapse?: () => void;
 }
 
-const AtomLibrary: React.FC<AtomLibraryProps> = ({ onAtomDragStart }) => {
+const AtomLibrary: React.FC<AtomLibraryProps> = ({ onAtomDragStart, onCollapse }) => {
   const [searchTerm, setSearchTerm] = useState('');
   const [openCategories, setOpenCategories] = useState<string[]>(['Data Sources']);
 
@@ -36,14 +37,23 @@ const AtomLibrary: React.FC<AtomLibraryProps> = ({ onAtomDragStart }) => {
     <div className="w-80 bg-white border-r border-gray-200 flex flex-col h-full">
       {/* Search Header */}
       <div className="p-4 border-b border-gray-200">
-        <div className="relative">
+        <div className="relative flex items-center">
           <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4" />
           <Input
             placeholder="Search atoms..."
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
-            className="pl-10 text-sm"
+            className="pl-10 pr-8 text-sm"
           />
+          {onCollapse && (
+            <button
+              onClick={onCollapse}
+              className="absolute right-2 top-1/2 transform -translate-y-1/2 p-1 hover:bg-gray-100 rounded"
+              title="Collapse"
+            >
+              <ChevronLeft className="w-4 h-4 text-gray-500" />
+            </button>
+          )}
         </div>
       </div>
       

--- a/TrinityFrontend/src/components/AtomList/AtomLibrary.tsx
+++ b/TrinityFrontend/src/components/AtomList/AtomLibrary.tsx
@@ -37,18 +37,20 @@ const AtomLibrary: React.FC<AtomLibraryProps> = ({ onAtomDragStart, onCollapse }
     <div className="w-80 bg-white border-r border-gray-200 flex flex-col h-full">
       {/* Search Header */}
       <div className="p-4 border-b border-gray-200">
-        <div className="relative flex items-center">
-          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4" />
-          <Input
-            placeholder="Search atoms..."
-            value={searchTerm}
-            onChange={(e) => setSearchTerm(e.target.value)}
-            className="pl-10 pr-8 text-sm"
-          />
+        <div className="flex items-center">
+          <div className="relative flex-1">
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4" />
+            <Input
+              placeholder="Search atoms..."
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              className="pl-10 text-sm"
+            />
+          </div>
           {onCollapse && (
             <button
               onClick={onCollapse}
-              className="absolute right-2 top-1/2 transform -translate-y-1/2 p-1 hover:bg-gray-100 rounded"
+              className="ml-2 p-1 hover:bg-gray-100 rounded"
               title="Collapse"
             >
               <ChevronLeft className="w-4 h-4 text-gray-500" />

--- a/TrinityFrontend/src/components/LaboratoryMode/LaboratoryMode.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/LaboratoryMode.tsx
@@ -16,6 +16,7 @@ const LaboratoryMode = () => {
   const [selectedAtomId, setSelectedAtomId] = useState<string>();
   const [selectedCardId, setSelectedCardId] = useState<string>();
   const [cardExhibited, setCardExhibited] = useState<boolean>(false);
+  const [auxActive, setAuxActive] = useState<'settings' | 'frames' | null>(null);
   const [error, setError] = useState<string | null>(null);
   const { toast } = useToast();
   const { cards, setCards } = useExhibitionStore();
@@ -73,6 +74,10 @@ const LaboratoryMode = () => {
     setSelectedAtomId(undefined);
     setSelectedCardId(cardId);
     setCardExhibited(exhibited);
+  };
+
+  const toggleSettingsPanel = () => {
+    setAuxActive(prev => (prev === 'settings' ? null : 'settings'));
   };
 
   const handleSave = async () => {
@@ -212,7 +217,12 @@ const LaboratoryMode = () => {
 
         {/* Main Canvas Area */}
         <div className="flex-1 p-6" onClick={() => {setSelectedAtomId(undefined); setSelectedCardId(undefined);}}>
-          <CanvasArea onAtomSelect={handleAtomSelect} onCardSelect={handleCardSelect} selectedCardId={selectedCardId} />
+          <CanvasArea
+            onAtomSelect={handleAtomSelect}
+            onCardSelect={handleCardSelect}
+            selectedCardId={selectedCardId}
+            onToggleSettingsPanel={toggleSettingsPanel}
+          />
         </div>
 
         {/* Auxiliary menu */}
@@ -220,6 +230,8 @@ const LaboratoryMode = () => {
           selectedAtomId={selectedAtomId}
           selectedCardId={selectedCardId}
           cardExhibited={cardExhibited}
+          active={auxActive}
+          onActiveChange={setAuxActive}
         />
       </div>
     </div>

--- a/TrinityFrontend/src/components/LaboratoryMode/LaboratoryMode.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/LaboratoryMode.tsx
@@ -5,9 +5,9 @@ import { Play, Save, Share2, Undo2, AlertTriangle } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import Header from '@/components/Header';
 import { safeStringify } from '@/utils/safeStringify';
-import AtomLibrary from '@/components/AtomList/AtomLibrary';
 import CanvasArea from './components/CanvasArea';
 import AuxiliaryMenu from './components/AuxiliaryMenu';
+import AuxiliaryMenuLeft from './components/AuxiliaryMenuLeft';
 import { useExhibitionStore } from '@/components/ExhibitionMode/store/exhibitionStore';
 import { REGISTRY_API, LAB_ACTIONS_API } from '@/lib/api';
 import { useLaboratoryStore } from './store/laboratoryStore';
@@ -213,7 +213,7 @@ const LaboratoryMode = () => {
 
       <div className="flex-1 flex overflow-hidden">
         {/* Atoms Sidebar */}
-        <AtomLibrary onAtomDragStart={handleAtomDragStart} />
+        <AuxiliaryMenuLeft onAtomDragStart={handleAtomDragStart} />
 
         {/* Main Canvas Area */}
         <div className="flex-1 p-6" onClick={() => {setSelectedAtomId(undefined); setSelectedCardId(undefined);}}>

--- a/TrinityFrontend/src/components/LaboratoryMode/components/AuxiliaryMenu.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/components/AuxiliaryMenu.tsx
@@ -7,10 +7,28 @@ interface Props {
   selectedAtomId?: string;
   selectedCardId?: string;
   cardExhibited?: boolean;
+  active?: 'settings' | 'frames' | null;
+  onActiveChange?: (active: 'settings' | 'frames' | null) => void;
 }
 
-const AuxiliaryMenu: React.FC<Props> = ({ selectedAtomId, selectedCardId, cardExhibited }) => {
-  const [active, setActive] = useState<'settings' | 'frames' | null>(null);
+const AuxiliaryMenu: React.FC<Props> = ({
+  selectedAtomId,
+  selectedCardId,
+  cardExhibited,
+  active: activeProp,
+  onActiveChange
+}) => {
+  const [internalActive, setInternalActive] = useState<'settings' | 'frames' | null>(null);
+  const controlled = activeProp !== undefined;
+  const active = controlled ? activeProp : internalActive;
+
+  const setActive = (value: 'settings' | 'frames' | null) => {
+    if (controlled) {
+      onActiveChange?.(value);
+    } else {
+      setInternalActive(value);
+    }
+  };
 
   const openSettings = () => setActive(active === 'settings' ? null : 'settings');
   const openFrames = () => setActive(active === 'frames' ? null : 'frames');

--- a/TrinityFrontend/src/components/LaboratoryMode/components/AuxiliaryMenuLeft.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/components/AuxiliaryMenuLeft.tsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import { Grid3X3, ChevronLeft } from 'lucide-react';
+import AtomLibrary from '@/components/AtomList/AtomLibrary';
+
+interface Props {
+  onAtomDragStart?: (e: React.DragEvent, atomId: string) => void;
+}
+
+const AuxiliaryMenuLeft: React.FC<Props> = ({ onAtomDragStart }) => {
+  const [open, setOpen] = useState(true);
+
+  if (!open) {
+    return (
+      <div className="bg-white border-r border-gray-200 transition-all duration-300 flex flex-col h-full w-12">
+        <div className="p-3 border-b border-gray-200 flex items-center justify-between">
+          <button
+            onClick={() => setOpen(true)}
+            className="inline-flex items-center justify-center p-1 h-8 w-8 rounded-md hover:bg-accent hover:text-accent-foreground"
+            title="Open Atom List"
+          >
+            <Grid3X3 className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative">
+      <div className="absolute top-2 right-2 z-10">
+        <button
+          onClick={() => setOpen(false)}
+          className="p-1 hover:bg-gray-100 rounded"
+          title="Collapse"
+        >
+          <ChevronLeft className="w-4 h-4 text-gray-500" />
+        </button>
+      </div>
+      <AtomLibrary onAtomDragStart={onAtomDragStart} />
+    </div>
+  );
+};
+
+export default AuxiliaryMenuLeft;

--- a/TrinityFrontend/src/components/LaboratoryMode/components/AuxiliaryMenuLeft.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/components/AuxiliaryMenuLeft.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Grid3X3, ChevronLeft } from 'lucide-react';
+import { Grid3X3 } from 'lucide-react';
 import AtomLibrary from '@/components/AtomList/AtomLibrary';
 
 interface Props {
@@ -26,18 +26,10 @@ const AuxiliaryMenuLeft: React.FC<Props> = ({ onAtomDragStart }) => {
   }
 
   return (
-    <div className="relative">
-      <div className="absolute top-2 right-2 z-10">
-        <button
-          onClick={() => setOpen(false)}
-          className="p-1 hover:bg-gray-100 rounded"
-          title="Collapse"
-        >
-          <ChevronLeft className="w-4 h-4 text-gray-500" />
-        </button>
-      </div>
-      <AtomLibrary onAtomDragStart={onAtomDragStart} />
-    </div>
+    <AtomLibrary
+      onAtomDragStart={onAtomDragStart}
+      onCollapse={() => setOpen(false)}
+    />
   );
 };
 

--- a/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea.tsx
@@ -785,7 +785,7 @@ const addNewCard = (moleculeId?: string, position?: number) => {
           return (
           <React.Fragment key={card.id}>
           <Card
-            className={`w-full min-h-[200px] bg-white rounded-2xl border-2 transition-all duration-300 flex flex-col ${
+            className={`w-full ${collapsedCards[card.id] ? '' : 'min-h-[200px]'} bg-white rounded-2xl border-2 transition-all duration-300 flex flex-col overflow-hidden ${
               dragOver === card.id
                 ? 'border-[#458EE2] bg-gradient-to-br from-blue-50 to-blue-100 shadow-lg'
                 : 'border-gray-200 shadow-sm hover:shadow-md'
@@ -808,6 +808,15 @@ const addNewCard = (moleculeId?: string, position?: number) => {
                   onAddAtom={(id, atom) => addAtomByName(id, atom)}
                   disabled={card.atoms.length > 0}
                 />
+                {card.atoms.length > 0 && (
+                  <button
+                    onClick={e => handleAtomSettingsClick(e, card.atoms[0].id)}
+                    className="p-1 hover:bg-gray-100 rounded"
+                    title="Atom Settings"
+                  >
+                    <Settings className="w-4 h-4 text-gray-400" />
+                  </button>
+                )}
                 <button
                   onClick={e => { e.stopPropagation(); toggleCardCollapse(card.id); }}
                   className="p-1 hover:bg-gray-100 rounded"

--- a/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea.tsx
@@ -818,14 +818,17 @@ const addNewCard = (moleculeId?: string, position?: number) => {
                   </button>
                 )}
                 <button
-                  onClick={e => { e.stopPropagation(); toggleCardCollapse(card.id); }}
+                  onClick={e => {
+                    e.stopPropagation();
+                    toggleCardCollapse(card.id);
+                  }}
                   className="p-1 hover:bg-gray-100 rounded"
                   title="Toggle Card"
                 >
                   {collapsedCards[card.id] ? (
-                    <ChevronUp className="w-4 h-4 text-gray-400" />
-                  ) : (
                     <ChevronDown className="w-4 h-4 text-gray-400" />
+                  ) : (
+                    <ChevronUp className="w-4 h-4 text-gray-400" />
                   )}
                 </button>
               </div>

--- a/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea.tsx
@@ -3,7 +3,7 @@ import { safeStringify } from '@/utils/safeStringify';
 import { Card, Card as AtomBox } from '@/components/ui/card';
 import { Switch } from '@/components/ui/switch';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
-import { Plus, Grid3X3, Trash2, Eye, Settings, ChevronDown, ChevronUp } from 'lucide-react';
+import { Plus, Grid3X3, Trash2, Eye, Settings, ChevronDown, Minus } from 'lucide-react';
 import { useExhibitionStore } from '../../ExhibitionMode/store/exhibitionStore';
 import { atoms as allAtoms } from '@/components/AtomList/data';
 import { molecules } from '@/components/MoleculeList/data';
@@ -817,20 +817,6 @@ const addNewCard = (moleculeId?: string, position?: number) => {
                     <Settings className="w-4 h-4 text-gray-400" />
                   </button>
                 )}
-                <button
-                  onClick={e => {
-                    e.stopPropagation();
-                    toggleCardCollapse(card.id);
-                  }}
-                  className="p-1 hover:bg-gray-100 rounded"
-                  title="Toggle Card"
-                >
-                  {collapsedCards[card.id] ? (
-                    <ChevronDown className="w-4 h-4 text-gray-400" />
-                  ) : (
-                    <ChevronUp className="w-4 h-4 text-gray-400" />
-                  )}
-                </button>
               </div>
               <div className="flex items-center space-x-2">
                 <span className="text-xs text-gray-500">Exhibit the Card</span>
@@ -845,6 +831,20 @@ const addNewCard = (moleculeId?: string, position?: number) => {
                   className="p-1 hover:bg-gray-100 rounded"
                 >
                   <Trash2 className="w-4 h-4 text-gray-400" />
+                </button>
+                <button
+                  onClick={e => {
+                    e.stopPropagation();
+                    toggleCardCollapse(card.id);
+                  }}
+                  className="p-1 hover:bg-gray-100 rounded"
+                  title="Toggle Card"
+                >
+                  {collapsedCards[card.id] ? (
+                    <ChevronDown className="w-4 h-4 text-gray-400" />
+                  ) : (
+                    <Minus className="w-4 h-4 text-gray-400" />
+                  )}
                 </button>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- update gitignore to ignore `.env` everywhere
- allow external control of auxiliary menu
- enable cards to be collapsed via new chevron icon
- add settings icon in atom headers to open the properties panel
- wire up panel toggle handling in laboratory mode

## Testing
- `npm run lint` *(fails: React hook errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687240ea689c8321acc650d795178c36