### PR TITLE
Link column classifier frontend to FastAPI

### DIFF
--- a/TrinityFrontend/src/components/AtomList/atoms/column-classifier/ColumnClassifierAtom.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/column-classifier/ColumnClassifierAtom.tsx
@@ -1,182 +1,207 @@
-
 import React, { useState } from 'react';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Settings, BarChart3, Eye } from 'lucide-react';
-import ColumnClassifierCanvas from './components/ColumnClassifierCanvas';
-import ColumnClassifierSettings from './components/ColumnClassifierSettings';
-import ColumnClassifierVisualisation from './components/ColumnClassifierVisualisation';
-import ColumnClassifierExhibition from './components/ColumnClassifierExhibition';
+import { Card } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Badge } from '@/components/ui/badge';
+import { CLASSIFIER_API } from '@/lib/api';
 
-export interface ColumnData {
-  name: string;
-  category: 'identifiers' | 'measures' | 'unclassified' | string;
-  sampleValues?: any[];
+interface ClassificationResponse {
+  final_classification: {
+    identifiers: string[];
+    measures: string[];
+    unclassified: string[];
+  };
+  auto_classification: {
+    confidence_scores: Record<string, number>;
+  };
 }
 
-export interface FileClassification {
-  fileName: string;
-  columns: ColumnData[];
-  customDimensions: { [key: string]: string[] };
-}
-
-export interface ClassifierData {
-  files: FileClassification[];
-  activeFileIndex: number;
-}
+interface Dimension { id: string; name: string }
 
 const ColumnClassifierAtom: React.FC = () => {
-  const [classifierData, setClassifierData] = useState<ClassifierData>({
-    files: [],
-    activeFileIndex: 0
-  });
-  
-  const [settings, setSettings] = useState({
-    autoClassify: true,
-    classificationMethod: 'dataType' as 'dataType' | 'columnName',
-    selectedFiles: [] as string[]
-  });
+  const [savedId, setSavedId] = useState('');
+  const [fileKey, setFileKey] = useState('');
+  const [columns, setColumns] = useState<Record<string, string>>({});
+  const [confidence, setConfidence] = useState<Record<string, number>>({});
+  const [dimensions, setDimensions] = useState<Dimension[]>([]);
+  const [newDim, setNewDim] = useState<Dimension>({ id: '', name: '' });
+  const [assignments, setAssignments] = useState<Record<string, string[]>>({});
+  const [step, setStep] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
 
-  const handleDataUpload = (files: FileClassification[]) => {
-    setClassifierData({
-      files,
-      activeFileIndex: 0
-    });
+  const loadClassification = async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const form = new FormData();
+      form.append('validator_atom_id', savedId);
+      form.append('file_key', fileKey);
+      const res = await fetch(`${CLASSIFIER_API}/classify_columns`, { method: 'POST', body: form });
+      if (!res.ok) throw new Error('Failed to classify');
+      const data: ClassificationResponse = await res.json();
+      const allCols: Record<string, string> = {};
+      data.final_classification.identifiers.forEach(c => (allCols[c] = 'identifiers'));
+      data.final_classification.measures.forEach(c => (allCols[c] = 'measures'));
+      data.final_classification.unclassified.forEach(c => (allCols[c] = 'unclassified'));
+      setColumns(allCols);
+      setConfidence(data.auto_classification.confidence_scores);
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
   };
 
-  const handleSettingsChange = (newSettings: any) => {
-    setSettings(prev => ({ ...prev, ...newSettings }));
+  const saveClassification = async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const identifiers = Object.keys(columns).filter(c => columns[c] === 'identifiers');
+      const measures = Object.keys(columns).filter(c => columns[c] === 'measures');
+      const unclassified = Object.keys(columns).filter(c => columns[c] === 'unclassified');
+      const form = new FormData();
+      form.append('validator_atom_id', savedId);
+      form.append('file_key', fileKey);
+      form.append('identifiers', JSON.stringify(identifiers));
+      form.append('measures', JSON.stringify(measures));
+      form.append('unclassified', JSON.stringify(unclassified));
+      const res = await fetch(`${CLASSIFIER_API}/classify_columns`, { method: 'POST', body: form });
+      if (!res.ok) throw new Error('Failed to save classification');
+      await res.json();
+      setStep(2);
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
   };
 
-  const handleColumnMove = (columnName: string, newCategory: string, fileIndex?: number) => {
-    const targetFileIndex = fileIndex !== undefined ? fileIndex : classifierData.activeFileIndex;
-    
-    setClassifierData(prev => ({
-      ...prev,
-      files: prev.files.map((file, index) => {
-        if (index === targetFileIndex) {
-          // Remove column from custom dimensions if it was there
-          const updatedCustomDimensions = { ...file.customDimensions };
-          Object.keys(updatedCustomDimensions).forEach(key => {
-            updatedCustomDimensions[key] = updatedCustomDimensions[key].filter(col => col !== columnName);
-          });
-
-          // Update column category
-          const updatedColumns = file.columns.map(col => 
-            col.name === columnName ? { ...col, category: newCategory } : col
-          );
-
-          // If moving to a custom dimension, add to that dimension
-          if (newCategory !== 'identifiers' && newCategory !== 'measures' && newCategory !== 'unclassified') {
-            if (!updatedCustomDimensions[newCategory]) {
-              updatedCustomDimensions[newCategory] = [];
-            }
-            updatedCustomDimensions[newCategory].push(columnName);
-          }
-
-          return {
-            ...file,
-            columns: updatedColumns,
-            customDimensions: updatedCustomDimensions
-          };
-        }
-        return file;
-      })
-    }));
+  const addDimension = () => {
+    if (!newDim.id || !newDim.name || dimensions.length >= 4) return;
+    if (dimensions.some(d => d.id === newDim.id || d.name === newDim.name)) return;
+    setDimensions([...dimensions, newDim]);
+    setNewDim({ id: '', name: '' });
   };
 
-  const handleCustomDimensionAdd = (dimensionName: string, fileIndex?: number) => {
-    const targetFileIndex = fileIndex !== undefined ? fileIndex : classifierData.activeFileIndex;
-    
-    setClassifierData(prev => ({
-      ...prev,
-      files: prev.files.map((file, index) => {
-        if (index === targetFileIndex) {
-          return {
-            ...file,
-            customDimensions: {
-              ...file.customDimensions,
-              [dimensionName]: []
-            }
-          };
-        }
-        return file;
-      })
-    }));
+  const saveDimensions = async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const form = new FormData();
+      form.append('validator_atom_id', savedId);
+      form.append('file_key', fileKey);
+      form.append('dimensions', JSON.stringify(dimensions));
+      const res = await fetch(`${CLASSIFIER_API}/define_dimensions`, { method: 'POST', body: form });
+      if (!res.ok) throw new Error('Failed to save dimensions');
+      await res.json();
+      const assignInit: Record<string, string[]> = {};
+      dimensions.forEach(d => (assignInit[d.id] = []));
+      setAssignments(assignInit);
+      setStep(3);
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
   };
 
-  const handleFileDelete = (fileIndex: number) => {
-    setClassifierData(prev => {
-      const newFiles = prev.files.filter((_, index) => index !== fileIndex);
-      const newActiveIndex = fileIndex === prev.activeFileIndex 
-        ? Math.max(0, prev.activeFileIndex - 1)
-        : prev.activeFileIndex > fileIndex 
-          ? prev.activeFileIndex - 1 
-          : prev.activeFileIndex;
-
-      return {
-        files: newFiles,
-        activeFileIndex: newFiles.length > 0 ? Math.min(newActiveIndex, newFiles.length - 1) : 0
-      };
-    });
+  const assign = async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const form = new FormData();
+      form.append('validator_atom_id', savedId);
+      form.append('file_key', fileKey);
+      form.append('identifier_assignments', JSON.stringify(assignments));
+      const res = await fetch(`${CLASSIFIER_API}/assign_identifiers_to_dimensions`, { method: 'POST', body: form });
+      if (!res.ok) throw new Error('Failed to assign identifiers');
+      await res.json();
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
   };
 
-  const setActiveFile = (fileIndex: number) => {
-    setClassifierData(prev => ({
-      ...prev,
-      activeFileIndex: fileIndex
-    }));
-  };
+  const identifierOptions = Object.keys(columns).filter(c => columns[c] === 'identifiers');
 
   return (
-    <div className="w-full h-full bg-white flex">
-      {/* Main Canvas Area */}
-      <div className="flex-1">
-        <ColumnClassifierCanvas 
-          data={classifierData}
-          onColumnMove={handleColumnMove}
-          onCustomDimensionAdd={handleCustomDimensionAdd}
-          onActiveFileChange={setActiveFile}
-          onFileDelete={handleFileDelete}
-        />
-      </div>
+    <div className="p-6 space-y-6">
+      <Card className="p-4 space-y-4">
+        <Input placeholder="Saved Dataframe ID" value={savedId} onChange={e => setSavedId(e.target.value)} />
+        <Input placeholder="File Key" value={fileKey} onChange={e => setFileKey(e.target.value)} className="mt-2" />
+        <Button onClick={loadClassification} disabled={loading || !savedId}>Load Columns</Button>
+      </Card>
 
-      {/* Properties Panel */}
-      <div className="w-80 border-l border-gray-200 bg-gray-50">
-        <Tabs defaultValue="settings" className="w-full h-full">
-          <TabsList className="grid w-full grid-cols-3 mx-4 my-4">
-            <TabsTrigger value="settings" className="text-xs">
-              <Settings className="w-3 h-3 mr-1" />
-              Settings
-            </TabsTrigger>
-            <TabsTrigger value="visualisation" className="text-xs">
-              <BarChart3 className="w-3 h-3 mr-1" />
-              Charts
-            </TabsTrigger>
-            <TabsTrigger value="exhibition" className="text-xs">
-              <Eye className="w-3 h-3 mr-1" />
-              Export
-            </TabsTrigger>
-          </TabsList>
-          
-          <div className="px-4 pb-4 h-[calc(100%-80px)] overflow-y-auto">
-            <TabsContent value="settings" className="mt-2">
-              <ColumnClassifierSettings 
-                settings={settings}
-                onSettingsChange={handleSettingsChange}
-                onDataUpload={handleDataUpload}
-              />
-            </TabsContent>
-            
-            <TabsContent value="visualisation" className="mt-2">
-              <ColumnClassifierVisualisation data={classifierData} />
-            </TabsContent>
-            
-            <TabsContent value="exhibition" className="mt-2">
-              <ColumnClassifierExhibition data={classifierData} />
-            </TabsContent>
-          </div>
-        </Tabs>
-      </div>
+      {error && <p className="text-red-500">{error}</p>}
+
+      {Object.keys(columns).length > 0 && step === 1 && (
+        <Card className="p-4 space-y-4">
+          {Object.keys(columns).map(col => (
+            <div key={col} className="flex items-center justify-between">
+              <span className="font-medium">{col}</span>
+              <div className="flex items-center space-x-2">
+                <Badge variant="outline">{confidence[col]?.toFixed(2)}</Badge>
+                <Select value={columns[col]} onValueChange={val => setColumns({ ...columns, [col]: val })}>
+                  <SelectTrigger className="w-40">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="identifiers">Identifier</SelectItem>
+                    <SelectItem value="measures">Measure</SelectItem>
+                    <SelectItem value="unclassified">Unclassified</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+          ))}
+          <Button onClick={saveClassification} disabled={loading}>Save Classification</Button>
+        </Card>
+      )}
+
+      {step === 2 && (
+        <Card className="p-4 space-y-4">
+          {dimensions.map(d => (
+            <Badge key={d.id} className="mr-2">{d.name}</Badge>
+          ))}
+          {dimensions.length < 4 && (
+            <div className="flex space-x-2">
+              <Input placeholder="id" value={newDim.id} onChange={e => setNewDim({ ...newDim, id: e.target.value })} />
+              <Input placeholder="name" value={newDim.name} onChange={e => setNewDim({ ...newDim, name: e.target.value })} />
+              <Button onClick={addDimension}>Add</Button>
+            </div>
+          )}
+          <Button onClick={saveDimensions} disabled={loading || dimensions.length === 0}>Define Dimensions</Button>
+        </Card>
+      )}
+
+      {step === 3 && (
+        <Card className="p-4 space-y-4">
+          {dimensions.map(dim => (
+            <div key={dim.id} className="space-y-2">
+              <p className="font-medium">{dim.name}</p>
+              <select
+                multiple
+                className="w-full border rounded p-2"
+                value={assignments[dim.id] || []}
+                onChange={e => {
+                  const options = Array.from(e.target.selectedOptions).map(o => o.value);
+                  setAssignments({ ...assignments, [dim.id]: options });
+                }}
+              >
+                {identifierOptions.map(id => (
+                  <option key={id} value={id} disabled={Object.entries(assignments).some(([k,v]) => k!==dim.id && v.includes(id))}>
+                    {id}
+                  </option>
+                ))}
+              </select>
+            </div>
+          ))}
+          <Button onClick={assign} disabled={loading}>Assign Identifiers</Button>
+        </Card>
+      )}
     </div>
   );
 };

--- a/TrinityFrontend/src/lib/api.ts
+++ b/TrinityFrontend/src/lib/api.ts
@@ -57,3 +57,6 @@ export const TRINITY_AI_API =
   import.meta.env.VITE_TRINITY_AI_API || backendOrigin.replace(/:8000$/, ':8002');
 
 export const LAB_ACTIONS_API = `${REGISTRY_API}/laboratory-actions`;
+
+export const CLASSIFIER_API =
+  import.meta.env.VITE_CLASSIFIER_API || `${backendOrigin.replace(/:8000$/, ':8005')}/classify`;


### PR DESCRIPTION
## Summary
- add `CLASSIFIER_API` constant
- implement simplified UI for the Column Classifier atom
  - load column classification from FastAPI
  - save user overrides
  - define business dimensions
  - assign identifiers to dimensions

## Testing
- `pip install -q -r TrinityBackendFastAPI/requirements.txt`
- `pytest -q TrinityBackendFastAPI/tests/test_dataframe_viewer.py` *(no tests found)*
- `npm --prefix TrinityFrontend run lint` *(failed: Cannot find package '@eslint/js')*
- `npx --yes tsc -p TrinityFrontend/tsconfig.app.json --noEmit` *(failed due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68751509b7dc83218d6bf1c6dd915ead