### PR TITLE
Fix router path for column classifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ Follow the steps below to run all services together.
   check will usually return **401** or **403**. The actual login follows
   immediately after.
 
+  When testing the column classifier endpoints a **404 Not Found** response
+  often indicates the specified `validator_atom_id` or `file_key` does not exist
+  rather than a missing route. Double-check these parameters if the API returns
+  a 404 JSON message like `{"detail": "Validator atom 'demo123' not found in database"}`.
+
   Update `CSRF_TRUSTED_ORIGINS` and `CORS_ALLOWED_ORIGINS` in
   `TrinityBackendDjango/.env` so both the local frontend URL
   `http://${HOST_IP}:8080` and the public domain

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Follow the steps below to run all services together.
   Override the API paths with `VITE_ACCOUNTS_API` etc. if needed when deploying
   the APIs on a separate domain.
 
+  If API requests return **403 Forbidden** ensure the browser has a valid session
+  cookie. Log in via the correct `/api/accounts/login/` path before calling
+  authenticated endpoints like `/api/registry/laboratory-actions/`.
+
   Update `CSRF_TRUSTED_ORIGINS` and `CORS_ALLOWED_ORIGINS` in
   `TrinityBackendDjango/.env` so both the local frontend URL
   `http://${HOST_IP}:8080` and the public domain

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ Follow the steps below to run all services together.
   cookie. Log in via the correct `/api/accounts/login/` path before calling
   authenticated endpoints like `/api/registry/laboratory-actions/`.
 
+  The frontend performs a preliminary GET request to `/api/accounts/users/me/`
+  during login to verify the API is reachable. Since no session exists yet this
+  check will usually return **401** or **403**. The actual login follows
+  immediately after.
+
   Update `CSRF_TRUSTED_ORIGINS` and `CORS_ALLOWED_ORIGINS` in
   `TrinityBackendDjango/.env` so both the local frontend URL
   `http://${HOST_IP}:8080` and the public domain

--- a/TrinityBackendFastAPI/app/api/router.py
+++ b/TrinityBackendFastAPI/app/api/router.py
@@ -15,5 +15,5 @@ api_router.include_router(card_archive_router)
 api_router.include_router(data_upload_validate_router)
 api_router.include_router(concat_router)
 api_router.include_router(merge_router)
-api_router.include_router(column_classifier_router, prefix="/classify")
+api_router.include_router(column_classifier_router)
 

--- a/TrinityBackendFastAPI/app/features/column_classifier/database.py
+++ b/TrinityBackendFastAPI/app/features/column_classifier/database.py
@@ -270,3 +270,29 @@ def update_business_dimensions_assignments_in_mongo(
     except Exception as e:
         logging.error(f"MongoDB update error for dimension assignments: {e}")
         return {"status": "error", "error": str(e)}
+
+
+def save_project_dimension_mapping(project_id: int, assignments: dict):
+    """Save identifier assignments per project"""
+    if not check_mongodb_connection():
+        return {"status": "error", "error": "MongoDB not connected"}
+    try:
+        document_id = f"project_{project_id}_dimensions"
+        document = {
+            "_id": document_id,
+            "project_id": project_id,
+            "assignments": assignments,
+            "updated_at": datetime.utcnow(),
+        }
+        result = db["project_dimension_mappings"].replace_one(
+            {"_id": document_id}, document, upsert=True
+        )
+        return {
+            "status": "success",
+            "mongo_id": document_id,
+            "operation": "inserted" if result.upserted_id else "updated",
+            "collection": "project_dimension_mappings",
+        }
+    except Exception as e:
+        logging.error(f"MongoDB save error for project mapping: {e}")
+        return {"status": "error", "error": str(e)}

--- a/TrinityBackendFastAPI/app/features/column_classifier/database.py
+++ b/TrinityBackendFastAPI/app/features/column_classifier/database.py
@@ -166,7 +166,12 @@ def test_mongodb_operations():
 
 # Add this function to your database.py
 
-def save_business_dimensions_to_mongo(validator_atom_id: str, file_key: str, dimensions_dict: dict):
+def save_business_dimensions_to_mongo(
+    validator_atom_id: str,
+    file_key: str,
+    dimensions_dict: dict,
+    project_id: int | None = None,
+):
     """Save business dimensions for a specific file key to MongoDB"""
     if not check_mongodb_connection():
         return {"status": "error", "error": "MongoDB not connected"}
@@ -177,6 +182,7 @@ def save_business_dimensions_to_mongo(validator_atom_id: str, file_key: str, dim
             "_id": document_id,
             "validator_atom_id": validator_atom_id,
             "file_key": file_key,
+            "project_id": project_id,
             "dimensions_type": "business_dimensions",
             "dimensions": dimensions_dict,
             "dimensions_count": len(dimensions_dict),
@@ -217,7 +223,12 @@ def get_business_dimensions_from_mongo(validator_atom_id: str, file_key: str):
         logging.error(f"MongoDB read error for business dimensions: {e}")
         return None
 
-def update_business_dimensions_assignments_in_mongo(validator_atom_id: str, file_key: str, assignments: dict):
+def update_business_dimensions_assignments_in_mongo(
+    validator_atom_id: str,
+    file_key: str,
+    assignments: dict,
+    project_id: int | None = None,
+):
     """Update business dimensions with identifier assignments in MongoDB"""
     if not check_mongodb_connection():
         return {"status": "error", "error": "MongoDB not connected"}
@@ -242,7 +253,8 @@ def update_business_dimensions_assignments_in_mongo(validator_atom_id: str, file
             "dimensions": updated_dimensions,
             "identifier_assignments": assignments,
             "updated_at": datetime.utcnow(),
-            "assignment_completed": True
+            "assignment_completed": True,
+            "project_id": project_id,
         }
         
         result = db["business_dimensions_with_assignments"].update_one(

--- a/TrinityBackendFastAPI/app/features/column_classifier/database.py
+++ b/TrinityBackendFastAPI/app/features/column_classifier/database.py
@@ -164,8 +164,6 @@ def test_mongodb_operations():
 
 
 
-# Add this function to your database.py
-
 def save_business_dimensions_to_mongo(
     validator_atom_id: str,
     file_key: str,

--- a/TrinityBackendFastAPI/app/features/column_classifier/routes.py
+++ b/TrinityBackendFastAPI/app/features/column_classifier/routes.py
@@ -367,8 +367,6 @@ async def classify_columns(
     )
     
     
-# Add this endpoint to your routes.py
-
 @router.post("/define_dimensions", response_model=DefineDimensionsResponse)
 async def define_dimensions(
     validator_atom_id: str = Form(...),
@@ -491,8 +489,6 @@ async def define_dimensions(
         )
     )
 
-
-# Add this endpoint to your routes.py
 
 @router.post("/assign_identifiers_to_dimensions", response_model=AssignIdentifiersResponse)
 async def assign_identifiers_to_dimensions(

--- a/TrinityBackendFastAPI/app/features/column_classifier/routes.py
+++ b/TrinityBackendFastAPI/app/features/column_classifier/routes.py
@@ -373,7 +373,8 @@ async def classify_columns(
 async def define_dimensions(
     validator_atom_id: str = Form(...),
     file_key: str = Form(...),
-    dimensions: str = Form(...)
+    dimensions: str = Form(...),
+    project_id: int = Form(None)
 ):
     """
     Endpoint to define business dimensions for a specific file key in a validator atom.
@@ -445,7 +446,9 @@ async def define_dimensions(
 
     # Save to MongoDB
     try:
-        mongo_result = save_business_dimensions_to_mongo(validator_atom_id, file_key, dims_dict)
+        mongo_result = save_business_dimensions_to_mongo(
+            validator_atom_id, file_key, dims_dict, project_id
+        )
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to save dimensions to MongoDB: {str(e)}")
 
@@ -481,6 +484,7 @@ async def define_dimensions(
         ),
         mongodb_saved=mongo_result.get("status") == "success",
         in_memory_saved=in_memory_status,
+        project_id=project_id,
         next_steps=NextSteps(
             assign_identifiers=f"POST /assign_identifiers_to_dimensions with validator_atom_id: {validator_atom_id}",
             view_assignments=f"GET /get_identifier_assignments/{validator_atom_id}/{file_key}"
@@ -494,7 +498,8 @@ async def define_dimensions(
 async def assign_identifiers_to_dimensions(
     validator_atom_id: str = Form(...),
     file_key: str = Form(...),
-    identifier_assignments: str = Form(...)
+    identifier_assignments: str = Form(...),
+    project_id: int = Form(None)
 ):
     """
     Assign identifiers to dimensions and save within business dimensions structure.
@@ -599,7 +604,9 @@ async def assign_identifiers_to_dimensions(
 
     # Save to MongoDB
     try:
-        mongo_result = update_business_dimensions_assignments_in_mongo(validator_atom_id, file_key, assignments)
+        mongo_result = update_business_dimensions_assignments_in_mongo(
+            validator_atom_id, file_key, assignments, project_id
+        )
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to save assignments to MongoDB: {str(e)}")
 
@@ -628,6 +635,7 @@ async def assign_identifiers_to_dimensions(
         validator_atom_id=validator_atom_id,
         file_key=file_key,
         validator_type=validator_data.get("template_type", "custom"),
+        project_id=project_id,
         updated_business_dimensions=updated_business_dimensions,
         assignment_summary=AssignmentSummary(
             total_identifiers=len(available_identifiers),

--- a/TrinityBackendFastAPI/app/features/column_classifier/schemas.py
+++ b/TrinityBackendFastAPI/app/features/column_classifier/schemas.py
@@ -63,6 +63,7 @@ class DefineDimensionsResponse(BaseModel):
     dimension_details: DimensionDetails
     mongodb_saved: bool
     in_memory_saved: str
+    project_id: int | None = None
     next_steps: NextSteps
 
 
@@ -86,6 +87,7 @@ class AssignIdentifiersResponse(BaseModel):
     validator_atom_id: str
     file_key: str
     validator_type: str
+    project_id: int | None = None
     updated_business_dimensions: Dict[str, Any]
     assignment_summary: AssignmentSummary
     unassigned_identifiers: List[str]

--- a/TrinityBackendFastAPI/app/features/column_classifier/schemas.py
+++ b/TrinityBackendFastAPI/app/features/column_classifier/schemas.py
@@ -32,16 +32,12 @@ class FinalClassification(BaseModel):
 class ClassifyColumnsResponse(BaseModel):
     status: str
     message: str
-    validator_atom_id: str
-    file_key: str
-    validator_type: str
+    dataframe: str
     auto_classification: AutoClassification
     user_classification: UserClassification
     final_classification: FinalClassification
     user_modified: bool
     summary: ClassificationSummary
-    mongodb_save_status: str
-    in_memory_save_status: str
     
     
 # Add this to your schemas.py file

--- a/TrinityBackendFastAPI/app/features/column_classifier/schemas.py
+++ b/TrinityBackendFastAPI/app/features/column_classifier/schemas.py
@@ -39,8 +39,6 @@ class ClassifyColumnsResponse(BaseModel):
     user_modified: bool
     summary: ClassificationSummary
     
-    
-# Add this to your schemas.py file
 
 class DimensionDetails(BaseModel):
     dimension_ids: List[str]
@@ -67,8 +65,6 @@ class DefineDimensionsResponse(BaseModel):
     next_steps: NextSteps
 
 
-
-# Add these to your schemas.py file
 
 class AssignmentSummary(BaseModel):
     total_identifiers: int

--- a/TrinityFrontend/src/components/AtomList/atoms/column-classifier/ColumnClassifierAtom.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/column-classifier/ColumnClassifierAtom.tsx
@@ -89,17 +89,17 @@ const ColumnClassifierAtom: React.FC<Props> = ({ atomId }) => {
   };
 
   const saveAssignments = async () => {
-    if (!settings.validatorId || !classifierData.files.length) return;
+    if (!classifierData.files.length) return;
     const currentFile = classifierData.files[classifierData.activeFileIndex];
     const stored = localStorage.getItem('current-project');
     const projectId = stored ? JSON.parse(stored).id : null;
     const form = new FormData();
-    form.append('validator_atom_id', settings.validatorId);
-    form.append('file_key', currentFile.fileName);
     form.append('identifier_assignments', JSON.stringify(currentFile.customDimensions));
     if (projectId) {
       form.append('project_id', String(projectId));
     }
+    if (settings.validatorId) form.append('validator_atom_id', settings.validatorId);
+    form.append('file_key', currentFile.fileName);
     await fetch(`${CLASSIFIER_API}/assign_identifiers_to_dimensions`, {
       method: 'POST',
       body: form,

--- a/TrinityFrontend/src/components/AtomList/atoms/column-classifier/ColumnClassifierAtom.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/column-classifier/ColumnClassifierAtom.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { BarChart3, Eye } from 'lucide-react';
+import { BarChart3 } from 'lucide-react';
 import ColumnClassifierCanvas from './components/ColumnClassifierCanvas';
 import ColumnClassifierVisualisation from './components/ColumnClassifierVisualisation';
-import ColumnClassifierExhibition from './components/ColumnClassifierExhibition';
 import {
   useLaboratoryStore,
   DEFAULT_COLUMN_CLASSIFIER_SETTINGS,
@@ -123,14 +122,10 @@ const ColumnClassifierAtom: React.FC<Props> = ({ atomId }) => {
 
       <div className="w-80 border-l border-gray-200 bg-gray-50">
         <Tabs defaultValue="visualisation" className="w-full h-full">
-          <TabsList className="grid w-full grid-cols-2 mx-4 my-4">
+          <TabsList className="grid w-full grid-cols-1 mx-4 my-4">
             <TabsTrigger value="visualisation" className="text-xs">
               <BarChart3 className="w-3 h-3 mr-1" />
               Charts
-            </TabsTrigger>
-            <TabsTrigger value="exhibition" className="text-xs">
-              <Eye className="w-3 h-3 mr-1" />
-              Export
             </TabsTrigger>
           </TabsList>
 
@@ -151,9 +146,6 @@ const ColumnClassifierAtom: React.FC<Props> = ({ atomId }) => {
               />
             </TabsContent>
 
-            <TabsContent value="exhibition" className="mt-2">
-              <ColumnClassifierExhibition data={classifierData} />
-            </TabsContent>
           </div>
         </Tabs>
       </div>

--- a/TrinityFrontend/src/components/AtomList/atoms/column-classifier/ColumnClassifierAtom.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/column-classifier/ColumnClassifierAtom.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import ColumnClassifierCanvas from './components/ColumnClassifierCanvas';
 import ColumnClassifierVisualisation from './components/ColumnClassifierVisualisation';
+import ColumnClassifierDimensionConfig from './components/ColumnClassifierDimensionConfig';
 import {
   useLaboratoryStore,
   DEFAULT_COLUMN_CLASSIFIER_SETTINGS,
@@ -133,21 +134,28 @@ const ColumnClassifierAtom: React.FC<Props> = ({ atomId }) => {
     ).every(c => c.length === 0);
 
   return (
-    <div className="w-full h-full bg-white flex">
-      <div className="w-3/5 p-4 overflow-y-auto">
-        <ColumnClassifierCanvas
+    <div className="w-full h-full bg-white flex flex-col">
+      <div className="flex flex-1">
+        <div className="w-3/5 p-4 overflow-y-auto">
+          <ColumnClassifierCanvas
+            data={classifierData}
+            validatorId={settings.validatorId}
+            onColumnMove={handleColumnMove}
+            onActiveFileChange={setActiveFile}
+            onFileDelete={handleFileDelete}
+          />
+        </div>
+        <div className="w-2/5 border-l border-gray-200 bg-gray-50 p-4 overflow-y-auto">
+          <ColumnClassifierVisualisation data={classifierData} />
+        </div>
+      </div>
+      <div className="border-t p-4 overflow-y-auto">
+        <ColumnClassifierDimensionConfig
           data={classifierData}
-          validatorId={settings.validatorId}
           onColumnMove={handleColumnMove}
-          onActiveFileChange={setActiveFile}
-          onFileDelete={handleFileDelete}
           onSave={saveAssignments}
           saveDisabled={saveDisabled}
         />
-      </div>
-
-      <div className="w-2/5 border-l border-gray-200 bg-gray-50 p-4 overflow-y-auto">
-        <ColumnClassifierVisualisation data={classifierData} />
       </div>
     </div>
   );

--- a/TrinityFrontend/src/components/AtomList/atoms/column-classifier/ColumnClassifierAtom.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/column-classifier/ColumnClassifierAtom.tsx
@@ -140,8 +140,13 @@ const ColumnClassifierAtom: React.FC<Props> = ({ atomId }) => {
                 data={classifierData}
                 onSave={saveAssignments}
                 saveDisabled={
-                  Object.keys(classifierData.files[classifierData.activeFileIndex].customDimensions).length === 0 ||
-                  Object.values(classifierData.files[classifierData.activeFileIndex].customDimensions).every(c => c.length === 0)
+                  !classifierData.files.length ||
+                  Object.keys(
+                    classifierData.files[classifierData.activeFileIndex]?.customDimensions || {}
+                  ).length === 0 ||
+                  Object.values(
+                    classifierData.files[classifierData.activeFileIndex]?.customDimensions || {}
+                  ).every(c => c.length === 0)
                 }
               />
             </TabsContent>

--- a/TrinityFrontend/src/components/AtomList/atoms/column-classifier/ColumnClassifierAtom.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/column-classifier/ColumnClassifierAtom.tsx
@@ -115,8 +115,7 @@ const ColumnClassifierAtom: React.FC<Props> = ({ atomId }) => {
     if (projectId) {
       form.append('project_id', String(projectId));
     }
-    if (settings.validatorId) form.append('validator_atom_id', settings.validatorId);
-    form.append('file_key', currentFile.fileName);
+    console.log('Saving assignments for project', projectId, currentFile.customDimensions);
     await fetch(`${CLASSIFIER_API}/assign_identifiers_to_dimensions`, {
       method: 'POST',
       body: form,

--- a/TrinityFrontend/src/components/AtomList/atoms/column-classifier/ColumnClassifierAtom.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/column-classifier/ColumnClassifierAtom.tsx
@@ -66,25 +66,6 @@ const ColumnClassifierAtom: React.FC<Props> = ({ atomId }) => {
     updateSettings(atomId, { data: updated });
   };
 
-  const handleCustomDimensionAdd = (dimensionName: string, fileIndex?: number) => {
-    const targetFileIndex = fileIndex !== undefined ? fileIndex : classifierData.activeFileIndex;
-    const updated = {
-      ...classifierData,
-      files: classifierData.files.map((file, index) => {
-        if (index === targetFileIndex) {
-          return {
-            ...file,
-            customDimensions: {
-              ...file.customDimensions,
-              [dimensionName]: []
-            }
-          };
-        }
-        return file;
-      })
-    };
-    updateSettings(atomId, { data: updated });
-  };
 
   const handleFileDelete = (fileIndex: number) => {
     const newFiles = classifierData.files.filter((_, index) => index !== fileIndex);
@@ -114,7 +95,6 @@ const ColumnClassifierAtom: React.FC<Props> = ({ atomId }) => {
         <ColumnClassifierCanvas
           data={classifierData}
           onColumnMove={handleColumnMove}
-          onCustomDimensionAdd={handleCustomDimensionAdd}
           onActiveFileChange={setActiveFile}
           onFileDelete={handleFileDelete}
         />

--- a/TrinityFrontend/src/components/AtomList/atoms/column-classifier/ColumnClassifierAtom.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/column-classifier/ColumnClassifierAtom.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { BarChart3 } from 'lucide-react';
+
 import ColumnClassifierCanvas from './components/ColumnClassifierCanvas';
 import ColumnClassifierVisualisation from './components/ColumnClassifierVisualisation';
 import {
@@ -108,46 +107,31 @@ const ColumnClassifierAtom: React.FC<Props> = ({ atomId }) => {
     });
   };
 
+  const saveDisabled =
+    !classifierData.files.length ||
+    Object.keys(
+      classifierData.files[classifierData.activeFileIndex]?.customDimensions || {}
+    ).length === 0 ||
+    Object.values(
+      classifierData.files[classifierData.activeFileIndex]?.customDimensions || {}
+    ).every(c => c.length === 0);
+
   return (
     <div className="w-full h-full bg-white flex">
-      <div className="flex-1">
+      <div className="w-3/5 p-4 overflow-y-auto">
         <ColumnClassifierCanvas
           data={classifierData}
           validatorId={settings.validatorId}
           onColumnMove={handleColumnMove}
           onActiveFileChange={setActiveFile}
           onFileDelete={handleFileDelete}
+          onSave={saveAssignments}
+          saveDisabled={saveDisabled}
         />
       </div>
 
-      <div className="w-80 border-l border-gray-200 bg-gray-50">
-        <Tabs defaultValue="visualisation" className="w-full h-full">
-          <TabsList className="grid w-full grid-cols-1 mx-4 my-4">
-            <TabsTrigger value="visualisation" className="text-xs">
-              <BarChart3 className="w-3 h-3 mr-1" />
-              Charts
-            </TabsTrigger>
-          </TabsList>
-
-          <div className="px-4 pb-4 h-[calc(100%-80px)] overflow-y-auto">
-            <TabsContent value="visualisation" className="mt-2">
-              <ColumnClassifierVisualisation
-                data={classifierData}
-                onSave={saveAssignments}
-                saveDisabled={
-                  !classifierData.files.length ||
-                  Object.keys(
-                    classifierData.files[classifierData.activeFileIndex]?.customDimensions || {}
-                  ).length === 0 ||
-                  Object.values(
-                    classifierData.files[classifierData.activeFileIndex]?.customDimensions || {}
-                  ).every(c => c.length === 0)
-                }
-              />
-            </TabsContent>
-
-          </div>
-        </Tabs>
+      <div className="w-2/5 border-l border-gray-200 bg-gray-50 p-4 overflow-y-auto">
+        <ColumnClassifierVisualisation data={classifierData} />
       </div>
     </div>
   );

--- a/TrinityFrontend/src/components/AtomList/atoms/column-classifier/ColumnClassifierAtom.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/column-classifier/ColumnClassifierAtom.tsx
@@ -94,6 +94,7 @@ const ColumnClassifierAtom: React.FC<Props> = ({ atomId }) => {
       <div className="flex-1">
         <ColumnClassifierCanvas
           data={classifierData}
+          validatorId={settings.validatorId}
           onColumnMove={handleColumnMove}
           onActiveFileChange={setActiveFile}
           onFileDelete={handleFileDelete}

--- a/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierCanvas.tsx
@@ -12,8 +12,7 @@ interface ColumnClassifierCanvasProps {
   onColumnMove: (columnName: string, newCategory: string, fileIndex?: number) => void;
   onActiveFileChange: (fileIndex: number) => void;
   onFileDelete?: (fileIndex: number) => void;
-  onSave?: () => void;
-  saveDisabled?: boolean;
+  // only handles column movements; saving handled separately
 }
 
 const ColumnClassifierCanvas: React.FC<ColumnClassifierCanvasProps> = ({
@@ -22,8 +21,7 @@ const ColumnClassifierCanvas: React.FC<ColumnClassifierCanvasProps> = ({
   onColumnMove,
   onActiveFileChange,
   onFileDelete,
-  onSave,
-  saveDisabled
+  // save functionality removed from this component
 }) => {
   const [showDropdowns, setShowDropdowns] = useState<{ [key: string]: boolean }>({});
   const getDisplayName = (name: string) => name.split('/').pop() || name;
@@ -226,43 +224,6 @@ const ColumnClassifierCanvas: React.FC<ColumnClassifierCanvasProps> = ({
             </Card>
           )}
 
-          <h4 className="font-semibold text-gray-700 text-lg mt-4 mb-2 w-full border-t pt-2">
-            Dimensions Config
-          </h4>
-
-          {Object.keys(currentFile.customDimensions).length === 0 ? (
-            <p className="text-sm text-gray-500">
-              Configure Dimensions in Properties -&gt; Dimensions to set Dimensions
-            </p>
-          ) : (
-            Object.entries(currentFile.customDimensions).map(([dimensionName, columnNames]) => {
-              const dimensionColumns = columnNames
-                .map(name => currentFile.columns.find(col => col.name === name))
-                .filter(Boolean) as ColumnData[];
-
-              return (
-                <DimensionCard
-                  key={dimensionName}
-                  title={dimensionName}
-                  icon={<TrendingUp className="w-5 h-5 mr-2" />}
-                  gradient="bg-gradient-to-r from-purple-500 to-purple-600"
-                  columns={dimensionColumns}
-                  category={dimensionName}
-                  onRemove={(columnName) => onColumnMove(columnName, 'identifiers', data.activeFileIndex)}
-                />
-              );
-            })
-          )}
-        </div>
-
-        <div className="pt-4">
-          <Button
-            disabled={saveDisabled}
-            onClick={onSave}
-            className="w-full h-12 text-sm font-semibold bg-gradient-to-r from-gray-800 to-gray-900 hover:from-gray-900 hover:to-black"
-          >
-            Save Dimensions
-          </Button>
         </div>
       </div>
     </div>

--- a/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierCanvas.tsx
@@ -26,6 +26,7 @@ const ColumnClassifierCanvas: React.FC<ColumnClassifierCanvasProps> = ({
   saveDisabled
 }) => {
   const [showDropdowns, setShowDropdowns] = useState<{ [key: string]: boolean }>({});
+  const getDisplayName = (name: string) => name.split('/').pop() || name;
 
   if (!data.files.length) {
     return (
@@ -161,12 +162,12 @@ const ColumnClassifierCanvas: React.FC<ColumnClassifierCanvasProps> = ({
                 variant="ghost"
                 size="sm"
                 onClick={() => onActiveFileChange(index)}
-                className={`flex items-center space-x-2 p-0 h-auto ${
+                className={`flex items-center space-x-2 p-0 h-auto whitespace-normal ${
                   index === data.activeFileIndex ? 'text-white hover:text-white' : ''
                 }`}
               >
                 <FileText className="w-4 h-4" />
-                <span className="font-medium">{file.fileName}</span>
+                <span className="font-medium break-all whitespace-normal">{getDisplayName(file.fileName)}</span>
               </Button>
               <Button
                 variant="ghost"

--- a/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierCanvas.tsx
@@ -3,28 +3,23 @@ import React, { useState } from 'react';
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Edit2, Plus, X, FileText, Trash2, TrendingUp, BarChart3, Tag } from 'lucide-react';
+import { Edit2, X, FileText, Trash2, TrendingUp, BarChart3, Tag } from 'lucide-react';
 import { ClassifierData, ColumnData } from '../ColumnClassifierAtom';
 
 interface ColumnClassifierCanvasProps {
   data: ClassifierData;
   onColumnMove: (columnName: string, newCategory: string, fileIndex?: number) => void;
-  onCustomDimensionAdd: (dimensionName: string, fileIndex?: number) => void;
   onActiveFileChange: (fileIndex: number) => void;
   onFileDelete?: (fileIndex: number) => void;
 }
 
-const ColumnClassifierCanvas: React.FC<ColumnClassifierCanvasProps> = ({ 
-  data, 
-  onColumnMove, 
-  onCustomDimensionAdd,
+const ColumnClassifierCanvas: React.FC<ColumnClassifierCanvasProps> = ({
+  data,
+  onColumnMove,
   onActiveFileChange,
   onFileDelete
 }) => {
   const [showDropdowns, setShowDropdowns] = useState<{ [key: string]: boolean }>({});
-  const [showCustomDimensionInput, setShowCustomDimensionInput] = useState(false);
-  const [newDimensionName, setNewDimensionName] = useState('');
 
   if (!data.files.length) {
     return (
@@ -72,13 +67,6 @@ const ColumnClassifierCanvas: React.FC<ColumnClassifierCanvasProps> = ({
     setShowDropdowns(prev => ({ ...prev, [category]: false }));
   };
 
-  const handleAddCustomDimension = () => {
-    if (newDimensionName.trim()) {
-      onCustomDimensionAdd(newDimensionName.trim(), data.activeFileIndex);
-      setNewDimensionName('');
-      setShowCustomDimensionInput(false);
-    }
-  };
 
   const handleFileDelete = (fileIndex: number, e: React.MouseEvent) => {
     e.stopPropagation();
@@ -214,71 +202,30 @@ const ColumnClassifierCanvas: React.FC<ColumnClassifierCanvasProps> = ({
         />
 
         {/* Custom Dimensions */}
-        {currentFile && Object.entries(currentFile.customDimensions).map(([dimensionName, columnNames]) => {
-          const dimensionColumns = columnNames.map(name => 
-            currentFile.columns.find(col => col.name === name)
-          ).filter(Boolean) as ColumnData[];
-
-          return (
-            <DimensionCard
-              key={dimensionName}
-              title={dimensionName}
-              icon={<TrendingUp className="w-5 h-5 mr-2" />}
-              gradient="bg-gradient-to-r from-purple-500 to-purple-600"
-              columns={dimensionColumns}
-              category={dimensionName}
-              onRemove={(columnName) => onColumnMove(columnName, 'unclassified', data.activeFileIndex)}
-            />
-          );
-        })}
-
-        {/* Create Custom Dimension */}
-        {!showCustomDimensionInput ? (
-          <Card className="border-2 border-dashed border-gray-300 hover:border-gray-400 transition-colors">
-            <div className="p-6">
-              <Button 
-                variant="outline" 
-                className="w-full h-16 text-lg font-medium"
-                onClick={() => setShowCustomDimensionInput(true)}
-              >
-                <Plus className="w-6 h-6 mr-3" />
-                Create Custom Dimension
-              </Button>
-            </div>
-          </Card>
+        {Object.keys(currentFile.customDimensions).length === 0 ? (
+          <p className="text-sm text-gray-500">
+            Configure Dimensions in Properties -&gt; Dimensions to set Dimensions
+          </p>
         ) : (
-          <Card className="border-0 shadow-xl bg-white/90 backdrop-blur-sm">
-            <div className="bg-gradient-to-r from-purple-500 to-purple-600 p-4">
-              <h4 className="font-bold text-white text-lg">New Custom Dimension</h4>
-            </div>
-            <div className="p-6 space-y-4">
-              <Input
-                placeholder="Enter dimension name..."
-                value={newDimensionName}
-                onChange={(e) => setNewDimensionName(e.target.value)}
-                onKeyPress={(e) => e.key === 'Enter' && handleAddCustomDimension()}
-                className="text-lg p-3"
+          Object.entries(currentFile.customDimensions).map(([dimensionName, columnNames]) => {
+            const dimensionColumns = columnNames.map(name =>
+              currentFile.columns.find(col => col.name === name)
+            ).filter(Boolean) as ColumnData[];
+
+            return (
+              <DimensionCard
+                key={dimensionName}
+                title={dimensionName}
+                icon={<TrendingUp className="w-5 h-5 mr-2" />}
+                gradient="bg-gradient-to-r from-purple-500 to-purple-600"
+                columns={dimensionColumns}
+                category={dimensionName}
+                onRemove={(columnName) => onColumnMove(columnName, 'unclassified', data.activeFileIndex)}
               />
-              <div className="flex space-x-3">
-                <Button 
-                  onClick={handleAddCustomDimension}
-                  className="bg-gradient-to-r from-purple-500 to-purple-600 hover:from-purple-600 hover:to-purple-700"
-                >
-                  Create Dimension
-                </Button>
-                <Button 
-                  variant="outline" 
-                  onClick={() => {
-                    setShowCustomDimensionInput(false);
-                    setNewDimensionName('');
-                  }}
-                >
-                  Cancel
-                </Button>
-              </div>
-            </div>
-          </Card>
+            );
+          })
         )}
+
 
         {/* Unclassified Columns - if any */}
         {getAvailableColumns().length > 0 && (

--- a/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierCanvas.tsx
@@ -83,13 +83,13 @@ const ColumnClassifierCanvas: React.FC<ColumnClassifierCanvasProps> = ({
     onRemove: (columnName: string) => void;
   }> = ({ title, icon, gradient, columns, category, onRemove }) => (
     <Card className="border-0 shadow-xl bg-white/90 backdrop-blur-sm overflow-hidden transform hover:scale-105 transition-all duration-300">
-      <div className={`${gradient} p-4`}>
+      <div className={`${gradient} p-3`}>
         <h4 className="font-bold text-white text-lg flex items-center">
           {icon}
           {title}
         </h4>
       </div>
-      <div className="p-6">
+      <div className="p-4">
         <div className="flex flex-wrap gap-3">
           {columns.map(column => (
             <Badge
@@ -136,7 +136,7 @@ const ColumnClassifierCanvas: React.FC<ColumnClassifierCanvasProps> = ({
   );
 
   return (
-    <div className="w-full h-full p-6 bg-gradient-to-br from-gray-50 to-gray-100 overflow-y-auto">
+    <div className="w-full h-full p-4 bg-gradient-to-br from-gray-50 to-gray-100 overflow-y-auto">
       <div className="mb-6">
         <h2 className="text-2xl font-bold text-gray-900 mb-4">
           Column <span className="bg-yellow-200 px-2 py-1 rounded">Classifier</span>
@@ -179,7 +179,7 @@ const ColumnClassifierCanvas: React.FC<ColumnClassifierCanvasProps> = ({
         </div>
       </div>
 
-      <div className="space-y-6">
+      <div className="space-y-4">
         {/* Identifiers Section */}
         <DimensionCard
           title="Identifiers"

--- a/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierCanvas.tsx
@@ -5,7 +5,6 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Edit2, X, FileText, Trash2, TrendingUp, BarChart3, Tag } from 'lucide-react';
 import { ClassifierData, ColumnData } from '../ColumnClassifierAtom';
-import { CLASSIFIER_API } from '@/lib/api';
 
 interface ColumnClassifierCanvasProps {
   data: ClassifierData;
@@ -75,26 +74,6 @@ const ColumnClassifierCanvas: React.FC<ColumnClassifierCanvasProps> = ({
     }
   };
 
-  const saveAssignments = async () => {
-    if (!validatorId) return;
-    const form = new FormData();
-    form.append('validator_atom_id', validatorId);
-    form.append('file_key', currentFile.fileName);
-    form.append(
-      'identifier_assignments',
-      JSON.stringify(currentFile.customDimensions)
-    );
-    try {
-      await fetch(`${CLASSIFIER_API}/assign_identifiers_to_dimensions`, {
-        method: 'POST',
-        body: form,
-        credentials: 'include'
-      });
-    } catch (err) {
-      console.error('Failed to save assignments', err);
-    }
-  };
-
   const DimensionCard: React.FC<{
     title: string;
     icon: React.ReactNode;
@@ -157,7 +136,7 @@ const ColumnClassifierCanvas: React.FC<ColumnClassifierCanvasProps> = ({
   );
 
   return (
-    <div className="w-full h-full p-6 bg-gradient-to-br from-gray-50 to-gray-100">
+    <div className="w-full h-full p-6 bg-gradient-to-br from-gray-50 to-gray-100 overflow-y-auto">
       <div className="mb-6">
         <h2 className="text-2xl font-bold text-gray-900 mb-4">
           Column <span className="bg-yellow-200 px-2 py-1 rounded">Classifier</span>
@@ -269,19 +248,6 @@ const ColumnClassifierCanvas: React.FC<ColumnClassifierCanvasProps> = ({
           })
         )}
 
-        {/* Save Dimensions Button */}
-        <div className="pt-4">
-          <Button
-            disabled={
-              Object.keys(currentFile.customDimensions).length === 0 ||
-              Object.values(currentFile.customDimensions).every(c => c.length === 0)
-            }
-            onClick={saveAssignments}
-            className="w-full h-14 text-lg font-semibold bg-gradient-to-r from-gray-800 to-gray-900 hover:from-gray-900 hover:to-black shadow-xl"
-          >
-            Save Dimensions
-          </Button>
-        </div>
       </div>
     </div>
   );

--- a/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierCanvas.tsx
@@ -12,6 +12,8 @@ interface ColumnClassifierCanvasProps {
   onColumnMove: (columnName: string, newCategory: string, fileIndex?: number) => void;
   onActiveFileChange: (fileIndex: number) => void;
   onFileDelete?: (fileIndex: number) => void;
+  onSave?: () => void;
+  saveDisabled?: boolean;
 }
 
 const ColumnClassifierCanvas: React.FC<ColumnClassifierCanvasProps> = ({
@@ -19,7 +21,9 @@ const ColumnClassifierCanvas: React.FC<ColumnClassifierCanvasProps> = ({
   validatorId,
   onColumnMove,
   onActiveFileChange,
-  onFileDelete
+  onFileDelete,
+  onSave,
+  saveDisabled
 }) => {
   const [showDropdowns, setShowDropdowns] = useState<{ [key: string]: boolean }>({});
 
@@ -248,6 +252,16 @@ const ColumnClassifierCanvas: React.FC<ColumnClassifierCanvasProps> = ({
           })
         )}
 
+      </div>
+
+      <div className="pt-4">
+        <Button
+          disabled={saveDisabled}
+          onClick={onSave}
+          className="w-full h-12 text-sm font-semibold bg-gradient-to-r from-gray-800 to-gray-900 hover:from-gray-900 hover:to-black"
+        >
+          Save Dimensions
+        </Button>
       </div>
     </div>
   );

--- a/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierCanvas.tsx
@@ -53,10 +53,7 @@ const ColumnClassifierCanvas: React.FC<ColumnClassifierCanvasProps> = ({
 
   const getAvailableIdentifiers = () => {
     if (!currentFile) return [];
-    const used = new Set(Object.values(currentFile.customDimensions).flat());
-    return currentFile.columns.filter(
-      col => col.category === 'identifiers' && !used.has(col.name)
-    );
+    return currentFile.columns.filter(col => col.category === 'identifiers');
   };
 
   const toggleDropdown = (category: string) => {
@@ -141,7 +138,7 @@ const ColumnClassifierCanvas: React.FC<ColumnClassifierCanvasProps> = ({
   );
 
   return (
-    <div className="w-full h-full p-4 bg-gradient-to-br from-gray-50 to-gray-100 overflow-y-auto">
+    <div className="w-full h-full p-4 bg-gradient-to-br from-gray-50 to-gray-100 flex flex-col">
       <div className="mb-6">
         <h2 className="text-2xl font-bold text-gray-900 mb-4">
           Column <span className="bg-yellow-200 px-2 py-1 rounded">Classifier</span>
@@ -184,85 +181,89 @@ const ColumnClassifierCanvas: React.FC<ColumnClassifierCanvasProps> = ({
         </div>
       </div>
 
-      <div className="space-y-4">
-        {/* Identifiers Section */}
-        <DimensionCard
-          title="Identifiers"
-          icon={<Tag className="w-5 h-5 mr-2" />}
-          gradient="bg-gradient-to-r from-blue-500 to-blue-600"
-          columns={identifiers}
-          category="identifiers"
-          onRemove={(columnName) => onColumnMove(columnName, 'unclassified', data.activeFileIndex)}
-        />
+      <div className="flex-1 flex flex-col overflow-hidden">
+        <div className="flex-1 overflow-y-auto space-y-4">
+          {/* Identifiers Section */}
+          <DimensionCard
+            title="Identifiers"
+            icon={<Tag className="w-5 h-5 mr-2" />}
+            gradient="bg-gradient-to-r from-blue-500 to-blue-600"
+            columns={identifiers}
+            category="identifiers"
+            onRemove={(columnName) => onColumnMove(columnName, 'identifiers', data.activeFileIndex)}
+          />
 
-        {/* Measures Section */}
-        <DimensionCard
-          title="Measures"
-          icon={<BarChart3 className="w-5 h-5 mr-2" />}
-          gradient="bg-gradient-to-r from-green-500 to-green-600"
-          columns={measures}
-          category="measures"
-          onRemove={(columnName) => onColumnMove(columnName, 'unclassified', data.activeFileIndex)}
-        />
+          {/* Measures Section */}
+          <DimensionCard
+            title="Measures"
+            icon={<BarChart3 className="w-5 h-5 mr-2" />}
+            gradient="bg-gradient-to-r from-green-500 to-green-600"
+            columns={measures}
+            category="measures"
+            onRemove={(columnName) => onColumnMove(columnName, 'measures', data.activeFileIndex)}
+          />
 
-        {/* Unclassified Columns - if any */}
-        {getUnclassifiedColumns().length > 0 && (
-          <Card className="border-2 border-dashed border-orange-300 bg-orange-50">
-            <div className="p-4">
-              <h4 className="font-semibold text-orange-800 mb-3 flex items-center">
-                <Edit2 className="w-4 h-4 mr-2" />
-                Unclassified Columns
-              </h4>
-              <div className="flex flex-wrap gap-2">
-                {getUnclassifiedColumns().map(column => (
-                  <Badge
-                    key={column.name}
-                    variant="outline"
-                    className="bg-white border-orange-300 text-orange-700"
-                  >
-                    {column.name}
-                  </Badge>
-                ))}
+          {/* Unclassified Columns - if any */}
+          {getUnclassifiedColumns().length > 0 && (
+            <Card className="border-2 border-dashed border-orange-300 bg-orange-50">
+              <div className="p-4">
+                <h4 className="font-semibold text-orange-800 mb-3 flex items-center">
+                  <Edit2 className="w-4 h-4 mr-2" />
+                  Unclassified Columns
+                </h4>
+                <div className="flex flex-wrap gap-2">
+                  {getUnclassifiedColumns().map(column => (
+                    <Badge
+                      key={column.name}
+                      variant="outline"
+                      className="bg-white border-orange-300 text-orange-700"
+                    >
+                      {column.name}
+                    </Badge>
+                  ))}
+                </div>
               </div>
-            </div>
-          </Card>
-        )}
+            </Card>
+          )}
 
-        {/* Custom Dimensions */}
-        {Object.keys(currentFile.customDimensions).length === 0 ? (
-          <p className="text-sm text-gray-500">
-            Configure Dimensions in Properties -&gt; Dimensions to set Dimensions
-          </p>
-        ) : (
-          Object.entries(currentFile.customDimensions).map(([dimensionName, columnNames]) => {
-            const dimensionColumns = columnNames.map(name =>
-              currentFile.columns.find(col => col.name === name)
-            ).filter(Boolean) as ColumnData[];
+          <h4 className="font-semibold text-gray-700 text-lg mt-4 mb-2 w-full border-t pt-2">
+            Dimensions Config
+          </h4>
 
-            return (
-              <DimensionCard
-                key={dimensionName}
-                title={dimensionName}
-                icon={<TrendingUp className="w-5 h-5 mr-2" />}
-                gradient="bg-gradient-to-r from-purple-500 to-purple-600"
-                columns={dimensionColumns}
-                category={dimensionName}
-                onRemove={(columnName) => onColumnMove(columnName, 'unclassified', data.activeFileIndex)}
-              />
-            );
-          })
-        )}
+          {Object.keys(currentFile.customDimensions).length === 0 ? (
+            <p className="text-sm text-gray-500">
+              Configure Dimensions in Properties -&gt; Dimensions to set Dimensions
+            </p>
+          ) : (
+            Object.entries(currentFile.customDimensions).map(([dimensionName, columnNames]) => {
+              const dimensionColumns = columnNames
+                .map(name => currentFile.columns.find(col => col.name === name))
+                .filter(Boolean) as ColumnData[];
 
-      </div>
+              return (
+                <DimensionCard
+                  key={dimensionName}
+                  title={dimensionName}
+                  icon={<TrendingUp className="w-5 h-5 mr-2" />}
+                  gradient="bg-gradient-to-r from-purple-500 to-purple-600"
+                  columns={dimensionColumns}
+                  category={dimensionName}
+                  onRemove={(columnName) => onColumnMove(columnName, 'identifiers', data.activeFileIndex)}
+                />
+              );
+            })
+          )}
+        </div>
 
-      <div className="pt-4">
-        <Button
-          disabled={saveDisabled}
-          onClick={onSave}
-          className="w-full h-12 text-sm font-semibold bg-gradient-to-r from-gray-800 to-gray-900 hover:from-gray-900 hover:to-black"
-        >
-          Save Dimensions
-        </Button>
+        <div className="pt-4">
+          <Button
+            disabled={saveDisabled}
+            onClick={onSave}
+            className="w-full h-12 text-sm font-semibold bg-gradient-to-r from-gray-800 to-gray-900 hover:from-gray-900 hover:to-black"
+          >
+            Save Dimensions
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierCanvas.tsx
@@ -49,9 +49,9 @@ const ColumnClassifierCanvas: React.FC<ColumnClassifierCanvasProps> = ({
     return currentFile.columns.filter(col => col.category === 'unclassified');
   };
 
-  const getAvailableIdentifiers = () => {
+  const getAvailableUnclassified = () => {
     if (!currentFile) return [];
-    return currentFile.columns.filter(col => col.category === 'identifiers');
+    return currentFile.columns.filter(col => col.category === 'unclassified');
   };
 
   const toggleDropdown = (category: string) => {
@@ -116,7 +116,7 @@ const ColumnClassifierCanvas: React.FC<ColumnClassifierCanvasProps> = ({
                 value=""
               >
                 <option value="">Select...</option>
-                {getAvailableIdentifiers().map(column => (
+                {getAvailableUnclassified().map(column => (
                   <option key={column.name} value={column.name}>
                     {column.name}
                   </option>
@@ -188,7 +188,7 @@ const ColumnClassifierCanvas: React.FC<ColumnClassifierCanvasProps> = ({
             gradient="bg-gradient-to-r from-blue-500 to-blue-600"
             columns={identifiers}
             category="identifiers"
-            onRemove={(columnName) => onColumnMove(columnName, 'identifiers', data.activeFileIndex)}
+            onRemove={(columnName) => onColumnMove(columnName, 'unclassified', data.activeFileIndex)}
           />
 
           {/* Measures Section */}
@@ -198,7 +198,7 @@ const ColumnClassifierCanvas: React.FC<ColumnClassifierCanvasProps> = ({
             gradient="bg-gradient-to-r from-green-500 to-green-600"
             columns={measures}
             category="measures"
-            onRemove={(columnName) => onColumnMove(columnName, 'measures', data.activeFileIndex)}
+            onRemove={(columnName) => onColumnMove(columnName, 'unclassified', data.activeFileIndex)}
           />
 
           {/* Unclassified Columns - if any */}

--- a/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierCanvas.tsx
@@ -201,6 +201,29 @@ const ColumnClassifierCanvas: React.FC<ColumnClassifierCanvasProps> = ({
           onRemove={(columnName) => onColumnMove(columnName, 'unclassified', data.activeFileIndex)}
         />
 
+        {/* Unclassified Columns - if any */}
+        {getAvailableColumns().length > 0 && (
+          <Card className="border-2 border-dashed border-orange-300 bg-orange-50">
+            <div className="p-4">
+              <h4 className="font-semibold text-orange-800 mb-3 flex items-center">
+                <Edit2 className="w-4 h-4 mr-2" />
+                Unclassified Columns
+              </h4>
+              <div className="flex flex-wrap gap-2">
+                {getAvailableColumns().map(column => (
+                  <Badge
+                    key={column.name}
+                    variant="outline"
+                    className="bg-white border-orange-300 text-orange-700"
+                  >
+                    {column.name}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+          </Card>
+        )}
+
         {/* Custom Dimensions */}
         {Object.keys(currentFile.customDimensions).length === 0 ? (
           <p className="text-sm text-gray-500">
@@ -226,33 +249,12 @@ const ColumnClassifierCanvas: React.FC<ColumnClassifierCanvasProps> = ({
           })
         )}
 
-
-        {/* Unclassified Columns - if any */}
-        {getAvailableColumns().length > 0 && (
-          <Card className="border-2 border-dashed border-orange-300 bg-orange-50">
-            <div className="p-4">
-              <h4 className="font-semibold text-orange-800 mb-3 flex items-center">
-                <Edit2 className="w-4 h-4 mr-2" />
-                Unclassified Columns
-              </h4>
-              <div className="flex flex-wrap gap-2">
-                {getAvailableColumns().map(column => (
-                  <Badge 
-                    key={column.name}
-                    variant="outline" 
-                    className="bg-white border-orange-300 text-orange-700"
-                  >
-                    {column.name}
-                  </Badge>
-                ))}
-              </div>
-            </div>
-          </Card>
-        )}
-
         {/* Save Dimensions Button */}
         <div className="pt-4">
-          <Button className="w-full h-14 text-lg font-semibold bg-gradient-to-r from-gray-800 to-gray-900 hover:from-gray-900 hover:to-black shadow-xl">
+          <Button
+            disabled={Object.keys(currentFile.customDimensions).length === 0}
+            className="w-full h-14 text-lg font-semibold bg-gradient-to-r from-gray-800 to-gray-900 hover:from-gray-900 hover:to-black shadow-xl"
+          >
             Save Dimensions
           </Button>
         </div>

--- a/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierDimensionConfig.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierDimensionConfig.tsx
@@ -1,0 +1,103 @@
+import React, { useState } from 'react';
+import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { TrendingUp, X } from 'lucide-react';
+import { ClassifierData, ColumnData } from '../ColumnClassifierAtom';
+
+interface Props {
+  data: ClassifierData;
+  onColumnMove: (columnName: string, newCategory: string, fileIndex?: number) => void;
+  onSave?: () => void;
+  saveDisabled?: boolean;
+}
+
+const ColumnClassifierDimensionConfig: React.FC<Props> = ({ data, onColumnMove, onSave, saveDisabled }) => {
+  const [showDropdowns, setShowDropdowns] = useState<{ [key: string]: boolean }>({});
+
+  if (!data.files.length) return null;
+  const currentFile = data.files[data.activeFileIndex];
+  const identifiers = currentFile.columns.filter(c => c.category === 'identifiers');
+  const assigned = Object.values(currentFile.customDimensions).flat();
+  const getAvailableIdentifiers = () => identifiers.filter(id => !assigned.includes(id.name));
+
+  const toggle = (dim: string) => {
+    setShowDropdowns(prev => ({ ...prev, [dim]: !prev[dim] }));
+  };
+  const handleSelect = (name: string, dimension: string) => {
+    onColumnMove(name, dimension, data.activeFileIndex);
+    setShowDropdowns(prev => ({ ...prev, [dimension]: false }));
+  };
+
+  return (
+    <div className="space-y-4">
+      <h4 className="font-semibold text-gray-700 text-lg">Dimensions Config</h4>
+      {Object.keys(currentFile.customDimensions).length === 0 ? (
+        <p className="text-sm text-gray-500">
+          Configure Dimensions in Properties -&gt; Dimensions to set Dimensions
+        </p>
+      ) : (
+        Object.entries(currentFile.customDimensions).map(([dimensionName, columnNames]) => {
+          const dimensionColumns = columnNames
+            .map(name => currentFile.columns.find(col => col.name === name))
+            .filter(Boolean) as ColumnData[];
+
+          return (
+            <Card key={dimensionName} className="border-0 shadow-xl bg-white/90 backdrop-blur-sm overflow-hidden">
+              <div className="bg-gradient-to-r from-purple-500 to-purple-600 p-3">
+                <h4 className="font-bold text-white text-lg flex items-center">
+                  <TrendingUp className="w-5 h-5 mr-2" />
+                  {dimensionName}
+                </h4>
+              </div>
+              <div className="p-4">
+                <div className="flex flex-wrap gap-3">
+                  {dimensionColumns.map(column => (
+                    <Badge
+                      key={column.name}
+                      className="bg-gradient-to-r from-purple-500 to-purple-600 text-white px-4 py-2 font-medium flex items-center gap-1"
+                    >
+                      {column.name}
+                      <X className="w-3 h-3 cursor-pointer hover:text-red-200" onClick={() => onColumnMove(column.name, 'identifiers', data.activeFileIndex)} />
+                    </Badge>
+                  ))}
+                  <div className="flex items-center gap-2">
+                    {showDropdowns[dimensionName] && (
+                      <select
+                        className="p-2 border rounded bg-white text-sm min-w-[120px]"
+                        onChange={(e) => { const val = e.target.value; if (val) handleSelect(val, dimensionName); }}
+                        value=""
+                      >
+                        <option value="">Select...</option>
+                        {getAvailableIdentifiers().map(column => (
+                          <option key={column.name} value={column.name}>
+                            {column.name}
+                          </option>
+                        ))}
+                      </select>
+                    )}
+                    <div
+                      className="flex items-center justify-center w-10 h-10 bg-gradient-to-r from-purple-500 to-purple-600 text-white rounded-full font-bold text-lg shadow-lg cursor-pointer hover:scale-110 transition-transform"
+                      onClick={() => toggle(dimensionName)}
+                    >
+                      +
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </Card>
+          );
+        })
+      )}
+      <Button
+        disabled={saveDisabled}
+        onClick={onSave}
+        className="w-full h-12 text-sm font-semibold bg-gradient-to-r from-gray-800 to-gray-900 hover:from-gray-900 hover:to-black"
+      >
+        Save Dimensions
+      </Button>
+    </div>
+  );
+};
+
+export default ColumnClassifierDimensionConfig;

--- a/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierExhibition.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierExhibition.tsx
@@ -171,10 +171,12 @@ const ColumnClassifierExhibition: React.FC<ColumnClassifierExhibitionProps> = ({
             <span>Total Columns:</span>
             <span className="font-medium">{currentFile.columns.length}</span>
           </div>
-          <div className="flex justify-between">
-            <span>Custom Dimensions:</span>
-            <span className="font-medium">{Object.keys(currentFile.customDimensions).length}</span>
-          </div>
+          {Object.keys(currentFile.customDimensions).length > 0 && (
+            <div className="flex justify-between">
+              <span>Custom Dimensions:</span>
+              <span className="font-medium">{Object.keys(currentFile.customDimensions).length}</span>
+            </div>
+          )}
         </div>
       </Card>
     </div>

--- a/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierExhibition.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierExhibition.tsx
@@ -42,7 +42,6 @@ const ColumnClassifierExhibition: React.FC<ColumnClassifierExhibitionProps> = ({
   };
 
   const exportToCSV = () => {
-    const currentFile = data.files[data.activeFileIndex];
     const csvContent = [
       ['Column Name', 'Category'],
       ...currentFile.columns.map(col => [col.name, col.category]),
@@ -55,15 +54,14 @@ const ColumnClassifierExhibition: React.FC<ColumnClassifierExhibitionProps> = ({
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = `${currentFile.fileName}-classification.csv`;
+    a.download = `${displayName}-classification.csv`;
     a.click();
     URL.revokeObjectURL(url);
   };
 
   const copyToClipboard = () => {
-    const currentFile = data.files[data.activeFileIndex];
     const text = JSON.stringify({
-      fileName: currentFile.fileName,
+      fileName: displayName,
       identifiers: currentFile.columns.filter(col => col.category === 'identifiers').map(col => col.name),
       measures: currentFile.columns.filter(col => col.category === 'measures').map(col => col.name),
       customDimensions: currentFile.customDimensions,
@@ -74,6 +72,7 @@ const ColumnClassifierExhibition: React.FC<ColumnClassifierExhibitionProps> = ({
   };
 
   const currentFile = data.files[data.activeFileIndex];
+  const displayName = currentFile.fileName.split('/').pop();
 
   return (
     <div className="space-y-6">
@@ -165,7 +164,7 @@ const ColumnClassifierExhibition: React.FC<ColumnClassifierExhibitionProps> = ({
         <div className="space-y-2 text-sm">
           <div className="flex justify-between">
             <span>Current File:</span>
-            <span className="font-medium">{currentFile.fileName}</span>
+            <span className="font-medium break-all whitespace-normal">{displayName}</span>
           </div>
           <div className="flex justify-between">
             <span>Total Columns:</span>

--- a/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierSettings.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierSettings.tsx
@@ -55,9 +55,15 @@ const ColumnClassifierSettings: React.FC<ColumnClassifierSettingsProps> = ({ ato
       const form = new FormData();
       form.append('validator_atom_id', savedId);
       form.append('file_key', fileKey);
-      const res = await fetch(`${CLASSIFIER_API}/classify_columns`, { method: 'POST', body: form });
-      if (!res.ok) throw new Error('Failed to classify');
-      const data: ClassificationResponse = await res.json();
+      const res = await fetch(`${CLASSIFIER_API}/classify_columns`, {
+        method: 'POST',
+        body: form,
+        credentials: 'include'
+      });
+      const data: ClassificationResponse = await res.json().catch(() => null);
+      if (!res.ok) {
+        throw new Error(data?.detail || 'Failed to classify');
+      }
       const cols: ColumnData[] = [
         ...data.final_classification.identifiers.map(name => ({ name, category: 'identifiers' })),
         ...data.final_classification.measures.map(name => ({ name, category: 'measures' })),

--- a/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierSettings.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierSettings.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { VALIDATE_API, CLASSIFIER_API } from '@/lib/api';
@@ -36,7 +35,6 @@ const ColumnClassifierSettings: React.FC<ColumnClassifierSettingsProps> = ({ ato
 
   const [frames, setFrames] = useState<Frame[]>([]);
   const [savedId, setSavedId] = useState(settings.validatorId || '');
-  const [fileKey, setFileKey] = useState(settings.fileKey || '');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
 
@@ -53,8 +51,7 @@ const ColumnClassifierSettings: React.FC<ColumnClassifierSettingsProps> = ({ ato
     setError('');
     try {
       const form = new FormData();
-      form.append('validator_atom_id', savedId);
-      form.append('file_key', fileKey);
+      form.append('dataframe', savedId);
       const res = await fetch(`${CLASSIFIER_API}/classify_columns`, {
         method: 'POST',
         body: form,
@@ -71,7 +68,7 @@ const ColumnClassifierSettings: React.FC<ColumnClassifierSettingsProps> = ({ ato
       ];
       const custom = Object.fromEntries((settings.dimensions || []).map(d => [d, []]));
       onClassification({ fileName: savedId, columns: cols, customDimensions: custom });
-      updateSettings(atomId, { validatorId: savedId, fileKey, assignments: {} });
+      updateSettings(atomId, { validatorId: savedId, assignments: {} });
     } catch (e: any) {
       setError(e.message);
     } finally {
@@ -96,15 +93,6 @@ const ColumnClassifierSettings: React.FC<ColumnClassifierSettingsProps> = ({ ato
               ))}
             </SelectContent>
           </Select>
-        </div>
-
-        <div>
-          <Label className="text-sm mb-2 block">File Key</Label>
-          <Input
-            value={fileKey}
-            onChange={e => setFileKey(e.target.value)}
-            placeholder="Optional"
-          />
         </div>
 
         {error && <p className="text-red-500 text-sm">{error}</p>}

--- a/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierVisualisation.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierVisualisation.tsx
@@ -30,14 +30,18 @@ const ColumnClassifierVisualisation: React.FC<ColumnClassifierVisualisationProps
     { name: 'Identifiers', count: categoryCounts.identifiers },
     { name: 'Measures', count: categoryCounts.measures },
     { name: 'Unclassified', count: categoryCounts.unclassified },
-    { name: 'Custom Dimensions', count: categoryCounts.customDimensions }
+    ...(categoryCounts.customDimensions > 0
+      ? [{ name: 'Custom Dimensions', count: categoryCounts.customDimensions }]
+      : [])
   ];
 
   const pieData = [
     { name: 'Identifiers', value: categoryCounts.identifiers, color: '#3b82f6' },
     { name: 'Measures', value: categoryCounts.measures, color: '#10b981' },
     { name: 'Unclassified', value: categoryCounts.unclassified, color: '#f59e0b' },
-    { name: 'Custom Dimensions', value: categoryCounts.customDimensions, color: '#8b5cf6' }
+    ...(categoryCounts.customDimensions > 0
+      ? [{ name: 'Custom Dimensions', value: categoryCounts.customDimensions, color: '#8b5cf6' }]
+      : [])
   ];
 
   return (
@@ -106,10 +110,12 @@ const ColumnClassifierVisualisation: React.FC<ColumnClassifierVisualisationProps
               {((categoryCounts.identifiers + categoryCounts.measures + Object.values(currentFile.customDimensions).flat().length) / currentFile.columns.length * 100).toFixed(1)}%
             </span>
           </div>
-          <div className="flex justify-between">
-            <span>Custom Dimensions:</span>
-            <span className="font-medium">{categoryCounts.customDimensions}</span>
-          </div>
+          {categoryCounts.customDimensions > 0 && (
+            <div className="flex justify-between">
+              <span>Custom Dimensions:</span>
+              <span className="font-medium">{categoryCounts.customDimensions}</span>
+            </div>
+          )}
         </div>
       </Card>
     </div>

--- a/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierVisualisation.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierVisualisation.tsx
@@ -1,5 +1,5 @@
 
-import React from 'react';
+import React, { useState, useCallback } from 'react';
 import { Card } from '@/components/ui/card';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, PieChart, Pie, Cell } from 'recharts';
 import { ClassifierData } from '../ColumnClassifierAtom';
@@ -9,23 +9,6 @@ interface ColumnClassifierVisualisationProps {
 }
 
 const RADIAN = Math.PI / 180;
-const renderPieLabel = ({ cx, cy, midAngle, innerRadius, outerRadius, name, value }: any) => {
-  const radius = innerRadius + (outerRadius - innerRadius) * 0.7;
-  const x = cx + radius * Math.cos(-midAngle * RADIAN);
-  const y = cy + radius * Math.sin(-midAngle * RADIAN);
-  return (
-    <text
-      x={x}
-      y={y}
-      textAnchor="middle"
-      dominantBaseline="central"
-      fontSize={12}
-      fill="#000"
-    >
-      {`${name}: ${value}`}
-    </text>
-  );
-};
 
 const ColumnClassifierVisualisation: React.FC<ColumnClassifierVisualisationProps> = ({ data }) => {
   if (!data.files.length) {
@@ -64,6 +47,30 @@ const ColumnClassifierVisualisation: React.FC<ColumnClassifierVisualisationProps
       : [])
   ];
 
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+
+  const renderPieLabel = useCallback(
+    ({ cx, cy, midAngle, innerRadius, outerRadius, name, value, index }: any) => {
+      if (index !== activeIndex) return null;
+      const radius = innerRadius + (outerRadius - innerRadius) * 0.7;
+      const x = cx + radius * Math.cos(-midAngle * RADIAN);
+      const y = cy + radius * Math.sin(-midAngle * RADIAN);
+      return (
+        <text
+          x={x}
+          y={y}
+          textAnchor="middle"
+          dominantBaseline="central"
+          fontSize={12}
+          fill="#000"
+        >
+          {`${name}: ${value}`}
+        </text>
+      );
+    },
+    [activeIndex]
+  );
+
   return (
     <div className="space-y-4">
       <Card className="p-4">
@@ -94,6 +101,8 @@ const ColumnClassifierVisualisation: React.FC<ColumnClassifierVisualisationProps
               dataKey="value"
               label={renderPieLabel}
               labelLine={false}
+              onMouseEnter={(_, index) => setActiveIndex(index)}
+              onMouseLeave={() => setActiveIndex(null)}
             >
               {pieData.map((entry, index) => (
                 <Cell key={`cell-${index}`} fill={entry.color} />

--- a/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierVisualisation.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierVisualisation.tsx
@@ -48,13 +48,13 @@ const ColumnClassifierVisualisation: React.FC<ColumnClassifierVisualisationProps
   ];
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       <Card className="p-4">
         <h4 className="font-semibold text-gray-900 mb-2">Current File</h4>
         <p className="text-sm text-gray-600 mb-4">{currentFile.fileName}</p>
         
         <h5 className="font-medium text-gray-900 mb-4">Column Distribution</h5>
-        <ResponsiveContainer width="100%" height={200}>
+        <ResponsiveContainer width="100%" height={160}>
           <BarChart data={barData}>
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="name" />
@@ -67,7 +67,7 @@ const ColumnClassifierVisualisation: React.FC<ColumnClassifierVisualisationProps
 
       <Card className="p-4">
         <h4 className="font-semibold text-gray-900 mb-4">Category Breakdown</h4>
-        <ResponsiveContainer width="100%" height={200}>
+        <ResponsiveContainer width="100%" height={160}>
           <PieChart>
             <Pie
               data={pieData}

--- a/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierVisualisation.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierVisualisation.tsx
@@ -1,14 +1,17 @@
 
 import React from 'react';
 import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, PieChart, Pie, Cell } from 'recharts';
 import { ClassifierData } from '../ColumnClassifierAtom';
 
 interface ColumnClassifierVisualisationProps {
   data: ClassifierData;
+  onSave?: () => void;
+  saveDisabled?: boolean;
 }
 
-const ColumnClassifierVisualisation: React.FC<ColumnClassifierVisualisationProps> = ({ data }) => {
+const ColumnClassifierVisualisation: React.FC<ColumnClassifierVisualisationProps> = ({ data, onSave, saveDisabled }) => {
   if (!data.files.length) {
     return (
       <div className="text-center p-8">
@@ -118,6 +121,16 @@ const ColumnClassifierVisualisation: React.FC<ColumnClassifierVisualisationProps
           )}
         </div>
       </Card>
+
+      <div className="pt-2">
+        <Button
+          disabled={saveDisabled}
+          onClick={onSave}
+          className="w-full h-12 text-sm font-semibold bg-gradient-to-r from-gray-800 to-gray-900 hover:from-gray-900 hover:to-black"
+        >
+          Save Dimensions
+        </Button>
+      </div>
     </div>
   );
 };

--- a/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierVisualisation.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierVisualisation.tsx
@@ -8,6 +8,25 @@ interface ColumnClassifierVisualisationProps {
   data: ClassifierData;
 }
 
+const RADIAN = Math.PI / 180;
+const renderPieLabel = ({ cx, cy, midAngle, innerRadius, outerRadius, name, value }: any) => {
+  const radius = innerRadius + (outerRadius - innerRadius) * 0.7;
+  const x = cx + radius * Math.cos(-midAngle * RADIAN);
+  const y = cy + radius * Math.sin(-midAngle * RADIAN);
+  return (
+    <text
+      x={x}
+      y={y}
+      textAnchor="middle"
+      dominantBaseline="central"
+      fontSize={12}
+      fill="#000"
+    >
+      {`${name}: ${value}`}
+    </text>
+  );
+};
+
 const ColumnClassifierVisualisation: React.FC<ColumnClassifierVisualisationProps> = ({ data }) => {
   if (!data.files.length) {
     return (
@@ -53,7 +72,7 @@ const ColumnClassifierVisualisation: React.FC<ColumnClassifierVisualisationProps
         
         <h5 className="font-medium text-gray-900 mb-4">Column Distribution</h5>
         <ResponsiveContainer width="100%" height={160}>
-          <BarChart data={barData}>
+          <BarChart data={barData} margin={{ left: -20 }}>
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="name" />
             <YAxis />
@@ -73,7 +92,8 @@ const ColumnClassifierVisualisation: React.FC<ColumnClassifierVisualisationProps
               cy="50%"
               outerRadius={80}
               dataKey="value"
-              label={({ name, value }) => `${name}: ${value}`}
+              label={renderPieLabel}
+              labelLine={false}
             >
               {pieData.map((entry, index) => (
                 <Cell key={`cell-${index}`} fill={entry.color} />

--- a/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierVisualisation.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierVisualisation.tsx
@@ -18,6 +18,7 @@ const ColumnClassifierVisualisation: React.FC<ColumnClassifierVisualisationProps
   }
 
   const currentFile = data.files[data.activeFileIndex];
+  const displayName = currentFile.fileName.split('/').pop();
   
   const categoryCounts = {
     identifiers: currentFile.columns.filter(col => col.category === 'identifiers').length,
@@ -48,7 +49,7 @@ const ColumnClassifierVisualisation: React.FC<ColumnClassifierVisualisationProps
     <div className="space-y-4">
       <Card className="p-4">
         <h4 className="font-semibold text-gray-900 mb-2">Current File</h4>
-        <p className="text-sm text-gray-600 mb-4">{currentFile.fileName}</p>
+        <p className="text-sm text-gray-600 mb-4 break-all whitespace-normal">{displayName}</p>
         
         <h5 className="font-medium text-gray-900 mb-4">Column Distribution</h5>
         <ResponsiveContainer width="100%" height={160}>

--- a/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierVisualisation.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierVisualisation.tsx
@@ -1,17 +1,14 @@
 
 import React from 'react';
 import { Card } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, PieChart, Pie, Cell } from 'recharts';
 import { ClassifierData } from '../ColumnClassifierAtom';
 
 interface ColumnClassifierVisualisationProps {
   data: ClassifierData;
-  onSave?: () => void;
-  saveDisabled?: boolean;
 }
 
-const ColumnClassifierVisualisation: React.FC<ColumnClassifierVisualisationProps> = ({ data, onSave, saveDisabled }) => {
+const ColumnClassifierVisualisation: React.FC<ColumnClassifierVisualisationProps> = ({ data }) => {
   if (!data.files.length) {
     return (
       <div className="text-center p-8">
@@ -121,16 +118,6 @@ const ColumnClassifierVisualisation: React.FC<ColumnClassifierVisualisationProps
           )}
         </div>
       </Card>
-
-      <div className="pt-2">
-        <Button
-          disabled={saveDisabled}
-          onClick={onSave}
-          className="w-full h-12 text-sm font-semibold bg-gradient-to-r from-gray-800 to-gray-900 hover:from-gray-900 hover:to-black"
-        >
-          Save Dimensions
-        </Button>
-      </div>
     </div>
   );
 };

--- a/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierVisualisation.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/ColumnClassifierVisualisation.tsx
@@ -41,10 +41,7 @@ const ColumnClassifierVisualisation: React.FC<ColumnClassifierVisualisationProps
   const pieData = [
     { name: 'Identifiers', value: categoryCounts.identifiers, color: '#3b82f6' },
     { name: 'Measures', value: categoryCounts.measures, color: '#10b981' },
-    { name: 'Unclassified', value: categoryCounts.unclassified, color: '#f59e0b' },
-    ...(categoryCounts.customDimensions > 0
-      ? [{ name: 'Custom Dimensions', value: categoryCounts.customDimensions, color: '#8b5cf6' }]
-      : [])
+    { name: 'Unclassified', value: categoryCounts.unclassified, color: '#f59e0b' }
   ];
 
   const [activeIndex, setActiveIndex] = useState<number | null>(null);

--- a/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/properties/ColumnClassifierDimensions.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/properties/ColumnClassifierDimensions.tsx
@@ -5,7 +5,6 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Plus } from 'lucide-react';
-import { CLASSIFIER_API } from '@/lib/api';
 import {
   useLaboratoryStore,
   ColumnClassifierSettings as SettingsType,
@@ -55,23 +54,13 @@ const ColumnClassifierDimensions: React.FC<Props> = ({ atomId }) => {
 
 
   const save = async () => {
-    if (!settings.validatorId || !settings.fileKey) {
+    if (!settings.validatorId || settings.data.files.length === 0) {
       setError('Classify a dataframe first');
       return;
     }
     setLoading(true);
     setError('');
     try {
-      const form = new FormData();
-      form.append('validator_atom_id', settings.validatorId);
-      form.append('file_key', settings.fileKey);
-      const dims = selected.map(d => ({ id: d, name: d }));
-      form.append('dimensions', JSON.stringify(dims));
-      const res = await fetch(`${CLASSIFIER_API}/define_dimensions`, {
-        method: 'POST',
-        body: form
-      });
-      if (!res.ok) throw new Error('Failed to save dimensions');
       updateSettings(atomId, { dimensions: selected });
       if (settings.data.files.length) {
         const updatedFiles = settings.data.files.map(file => ({

--- a/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/properties/ColumnClassifierDimensions.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/properties/ColumnClassifierDimensions.tsx
@@ -24,7 +24,7 @@ const ColumnClassifierDimensions: React.FC<Props> = ({ atomId }) => {
   };
 
   const [options, setOptions] = useState<string[]>(
-    Array.from(new Set(['market', 'product', ...(settings.dimensions || [])]))
+    Array.from(new Set(settings.dimensions || []))
   );
   const [selected, setSelected] = useState<string[]>(settings.dimensions || []);
   const [showInput, setShowInput] = useState(false);

--- a/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/properties/ColumnClassifierDimensions.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/properties/ColumnClassifierDimensions.tsx
@@ -3,7 +3,6 @@ import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Checkbox } from '@/components/ui/checkbox';
 import { Plus } from 'lucide-react';
 import { CLASSIFIER_API } from '@/lib/api';
 import {
@@ -31,13 +30,11 @@ const ColumnClassifierDimensions: React.FC<Props> = ({ atomId }) => {
   const [newDim, setNewDim] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  // list of identifier columns for potential future assignments
   const identifiers =
     settings.data.files[settings.data.activeFileIndex]?.columns
       .filter(c => c.category === 'identifiers')
       .map(c => c.name) || [];
-  const [assignState, setAssignState] = useState<{ [key: string]: string[] }>(
-    settings.assignments || {}
-  );
 
   const toggle = (dim: string) => {
     setSelected(prev =>
@@ -55,20 +52,6 @@ const ColumnClassifierDimensions: React.FC<Props> = ({ atomId }) => {
     setShowInput(false);
   };
 
-  const toggleIdentifier = (dim: string, id: string) => {
-    setAssignState(prev => {
-      const updated: { [key: string]: string[] } = { ...prev };
-      // remove from all dims
-      Object.keys(updated).forEach(key => {
-        updated[key] = updated[key].filter(v => v !== id);
-      });
-      if (!updated[dim]) updated[dim] = [];
-      if (!prev[dim]?.includes(id)) {
-        updated[dim].push(id);
-      }
-      return updated;
-    });
-  };
 
   const save = async () => {
     if (!settings.validatorId || !settings.fileKey) {
@@ -106,30 +89,6 @@ const ColumnClassifierDimensions: React.FC<Props> = ({ atomId }) => {
     }
   };
 
-  const saveAssignments = async () => {
-    if (!settings.validatorId || !settings.fileKey) {
-      setError('Classify a dataframe first');
-      return;
-    }
-    setLoading(true);
-    setError('');
-    try {
-      const form = new FormData();
-      form.append('validator_atom_id', settings.validatorId);
-      form.append('file_key', settings.fileKey);
-      form.append('identifier_assignments', JSON.stringify(assignState));
-      const res = await fetch(
-        `${CLASSIFIER_API}/assign_identifiers_to_dimensions`,
-        { method: 'POST', body: form }
-      );
-      if (!res.ok) throw new Error('Failed to assign identifiers');
-      updateSettings(atomId, { assignments: assignState });
-    } catch (e: any) {
-      setError(e.message);
-    } finally {
-      setLoading(false);
-    }
-  };
 
   return (
     <div className="space-y-4 p-2">
@@ -169,32 +128,6 @@ const ColumnClassifierDimensions: React.FC<Props> = ({ atomId }) => {
           Save Dimensions
         </Button>
       </Card>
-
-      {identifiers.length > 0 && selected.length > 0 && (
-        <Card className="p-4 space-y-4">
-          <Label className="text-sm mb-2 block">Assign Identifiers</Label>
-          {selected.map(dim => (
-            <div key={dim} className="mb-3">
-              <p className="font-semibold capitalize mb-1">{dim}</p>
-              {identifiers.map(id => (
-                <div key={id} className="flex items-center space-x-2 mb-1">
-                  <Checkbox
-                    id={`${atomId}-${dim}-${id}`}
-                    checked={assignState[dim]?.includes(id) || false}
-                    onCheckedChange={() => toggleIdentifier(dim, id)}
-                  />
-                  <label htmlFor={`${atomId}-${dim}-${id}`} className="text-sm">
-                    {id}
-                  </label>
-                </div>
-              ))}
-            </div>
-          ))}
-          <Button onClick={saveAssignments} disabled={loading} className="w-full">
-            Save Assignments
-          </Button>
-        </Card>
-      )}
     </div>
   );
 };

--- a/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/properties/ColumnClassifierDimensions.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/column-classifier/components/properties/ColumnClassifierDimensions.tsx
@@ -3,6 +3,7 @@ import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Plus } from 'lucide-react';
 import { CLASSIFIER_API } from '@/lib/api';
 import {
@@ -23,7 +24,7 @@ const ColumnClassifierDimensions: React.FC<Props> = ({ atomId }) => {
   };
 
   const [options, setOptions] = useState<string[]>(
-    Array.from(new Set(settings.dimensions || []))
+    Array.from(new Set(['market', 'product', ...(settings.dimensions || [])]))
   );
   const [selected, setSelected] = useState<string[]>(settings.dimensions || []);
   const [showInput, setShowInput] = useState(false);

--- a/TrinityFrontend/src/components/AtomList/atoms/data-upload-validate/components/properties/DataUploadValidateProperties.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/data-upload-validate/components/properties/DataUploadValidateProperties.tsx
@@ -1,46 +1,51 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect } from "react";
+import { Settings, Upload, Table, BarChart3, Minus, Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import {
-  Settings,
-  Upload,
-  Table,
-  BarChart3,
-  Minus,
-  Plus
-} from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Input } from '@/components/ui/input';
-import { Badge } from '@/components/ui/badge';
-import { Checkbox } from '@/components/ui/checkbox';
-import { VALIDATE_API } from '@/lib/api';
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
+import { VALIDATE_API } from "@/lib/api";
 import {
   useLaboratoryStore,
   DataUploadSettings,
-  DEFAULT_DATAUPLOAD_SETTINGS
-} from '@/components/LaboratoryMode/store/laboratoryStore';
+  DEFAULT_DATAUPLOAD_SETTINGS,
+} from "@/components/LaboratoryMode/store/laboratoryStore";
 
 interface Props {
   atomId: string;
 }
 const DataUploadValidateProperties: React.FC<Props> = ({ atomId }) => {
-  const atom = useLaboratoryStore(state => state.getAtom(atomId));
-  const updateSettings = useLaboratoryStore(state => state.updateAtomSettings);
+  const atom = useLaboratoryStore((state) => state.getAtom(atomId));
+  const updateSettings = useLaboratoryStore(
+    (state) => state.updateAtomSettings,
+  );
   const settings: DataUploadSettings =
-    (atom?.settings as DataUploadSettings) || { ...DEFAULT_DATAUPLOAD_SETTINGS };
-  const [allAvailableFiles, setAllAvailableFiles] = useState<{ name: string; source: string }[]>(
-    settings.requiredFiles?.map(name => ({ name, source: 'upload' })) || []
+    (atom?.settings as DataUploadSettings) || {
+      ...DEFAULT_DATAUPLOAD_SETTINGS,
+    };
+  const [allAvailableFiles, setAllAvailableFiles] = useState<
+    { name: string; source: string }[]
+  >(settings.requiredFiles?.map((name) => ({ name, source: "upload" })) || []);
+  const [selectedMasterFile, setSelectedMasterFile] = useState<string>("");
+  const [validatorId, setValidatorId] = useState<string>(
+    settings.validatorId || "",
   );
-  const [selectedMasterFile, setSelectedMasterFile] = useState<string>('');
-  const [validatorId, setValidatorId] = useState<string>(settings.validatorId || '');
-  const [columnDataTypes, setColumnDataTypes] = useState<Record<string, string>>(
-    {}
-  );
+  const [columnDataTypes, setColumnDataTypes] = useState<
+    Record<string, string>
+  >({});
   const dataTypeOptions = [
-    { value: 'not_defined', label: 'Not defined' },
-    { value: 'number', label: 'Number' },
-    { value: 'string', label: 'String' },
-    { value: 'date', label: 'Date' }
+    { value: "not_defined", label: "Not defined" },
+    { value: "number", label: "Number" },
+    { value: "string", label: "String" },
+    { value: "date", label: "Date" },
   ];
 
   interface RangeValidation {
@@ -51,7 +56,7 @@ const DataUploadValidateProperties: React.FC<Props> = ({ atomId }) => {
   }
 
   const [rangeValidations, setRangeValidations] = useState<RangeValidation[]>([
-    { id: 1, column: '', min: '', max: '' }
+    { id: 1, column: "", min: "", max: "" },
   ]);
 
   interface PeriodicityValidation {
@@ -60,9 +65,9 @@ const DataUploadValidateProperties: React.FC<Props> = ({ atomId }) => {
     periodicity: string;
   }
 
-  const [periodicityValidations, setPeriodicityValidations] = useState<PeriodicityValidation[]>([
-    { id: 1, column: '', periodicity: '' }
-  ]);
+  const [periodicityValidations, setPeriodicityValidations] = useState<
+    PeriodicityValidation[]
+  >([{ id: 1, column: "", periodicity: "" }]);
 
   const [numericalColumns, setNumericalColumns] = useState<string[]>([]);
   const [dateColumns, setDateColumns] = useState<string[]>([]);
@@ -75,11 +80,13 @@ const DataUploadValidateProperties: React.FC<Props> = ({ atomId }) => {
   useEffect(() => {
     if (!validatorId) return;
     fetch(`${VALIDATE_API}/get_validator_config/${validatorId}`)
-      .then(res => res.json())
-      .then(cfg => {
+      .then((res) => res.json())
+      .then((cfg) => {
         const files = cfg.file_keys || [];
         if (files.length > 0) {
-          setAllAvailableFiles(files.map((f: string) => ({ name: f, source: 'upload' })));
+          setAllAvailableFiles(
+            files.map((f: string) => ({ name: f, source: "upload" })),
+          );
           if (!selectedMasterFile) setSelectedMasterFile(files[0]);
         }
 
@@ -87,11 +94,20 @@ const DataUploadValidateProperties: React.FC<Props> = ({ atomId }) => {
         if (cfg.validations) {
           Object.entries(cfg.validations).forEach(([k, list]: any) => {
             const ranges = (list as any[])
-              .filter(v => v.validation_type === 'range')
-              .map(v => ({ id: Date.now() + Math.random(), column: v.column, min: v.min || '', max: v.max || '' }));
+              .filter((v) => v.validation_type === "range")
+              .map((v) => ({
+                id: Date.now() + Math.random(),
+                column: v.column,
+                min: v.min || "",
+                max: v.max || "",
+              }));
             const periodicities = (list as any[])
-              .filter(v => v.validation_type === 'periodicity')
-              .map(v => ({ id: Date.now() + Math.random(), column: v.column, periodicity: v.periodicity || '' }));
+              .filter((v) => v.validation_type === "periodicity")
+              .map((v) => ({
+                id: Date.now() + Math.random(),
+                column: v.column,
+                periodicity: v.periodicity || "",
+              }));
             parsedValidations[k] = { ranges, periodicities };
           });
         }
@@ -101,7 +117,7 @@ const DataUploadValidateProperties: React.FC<Props> = ({ atomId }) => {
           requiredFiles: files,
           validations: parsedValidations,
           classification: cfg.classification || {},
-          columnConfig: cfg.column_types || {}
+          columnConfig: cfg.column_types || {},
         });
 
         if (files.length > 0) {
@@ -110,7 +126,7 @@ const DataUploadValidateProperties: React.FC<Props> = ({ atomId }) => {
           const saved = cfg.column_types?.[firstKey] || {};
           const merged: Record<string, string> = {};
           schemaCols.forEach((c: any) => {
-            merged[c.column] = saved[c.column] || 'not_defined';
+            merged[c.column] = saved[c.column] || "not_defined";
           });
           setColumnDataTypes(merged);
         }
@@ -119,33 +135,39 @@ const DataUploadValidateProperties: React.FC<Props> = ({ atomId }) => {
   }, []);
 
   const periodicityOptions = [
-    { value: 'daily', label: 'Daily' },
-    { value: 'weekly', label: 'Weekly' },
-    { value: 'monthly', label: 'Monthly' }
+    { value: "daily", label: "Daily" },
+    { value: "weekly", label: "Weekly" },
+    { value: "monthly", label: "Monthly" },
   ];
 
-
-  const handleMasterFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleMasterFileSelect = async (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
     if (!e.target.files) return;
     const files = Array.from(e.target.files);
     const id = `validator-${Date.now()}`;
     const form = new FormData();
-    form.append('validator_atom_id', id);
-    files.forEach(f => form.append('files', f));
-    const keys = files.map(f => f.name);
-    form.append('file_keys', JSON.stringify(keys));
+    form.append("validator_atom_id", id);
+    files.forEach((f) => form.append("files", f));
+    const keys = files.map((f) => f.name);
+    form.append("file_keys", JSON.stringify(keys));
 
-    const res = await fetch(`${VALIDATE_API}/create_new`, { method: 'POST', body: form });
+    const res = await fetch(`${VALIDATE_API}/create_new`, {
+      method: "POST",
+      body: form,
+    });
     if (res.ok) {
       setValidatorId(id);
-      setAllAvailableFiles(keys.map(k => ({ name: k, source: 'upload' })));
+      setAllAvailableFiles(keys.map((k) => ({ name: k, source: "upload" })));
       setSelectedMasterFile(keys[0]);
-      const cfg = await fetch(`${VALIDATE_API}/get_validator_config/${id}`).then(r => r.json());
+      const cfg = await fetch(
+        `${VALIDATE_API}/get_validator_config/${id}`,
+      ).then((r) => r.json());
       const defaultTypes: Record<string, string> = {};
       const firstKey = keys[0];
       if (cfg.schemas && cfg.schemas[firstKey]) {
         cfg.schemas[firstKey].columns.forEach((c: any) => {
-          defaultTypes[c.column] = 'not_defined';
+          defaultTypes[c.column] = "not_defined";
         });
       }
       if (cfg.column_types && cfg.column_types[firstKey]) {
@@ -158,32 +180,32 @@ const DataUploadValidateProperties: React.FC<Props> = ({ atomId }) => {
         validatorId: id,
         requiredFiles: keys,
         validations: settings.validations || {},
-        columnConfig: { [firstKey]: defaultTypes }
+        columnConfig: { [firstKey]: defaultTypes },
       });
     }
   };
 
   const handleDataTypeChange = (column: string, value: string) => {
-    setColumnDataTypes(prev => ({ ...prev, [column]: value }));
+    setColumnDataTypes((prev) => ({ ...prev, [column]: value }));
   };
 
   useEffect(() => {
     if (!validatorId || !selectedMasterFile) return;
     fetch(`${VALIDATE_API}/get_validator_config/${validatorId}`)
-      .then(res => res.json())
-      .then(cfg => {
+      .then((res) => res.json())
+      .then((cfg) => {
         const schemaCols = cfg.schemas?.[selectedMasterFile]?.columns || [];
         const saved = cfg.column_types?.[selectedMasterFile] || {};
         const merged: Record<string, string> = {};
         schemaCols.forEach((c: any) => {
-          merged[c.column] = saved[c.column] || 'not_defined';
+          merged[c.column] = saved[c.column] || "not_defined";
         });
         setColumnDataTypes(merged);
         updateSettings(atomId, {
           columnConfig: {
             ...(settings.columnConfig || {}),
-            [selectedMasterFile]: merged
-          }
+            [selectedMasterFile]: merged,
+          },
         });
         if (cfg.classification?.[selectedMasterFile]) {
           const cls = cfg.classification[selectedMasterFile];
@@ -193,16 +215,25 @@ const DataUploadValidateProperties: React.FC<Props> = ({ atomId }) => {
         if (cfg.validations?.[selectedMasterFile]) {
           const list = cfg.validations[selectedMasterFile] as any[];
           const ranges = list
-            .filter(v => v.validation_type === 'range')
-            .map(v => ({ id: Date.now() + Math.random(), column: v.column, min: v.min || '', max: v.max || '' }));
+            .filter((v) => v.validation_type === "range")
+            .map((v) => ({
+              id: Date.now() + Math.random(),
+              column: v.column,
+              min: v.min || "",
+              max: v.max || "",
+            }));
           const periodicities = list
-            .filter(v => v.validation_type === 'periodicity')
-            .map(v => ({ id: Date.now() + Math.random(), column: v.column, periodicity: v.periodicity || '' }));
+            .filter((v) => v.validation_type === "periodicity")
+            .map((v) => ({
+              id: Date.now() + Math.random(),
+              column: v.column,
+              periodicity: v.periodicity || "",
+            }));
           updateSettings(atomId, {
             validations: {
               ...(settings.validations || {}),
-              [selectedMasterFile]: { ranges, periodicities }
-            }
+              [selectedMasterFile]: { ranges, periodicities },
+            },
           });
         }
       })
@@ -213,13 +244,13 @@ const DataUploadValidateProperties: React.FC<Props> = ({ atomId }) => {
 
   useEffect(() => {
     const nums = Object.entries(columnDataTypes)
-      .filter(([, t]) => t === 'integer' || t === 'numeric')
+      .filter(([, t]) => t === "integer" || t === "numeric")
       .map(([c]) => c);
     const dates = Object.entries(columnDataTypes)
-      .filter(([, t]) => t === 'date')
+      .filter(([, t]) => t === "date")
       .map(([c]) => c);
     const cats = Object.entries(columnDataTypes)
-      .filter(([, t]) => !['integer', 'numeric', 'date'].includes(t))
+      .filter(([, t]) => !["integer", "numeric", "date"].includes(t))
       .map(([c]) => c);
     setNumericalColumns(nums);
     setDateColumns(dates);
@@ -231,16 +262,20 @@ const DataUploadValidateProperties: React.FC<Props> = ({ atomId }) => {
     if (selectedMasterFile && settings.validations?.[selectedMasterFile]) {
       const val = settings.validations[selectedMasterFile];
       setRangeValidations(
-        val.ranges.length > 0 ? val.ranges : [{ id: Date.now(), column: '', min: '', max: '' }]
+        val.ranges.length > 0
+          ? val.ranges
+          : [{ id: Date.now(), column: "", min: "", max: "" }],
       );
       setPeriodicityValidations(
         val.periodicities.length > 0
           ? val.periodicities
-          : [{ id: Date.now(), column: '', periodicity: '' }]
+          : [{ id: Date.now(), column: "", periodicity: "" }],
       );
     } else {
-      setRangeValidations([{ id: Date.now(), column: '', min: '', max: '' }]);
-      setPeriodicityValidations([{ id: Date.now(), column: '', periodicity: '' }]);
+      setRangeValidations([{ id: Date.now(), column: "", min: "", max: "" }]);
+      setPeriodicityValidations([
+        { id: Date.now(), column: "", periodicity: "" },
+      ]);
     }
 
     if (selectedMasterFile && settings.classification?.[selectedMasterFile]) {
@@ -254,31 +289,45 @@ const DataUploadValidateProperties: React.FC<Props> = ({ atomId }) => {
   }, [selectedMasterFile]);
 
   const addRangeValidation = () => {
-    setRangeValidations(prev => [...prev, { id: Date.now(), column: '', min: '', max: '' }]);
+    setRangeValidations((prev) => [
+      ...prev,
+      { id: Date.now(), column: "", min: "", max: "" },
+    ]);
   };
 
   const removeRangeValidation = (id: number) => {
-    setRangeValidations(prev => prev.filter(r => r.id !== id));
+    setRangeValidations((prev) => prev.filter((r) => r.id !== id));
   };
 
-  const updateRangeValidation = (id: number, key: 'column' | 'min' | 'max', value: string) => {
-    setRangeValidations(prev => prev.map(r => (r.id === id ? { ...r, [key]: value } : r)));
+  const updateRangeValidation = (
+    id: number,
+    key: "column" | "min" | "max",
+    value: string,
+  ) => {
+    setRangeValidations((prev) =>
+      prev.map((r) => (r.id === id ? { ...r, [key]: value } : r)),
+    );
   };
 
   const addPeriodicityValidation = () => {
-    setPeriodicityValidations(prev => [...prev, { id: Date.now(), column: '', periodicity: '' }]);
+    setPeriodicityValidations((prev) => [
+      ...prev,
+      { id: Date.now(), column: "", periodicity: "" },
+    ]);
   };
 
   const removePeriodicityValidation = (id: number) => {
-    setPeriodicityValidations(prev => prev.filter(p => p.id !== id));
+    setPeriodicityValidations((prev) => prev.filter((p) => p.id !== id));
   };
 
   const updatePeriodicityValidation = (
     id: number,
-    key: 'column' | 'periodicity',
-    value: string
+    key: "column" | "periodicity",
+    value: string,
   ) => {
-    setPeriodicityValidations(prev => prev.map(p => (p.id === id ? { ...p, [key]: value } : p)));
+    setPeriodicityValidations((prev) =>
+      prev.map((p) => (p.id === id ? { ...p, [key]: value } : p)),
+    );
   };
 
   const handleSaveConfiguration = async () => {
@@ -286,76 +335,95 @@ const DataUploadValidateProperties: React.FC<Props> = ({ atomId }) => {
 
     const definedTypes: Record<string, string> = {};
     Object.entries(columnDataTypes).forEach(([col, typ]) => {
-      if (typ && typ !== 'not_defined') definedTypes[col] = typ;
+      if (typ && typ !== "not_defined") definedTypes[col] = typ;
     });
     const typeForm = new FormData();
-    typeForm.append('validator_atom_id', validatorId);
-    typeForm.append('file_key', selectedMasterFile);
-    typeForm.append('column_types', JSON.stringify(definedTypes));
-    await fetch(`${VALIDATE_API}/update_column_types`, { method: 'POST', body: typeForm });
+    typeForm.append("validator_atom_id", validatorId);
+    typeForm.append("file_key", selectedMasterFile);
+    typeForm.append("column_types", JSON.stringify(definedTypes));
+    await fetch(`${VALIDATE_API}/update_column_types`, {
+      method: "POST",
+      body: typeForm,
+    });
 
     const columnConditions: Record<string, any[]> = {};
-    rangeValidations.forEach(r => {
+    rangeValidations.forEach((r) => {
       if (!r.column) return;
       const conds: any[] = [];
-      if (r.min !== '') {
-        conds.push({ operator: 'greater_than_or_equal', value: r.min, error_message: 'min check' });
+      if (r.min !== "") {
+        conds.push({
+          operator: "greater_than_or_equal",
+          value: r.min,
+          error_message: "min check",
+        });
       }
-      if (r.max !== '') {
-        conds.push({ operator: 'less_than_or_equal', value: r.max, error_message: 'max check' });
+      if (r.max !== "") {
+        conds.push({
+          operator: "less_than_or_equal",
+          value: r.max,
+          error_message: "max check",
+        });
       }
       if (conds.length > 0) columnConditions[r.column] = conds;
     });
 
     const columnFrequencies: Record<string, string> = {};
-    periodicityValidations.forEach(p => {
-      if (p.column && p.periodicity) columnFrequencies[p.column] = p.periodicity;
+    periodicityValidations.forEach((p) => {
+      if (p.column && p.periodicity)
+        columnFrequencies[p.column] = p.periodicity;
     });
 
     await fetch(`${VALIDATE_API}/configure_validation_config`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         validator_atom_id: validatorId,
         file_key: selectedMasterFile,
         column_conditions: columnConditions,
-        column_frequencies: columnFrequencies
-      })
+        column_frequencies: columnFrequencies,
+      }),
     });
 
     const classifyForm = new FormData();
-    classifyForm.append('validator_atom_id', validatorId);
-    classifyForm.append('file_key', selectedMasterFile);
-    classifyForm.append('identifiers', JSON.stringify(selectedIdentifiers));
-    classifyForm.append('measures', JSON.stringify(selectedMeasures));
-    classifyForm.append('unclassified', JSON.stringify([]));
-    await fetch(`${VALIDATE_API}/classify_columns`, { method: 'POST', body: classifyForm });
+    classifyForm.append("validator_atom_id", validatorId);
+    classifyForm.append("file_key", selectedMasterFile);
+    classifyForm.append("identifiers", JSON.stringify(selectedIdentifiers));
+    classifyForm.append("measures", JSON.stringify(selectedMeasures));
+    classifyForm.append("unclassified", JSON.stringify([]));
+    await fetch(`${VALIDATE_API}/classify_columns`, {
+      method: "POST",
+      body: classifyForm,
+    });
 
-    const savedRanges = rangeValidations.filter(r => r.column && (r.min !== '' || r.max !== ''));
-    const savedPeriods = periodicityValidations.filter(p => p.column && p.periodicity);
+    const savedRanges = rangeValidations.filter(
+      (r) => r.column && (r.min !== "" || r.max !== ""),
+    );
+    const savedPeriods = periodicityValidations.filter(
+      (p) => p.column && p.periodicity,
+    );
     const newValidations = {
       ...(settings.validations || {}),
       [selectedMasterFile]: {
         ranges: savedRanges,
-        periodicities: savedPeriods
-      }
+        periodicities: savedPeriods,
+      },
     };
     const newClassification = {
       ...(settings.classification || {}),
       [selectedMasterFile]: {
         identifiers: selectedIdentifiers,
-        measures: selectedMeasures
-      }
+        measures: selectedMeasures,
+      },
     };
     updateSettings(atomId, {
       validatorId,
-      requiredFiles: allAvailableFiles.map(f => f.name),
+      requiredFiles: allAvailableFiles.map((f) => f.name),
       validations: newValidations,
       classification: newClassification,
       columnConfig: {
         ...(settings.columnConfig || {}),
-        [selectedMasterFile]: columnDataTypes
-      }
+        [selectedMasterFile]: columnDataTypes,
+      },
     });
   };
 
@@ -373,7 +441,9 @@ const DataUploadValidateProperties: React.FC<Props> = ({ atomId }) => {
         <div className="p-4 border-b border-gray-200 bg-gray-50">
           <div className="space-y-4">
             <div>
-              <label className="text-sm font-medium text-gray-700 block mb-2">Upload Master File</label>
+              <label className="text-sm font-medium text-gray-700 block mb-2">
+                Upload Master File
+              </label>
               <input
                 type="file"
                 multiple
@@ -383,7 +453,11 @@ const DataUploadValidateProperties: React.FC<Props> = ({ atomId }) => {
                 id="master-file-upload"
               />
               <label htmlFor="master-file-upload">
-                <Button asChild variant="outline" className="w-full cursor-pointer border-gray-300">
+                <Button
+                  asChild
+                  variant="outline"
+                  className="w-full cursor-pointer border-gray-300"
+                >
                   <span className="flex items-center justify-center space-x-2">
                     <Upload className="w-4 h-4" />
                     <span>Choose Files</span>
@@ -393,8 +467,13 @@ const DataUploadValidateProperties: React.FC<Props> = ({ atomId }) => {
             </div>
 
             <div>
-              <label className="text-sm font-medium text-gray-700 block mb-2">Select Master File</label>
-              <Select value={selectedMasterFile} onValueChange={setSelectedMasterFile}>
+              <label className="text-sm font-medium text-gray-700 block mb-2">
+                Select Master File
+              </label>
+              <Select
+                value={selectedMasterFile}
+                onValueChange={setSelectedMasterFile}
+              >
                 <SelectTrigger className="bg-white border-gray-300">
                   <SelectValue placeholder="Select a master file..." />
                 </SelectTrigger>
@@ -405,7 +484,10 @@ const DataUploadValidateProperties: React.FC<Props> = ({ atomId }) => {
                     </SelectItem>
                   ) : (
                     allAvailableFiles.map((file, index) => (
-                      <SelectItem key={`${file.source}-${index}`} value={file.name}>
+                      <SelectItem
+                        key={`${file.source}-${index}`}
+                        value={file.name}
+                      >
                         {file.name}
                       </SelectItem>
                     ))
@@ -417,9 +499,9 @@ const DataUploadValidateProperties: React.FC<Props> = ({ atomId }) => {
         </div>
 
         {/* Tabs Section - Only active when master file is selected */}
-        {selectedMasterFile && selectedMasterFile !== 'no-files' && (
+        {selectedMasterFile && selectedMasterFile !== "no-files" && (
           <Tabs defaultValue="datatype" className="w-full">
-            <TabsList className="grid w-full grid-cols-3 mx-4 my-4">
+            <TabsList className="grid w-full grid-cols-2 mx-4 my-4">
               <TabsTrigger value="datatype" className="text-xs">
                 <Table className="w-3 h-3 mr-1" />
                 DataType
@@ -428,64 +510,85 @@ const DataUploadValidateProperties: React.FC<Props> = ({ atomId }) => {
                 <BarChart3 className="w-3 h-3 mr-1" />
                 Value
               </TabsTrigger>
-              <TabsTrigger value="dimension" className="text-xs">
-                <Settings className="w-3 h-3 mr-1" />
-                Dimension
-              </TabsTrigger>
             </TabsList>
 
             <div className="px-4">
               <TabsContent value="datatype" className="space-y-4">
                 <div className="pt-4">
-                  <h4 className="text-sm font-medium text-gray-900 mb-3">Column Data Types</h4>
+                  <h4 className="text-sm font-medium text-gray-900 mb-3">
+                    Column Data Types
+                  </h4>
                   <div className="space-y-3">
-                    {Object.entries(columnDataTypes).map(([columnName, dataType]) => (
-                      <div
-                        key={columnName}
-                        className="flex items-center justify-between p-3 bg-gray-50 rounded-lg border border-gray-200"
-                      >
-                        <div className="flex-1">
-                          <p className="text-sm font-medium text-gray-900">{columnName}</p>
-                          <p className="text-xs text-gray-600">Data Type</p>
+                    {Object.entries(columnDataTypes).map(
+                      ([columnName, dataType]) => (
+                        <div
+                          key={columnName}
+                          className="flex items-center justify-between p-3 bg-gray-50 rounded-lg border border-gray-200"
+                        >
+                          <div className="flex-1">
+                            <p className="text-sm font-medium text-gray-900">
+                              {columnName}
+                            </p>
+                            <p className="text-xs text-gray-600">Data Type</p>
+                          </div>
+                          <Select
+                            value={dataType}
+                            onValueChange={(value) =>
+                              handleDataTypeChange(columnName, value)
+                            }
+                          >
+                            <SelectTrigger className="w-20 h-8 text-xs bg-white border-gray-300">
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {dataTypeOptions.map((option) => (
+                                <SelectItem
+                                  key={option.value}
+                                  value={option.value}
+                                >
+                                  {option.label}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
                         </div>
-                        <Select value={dataType} onValueChange={value => handleDataTypeChange(columnName, value)}>
-                          <SelectTrigger className="w-20 h-8 text-xs bg-white border-gray-300">
-                            <SelectValue />
-                          </SelectTrigger>
-                          <SelectContent>
-                            {dataTypeOptions.map(option => (
-                              <SelectItem key={option.value} value={option.value}>
-                                {option.label}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      </div>
-                    ))}
+                      ),
+                    )}
                   </div>
                 </div>
               </TabsContent>
 
               <TabsContent value="value" className="space-y-4">
                 <div className="pt-4">
-                  <h4 className="text-sm font-medium text-gray-900 mb-4">Value Settings</h4>
+                  <h4 className="text-sm font-medium text-gray-900 mb-4">
+                    Value Settings
+                  </h4>
 
                   {/* Range Validation Section */}
                   <div className="space-y-4">
                     <div className="flex items-center justify-between">
-                      <h5 className="text-sm font-medium text-gray-700">Range Validation</h5>
-                      <Button onClick={addRangeValidation} size="sm" variant="outline" className="h-7 px-2">
+                      <h5 className="text-sm font-medium text-gray-700">
+                        Range Validation
+                      </h5>
+                      <Button
+                        onClick={addRangeValidation}
+                        size="sm"
+                        variant="outline"
+                        className="h-7 px-2"
+                      >
                         <Plus className="w-3 h-3" />
                       </Button>
                     </div>
 
-                    {rangeValidations.map(range => (
+                    {rangeValidations.map((range) => (
                       <div
                         key={range.id}
                         className="p-3 bg-gray-50 rounded-lg border border-gray-200 space-y-3"
                       >
                         <div className="flex items-center justify-between">
-                          <label className="text-xs font-medium text-gray-700">Column</label>
+                          <label className="text-xs font-medium text-gray-700">
+                            Column
+                          </label>
                           {rangeValidations.length > 1 && (
                             <Button
                               onClick={() => removeRangeValidation(range.id)}
@@ -499,13 +602,15 @@ const DataUploadValidateProperties: React.FC<Props> = ({ atomId }) => {
                         </div>
                         <Select
                           value={range.column}
-                          onValueChange={value => updateRangeValidation(range.id, 'column', value)}
+                          onValueChange={(value) =>
+                            updateRangeValidation(range.id, "column", value)
+                          }
                         >
                           <SelectTrigger className="bg-white border-gray-300 h-8 text-xs">
                             <SelectValue placeholder="Select numerical column..." />
                           </SelectTrigger>
                           <SelectContent>
-                            {numericalColumns.map(column => (
+                            {numericalColumns.map((column) => (
                               <SelectItem key={column} value={column}>
                                 {column}
                               </SelectItem>
@@ -514,20 +619,36 @@ const DataUploadValidateProperties: React.FC<Props> = ({ atomId }) => {
                         </Select>
                         <div className="grid grid-cols-2 gap-2">
                           <div>
-                            <label className="text-xs font-medium text-gray-700 block mb-1">Min</label>
+                            <label className="text-xs font-medium text-gray-700 block mb-1">
+                              Min
+                            </label>
                             <Input
                               placeholder="Min value"
                               value={range.min}
-                              onChange={e => updateRangeValidation(range.id, 'min', e.target.value)}
+                              onChange={(e) =>
+                                updateRangeValidation(
+                                  range.id,
+                                  "min",
+                                  e.target.value,
+                                )
+                              }
                               className="bg-white border-gray-300 h-8 text-xs"
                             />
                           </div>
                           <div>
-                            <label className="text-xs font-medium text-gray-700 block mb-1">Max</label>
+                            <label className="text-xs font-medium text-gray-700 block mb-1">
+                              Max
+                            </label>
                             <Input
                               placeholder="Max value"
                               value={range.max}
-                              onChange={e => updateRangeValidation(range.id, 'max', e.target.value)}
+                              onChange={(e) =>
+                                updateRangeValidation(
+                                  range.id,
+                                  "max",
+                                  e.target.value,
+                                )
+                              }
                               className="bg-white border-gray-300 h-8 text-xs"
                             />
                           </div>
@@ -539,22 +660,33 @@ const DataUploadValidateProperties: React.FC<Props> = ({ atomId }) => {
                   {/* Periodicity Validation Section */}
                   <div className="space-y-4 mt-6">
                     <div className="flex items-center justify-between">
-                      <h5 className="text-sm font-medium text-gray-700">Periodicity Validation</h5>
-                      <Button onClick={addPeriodicityValidation} size="sm" variant="outline" className="h-7 px-2">
+                      <h5 className="text-sm font-medium text-gray-700">
+                        Periodicity Validation
+                      </h5>
+                      <Button
+                        onClick={addPeriodicityValidation}
+                        size="sm"
+                        variant="outline"
+                        className="h-7 px-2"
+                      >
                         <Plus className="w-3 h-3" />
                       </Button>
                     </div>
 
-                    {periodicityValidations.map(periodicity => (
+                    {periodicityValidations.map((periodicity) => (
                       <div
                         key={periodicity.id}
                         className="p-3 bg-gray-50 rounded-lg border border-gray-200 space-y-3"
                       >
                         <div className="flex items-center justify-between">
-                          <label className="text-xs font-medium text-gray-700">Date Column</label>
+                          <label className="text-xs font-medium text-gray-700">
+                            Date Column
+                          </label>
                           {periodicityValidations.length > 1 && (
                             <Button
-                              onClick={() => removePeriodicityValidation(periodicity.id)}
+                              onClick={() =>
+                                removePeriodicityValidation(periodicity.id)
+                              }
                               size="sm"
                               variant="outline"
                               className="h-6 px-2"
@@ -565,13 +697,19 @@ const DataUploadValidateProperties: React.FC<Props> = ({ atomId }) => {
                         </div>
                         <Select
                           value={periodicity.column}
-                          onValueChange={value => updatePeriodicityValidation(periodicity.id, 'column', value)}
+                          onValueChange={(value) =>
+                            updatePeriodicityValidation(
+                              periodicity.id,
+                              "column",
+                              value,
+                            )
+                          }
                         >
                           <SelectTrigger className="bg-white border-gray-300 h-8 text-xs">
                             <SelectValue placeholder="Select date column..." />
                           </SelectTrigger>
                           <SelectContent>
-                            {dateColumns.map(column => (
+                            {dateColumns.map((column) => (
                               <SelectItem key={column} value={column}>
                                 {column}
                               </SelectItem>
@@ -579,17 +717,28 @@ const DataUploadValidateProperties: React.FC<Props> = ({ atomId }) => {
                           </SelectContent>
                         </Select>
                         <div>
-                          <label className="text-xs font-medium text-gray-700 block mb-1">Periodicity</label>
+                          <label className="text-xs font-medium text-gray-700 block mb-1">
+                            Periodicity
+                          </label>
                           <Select
                             value={periodicity.periodicity}
-                            onValueChange={value => updatePeriodicityValidation(periodicity.id, 'periodicity', value)}
+                            onValueChange={(value) =>
+                              updatePeriodicityValidation(
+                                periodicity.id,
+                                "periodicity",
+                                value,
+                              )
+                            }
                           >
                             <SelectTrigger className="bg-white border-gray-300 h-8 text-xs">
                               <SelectValue placeholder="Select periodicity..." />
                             </SelectTrigger>
                             <SelectContent>
-                              {periodicityOptions.map(option => (
-                                <SelectItem key={option.value} value={option.value}>
+                              {periodicityOptions.map((option) => (
+                                <SelectItem
+                                  key={option.value}
+                                  value={option.value}
+                                >
                                   {option.label}
                                 </SelectItem>
                               ))}
@@ -601,62 +750,13 @@ const DataUploadValidateProperties: React.FC<Props> = ({ atomId }) => {
                   </div>
                 </div>
               </TabsContent>
-
-              <TabsContent value="dimension" className="space-y-4">
-                <div className="pt-4">
-                  <h4 className="text-sm font-medium text-gray-900 mb-3">Dimension Settings</h4>
-                  <div className="space-y-4">
-                    <div>
-                      <label className="text-sm font-medium text-gray-700 block mb-3">Identifiers</label>
-                      <div className="grid grid-cols-2 gap-2">
-                        {categoricalColumns.map(col => (
-                          <label key={col} className="flex items-center space-x-2 text-xs">
-                            <Checkbox
-                              checked={selectedIdentifiers.includes(col)}
-                              onCheckedChange={val => {
-                                const checked = Boolean(val);
-                                setSelectedIdentifiers(prev =>
-                                  checked ? [...prev, col] : prev.filter(c => c !== col)
-                                );
-                              }}
-                            />
-                            <span>{col}</span>
-                          </label>
-                        ))}
-                      </div>
-                    </div>
-
-                    <div>
-                      <label className="text-sm font-medium text-gray-700 block mb-3">Measures</label>
-                      <div className="grid grid-cols-2 gap-2">
-                        {continuousColumns.map(col => (
-                          <label key={col} className="flex items-center space-x-2 text-xs">
-                            <Checkbox
-                              checked={selectedMeasures.includes(col)}
-                              onCheckedChange={val => {
-                                const checked = Boolean(val);
-                                setSelectedMeasures(prev =>
-                                  checked ? [...prev, col] : prev.filter(c => c !== col)
-                                );
-                              }}
-                            />
-                            <span>{col}</span>
-                          </label>
-                        ))}
-                      </div>
-                    </div>
-
-                    <Button variant="outline" size="sm" className="w-full border-gray-300">
-                      <Plus className="w-3 h-3 mr-1" />
-                      Add Custom Dimension
-                    </Button>
-                  </div>
-                </div>
-              </TabsContent>
             </div>
 
             <div className="p-4 border-t border-gray-200 mt-4">
-              <Button onClick={handleSaveConfiguration} className="w-full bg-gradient-to-r from-blue-500 to-blue-600 hover:from-blue-600 hover:to-blue-700 text-white shadow-lg">
+              <Button
+                onClick={handleSaveConfiguration}
+                className="w-full bg-gradient-to-r from-blue-500 to-blue-600 hover:from-blue-600 hover:to-blue-700 text-white shadow-lg"
+              >
                 Save Configuration
               </Button>
             </div>
@@ -664,10 +764,12 @@ const DataUploadValidateProperties: React.FC<Props> = ({ atomId }) => {
         )}
 
         {/* Message when no master file is selected */}
-        {(!selectedMasterFile || selectedMasterFile === 'no-files') && (
+        {(!selectedMasterFile || selectedMasterFile === "no-files") && (
           <div className="p-8 text-center text-gray-500">
             <Table className="w-12 h-12 mx-auto mb-4 text-gray-300" />
-            <p className="text-sm">Select a master file to configure data types and settings</p>
+            <p className="text-sm">
+              Select a master file to configure data types and settings
+            </p>
           </div>
         )}
       </div>
@@ -676,4 +778,3 @@ const DataUploadValidateProperties: React.FC<Props> = ({ atomId }) => {
 };
 
 export default DataUploadValidateProperties;
-

--- a/TrinityFrontend/src/components/LaboratoryMode/store/laboratoryStore.ts
+++ b/TrinityFrontend/src/components/LaboratoryMode/store/laboratoryStore.ts
@@ -154,7 +154,7 @@ export const DEFAULT_COLUMN_CLASSIFIER_SETTINGS: ColumnClassifierSettings = {
   },
   validatorId: '',
   fileKey: '',
-  dimensions: ['market', 'product'],
+  dimensions: [],
   assignments: {}
 };
 

--- a/TrinityFrontend/src/contexts/AuthContext.tsx
+++ b/TrinityFrontend/src/contexts/AuthContext.tsx
@@ -73,6 +73,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     console.log('Checking backend availability at', `${API_BASE}/users/me/`);
     try {
       const ping = await fetch(`${API_BASE}/users/me/`, { credentials: 'include' });
+      // This request is unauthenticated on first login so a 401/403
+      // response is expected. It merely confirms the API is reachable.
       console.log('Backend check status', ping.status);
     } catch (err) {
       console.log('Backend check failed', err);

--- a/TrinityFrontend/src/lib/api.ts
+++ b/TrinityFrontend/src/lib/api.ts
@@ -59,4 +59,4 @@ export const TRINITY_AI_API =
 export const LAB_ACTIONS_API = `${REGISTRY_API}/laboratory-actions`;
 
 export const CLASSIFIER_API =
-  import.meta.env.VITE_CLASSIFIER_API || `${backendOrigin.replace(/:8000$/, ':8001')}/classify`;
+  import.meta.env.VITE_CLASSIFIER_API || `${backendOrigin.replace(/:8000$/, ':8001')}/api/classify`;

--- a/columnCLassifierDebug.txt
+++ b/columnCLassifierDebug.txt
@@ -1,0 +1,13 @@
+# Column Classifier API Check
+
+Run this `curl` command with sample form values. Replace `demo123` and `sales` with your own
+validator atom ID and file key as needed:
+
+```bash
+curl -X POST http://localhost:8001/api/classify/classify_columns \
+  -F "validator_atom_id=demo123" \
+  -F "file_key=sales" \
+  -F "identifiers=[]" \
+  -F "measures=[]" \
+  -F "unclassified=[]"
+```

--- a/columnCLassifierDebug.txt
+++ b/columnCLassifierDebug.txt
@@ -1,13 +1,23 @@
 # Column Classifier API Check
 
-Run this `curl` command with sample form values. Replace `demo123` and `sales` with your own
-validator atom ID and file key as needed:
+Run these `curl` commands to verify the API. Log in first so the session cookie
+is stored in `cookies.txt`:
 
 ```bash
-curl -X POST http://localhost:8001/api/classify/classify_columns \
+# 1. Authenticate against Django
+curl -c cookies.txt -H 'Content-Type: application/json' \
+  -X POST http://localhost:8000/api/accounts/login/ \
+  -d '{"username":"admin","password":"admin123"}'
+
+# 2. Call the classifier service using that cookie
+curl -b cookies.txt -X POST http://localhost:8001/api/classify/classify_columns \
   -F "validator_atom_id=demo123" \
   -F "file_key=sales" \
   -F "identifiers=[]" \
   -F "measures=[]" \
   -F "unclassified=[]"
 ```
+
+Replace `admin`/`admin123` with your Django credentials and update the
+`validator_atom_id` and `file_key` parameters with actual values from your
+environment.

--- a/columnCLassifierDebug.txt
+++ b/columnCLassifierDebug.txt
@@ -18,6 +18,10 @@ curl -b cookies.txt -X POST http://localhost:8001/api/classify/classify_columns 
   -F "unclassified=[]"
 ```
 
+If the response is `{"detail": "Validator atom 'demo123' not found in database"}`
+or a similar 404 message, the service is reachable but the given `validator_atom_id`
+or `file_key` does not exist. Provide valid values from your environment.
+
 Replace `admin`/`admin123` with your Django credentials and update the
 `validator_atom_id` and `file_key` parameters with actual values from your
 environment.


### PR DESCRIPTION
## Summary
- register column classifier router without extra prefix
- use `/api/classify` path for frontend calls

## Testing
- `pytest -q` *(fails: ImportError: fastapi not found)*

------
https://chatgpt.com/codex/tasks/task_e_68760cf129188321a2e3330a34a5da7c