### PR TITLE
Enable column classifier routing

### DIFF
--- a/TrinityBackendFastAPI/app/api/router.py
+++ b/TrinityBackendFastAPI/app/api/router.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter
 from app.features.feature_overview.endpoint import router as feature_overview_router
 from app.features.text_box.routes import router as textbox_router
 from app.features.data_upload_validate.endpoint import router as data_upload_validate_router
-from app.features.column_classifier.routes import router as column_classifier_router
+from app.features.column_classifier.endpoint import router as column_classifier_router
 from .card_archive import router as card_archive_router
 from app.features.concat.endpoint import router as concat_router
 from app.features.merge.endpoint import router as merge_router
@@ -15,5 +15,5 @@ api_router.include_router(card_archive_router)
 api_router.include_router(data_upload_validate_router)
 api_router.include_router(concat_router)
 api_router.include_router(merge_router)
-api_router.include_router(column_classifier_router, prefix="/column-classifier")
+api_router.include_router(column_classifier_router)
 

--- a/TrinityBackendFastAPI/app/features/column_classifier/endpoint.py
+++ b/TrinityBackendFastAPI/app/features/column_classifier/endpoint.py
@@ -1,0 +1,9 @@
+from fastapi import APIRouter
+from .routes import router as column_classifier_routes
+
+router = APIRouter()
+router.include_router(
+    column_classifier_routes,
+    prefix="/column-classifier",
+    tags=["Column Classifier"]
+)

--- a/TrinityBackendFastAPI/app/features/column_classifier/main.py
+++ b/TrinityBackendFastAPI/app/features/column_classifier/main.py
@@ -1,7 +1,7 @@
 # main.py - FastAPI App Entrypoint
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.features.column_classifier.routes import router  # ✅ Direct import
+from app.features.column_classifier.endpoint import router  # use packaged router
 import uvicorn
 
 # Create FastAPI app instance

--- a/debugging_column_classifier.txt
+++ b/debugging_column_classifier.txt
@@ -1,0 +1,35 @@
+# Debugging Column Classifier API
+
+These steps help verify that the column classifier service is reachable and
+configured like the other FastAPI atoms.
+
+1. **Check routing in the main router**
+   - `TrinityBackendFastAPI/app/api/router.py` should import the router from
+     `app.features.column_classifier.endpoint` and include it without an extra
+     prefix. This mirrors how other atoms (data upload & validate, feature
+     overview, concat) are registered.
+
+2. **Health check**
+   - Request `GET /api/column-classifier/health` on the FastAPI service
+     (port `8001`). A response with `{"status": "healthy"}` confirms the
+     routes are loaded.
+
+3. **Validate endpoints manually**
+   - `POST /api/column-classifier/classify_columns` accepts form data. Test with
+     `curl`:
+     ```bash
+     curl -X POST http://<HOST_IP>:8001/api/column-classifier/classify_columns \
+          -F validator_atom_id=example_id \
+          -F file_key=dataset1 \
+          -F identifiers="[]" -F measures="[]" -F unclassified="[]"
+     ```
+     Replace `<HOST_IP>` with `127.0.0.1` or the container's address.
+
+4. **Browser errors**
+   - A `404 Not Found` typically means the router prefix is incorrect or the
+     FastAPI container isn't running. Verify the container logs with
+     `docker-compose logs fastapi` for any import errors.
+
+5. **Restart services**
+   - After modifying backend code, run `scripts/start_backend.sh` to rebuild
+     the FastAPI container so changes take effect.


### PR DESCRIPTION
## Summary
- add dedicated endpoint router for column classifier
- register column classifier like other atoms
- update standalone main app
- add debugging notes for troubleshooting routing

## Testing
- `python -m py_compile TrinityBackendFastAPI/app/api/router.py TrinityBackendFastAPI/app/features/column_classifier/endpoint.py`
- `python -m py_compile TrinityBackendFastAPI/app/features/column_classifier/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6874feb6c1088321b93837996ac3de16