### PR TITLE
Fix feature overview crash during prefetch

### DIFF
--- a/TrinityFrontend/src/components/AtomList/atoms/feature-overview/components/FeatureOverviewCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/feature-overview/components/FeatureOverviewCanvas.tsx
@@ -100,7 +100,7 @@ const FeatureOverviewCanvas: React.FC<FeatureOverviewCanvasProps> = ({
       displaySkus();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dimensionMap]);
+  }, [dimensionMap, settings.dataSource]);
 
   useEffect(() => {
     setSkuRows(Array.isArray(settings.skuTable) ? settings.skuTable : []);
@@ -167,6 +167,7 @@ const FeatureOverviewCanvas: React.FC<FeatureOverviewCanvasProps> = ({
         `${FEATURE_OVERVIEW_API}/cached_dataframe?object_name=${encodeURIComponent(
           settings.dataSource,
         )}`,
+        { credentials: 'include' }
       );
       if (!res.ok) {
         console.warn("⚠️ cached dataframe request failed", res.status);

--- a/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea.tsx
@@ -119,7 +119,8 @@ const CanvasArea: React.FC<CanvasAreaProps> = ({ onAtomSelect, onCardSelect, sel
     try {
       console.log('✈️ fetching flight table', name);
       const fr = await fetch(
-        `${FEATURE_OVERVIEW_API}/flight_table?object_name=${encodeURIComponent(name)}`
+        `${FEATURE_OVERVIEW_API}/flight_table?object_name=${encodeURIComponent(name)}`,
+        { credentials: 'include' }
       );
       if (fr.ok) {
         await fr.arrayBuffer();
@@ -127,7 +128,8 @@ const CanvasArea: React.FC<CanvasAreaProps> = ({ onAtomSelect, onCardSelect, sel
       }
       console.log('🔎 prefetching dataframe', name);
       const res = await fetch(
-        `${FEATURE_OVERVIEW_API}/cached_dataframe?object_name=${encodeURIComponent(name)}`
+        `${FEATURE_OVERVIEW_API}/cached_dataframe?object_name=${encodeURIComponent(name)}`,
+        { credentials: 'include' }
       );
       if (res.ok) {
         await res.text();


### PR DESCRIPTION
## Summary
- ensure Feature Overview SKUs load only when a data source exists
- include credentials when prefetching data from the backend

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687775905b8c83218f9949064e62d300