### PR TITLE
Fix missing dependency for FastAPI

### DIFF
--- a/TrinityBackendDjango/requirements.txt
+++ b/TrinityBackendDjango/requirements.txt
@@ -31,3 +31,4 @@ minio
 pandas
 motor
 python-multipart
+pydantic-settings==2.10.1

--- a/TrinityBackendDjango/requirements.txt
+++ b/TrinityBackendDjango/requirements.txt
@@ -32,3 +32,4 @@ pandas
 motor
 python-multipart
 pydantic-settings==2.10.1
+httpx

--- a/TrinityBackendFastAPI/app/features/column_classifier/config.py
+++ b/TrinityBackendFastAPI/app/features/column_classifier/config.py
@@ -1,5 +1,5 @@
 # config.py - Data Classification API Configuration (FIXED)
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 from functools import lru_cache
 from typing import Optional
 
@@ -58,11 +58,13 @@ class Settings(BaseSettings):
     log_format: str = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
     enable_request_logging: bool = True
     
-    class Config:
-        env_prefix = "CLASSIFY_"
-        case_sensitive = False
-        env_file = ".env"
-        env_file_encoding = "utf-8"
+    model_config = SettingsConfigDict(
+        env_prefix="CLASSIFY_",
+        case_sensitive=False,
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
 
 @lru_cache()
 def get_settings() -> Settings:


### PR DESCRIPTION
## Summary
- install pydantic-settings in Django base image so FastAPI container gets the module

## Testing
- `pip install -r TrinityBackendDjango/requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: httpx)*

------
https://chatgpt.com/codex/tasks/task_e_6876068ca14c8321a4f690d8b60e54e9