### PR TITLE
Add development docker-compose stack

### DIFF
--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -1,0 +1,52 @@
+# Development Environment Setup
+
+This project now includes a separate Docker Compose file for running
+all services in a development stack without interfering with the
+production containers.
+
+## Files
+- `docker-compose-dev.yml` – defines the development services with
+  different port mappings and a dedicated Docker network `trinity-dev-net`.
+- `cloudflared-dev/` – contains the compose file and credentials for a
+  Cloudflare tunnel exposing `trinity-dev.quantmatrixai.com`.
+
+## Preparing the Cloudflare tunnel
+1. Install the `cloudflared` CLI and authenticate with your
+   Cloudflare account.
+2. Create a new tunnel and DNS record for the dev domain:
+   ```bash
+   cloudflared tunnel create trinity-dev
+   cloudflared tunnel route dns trinity-dev trinity-dev.quantmatrixai.com
+   ```
+3. Copy the generated credentials JSON into
+   `cloudflared-dev/tunnelCreds/` and update
+   `cloudflared-dev/tunnelCreds/config.yml` with the tunnel ID. The
+   config already points at `trinity-dev.quantmatrixai.com` and will
+   forward traffic to the Traefik container.
+
+Start the tunnel:
+```bash
+cd cloudflared-dev
+docker compose -p trinity-dev up -d
+```
+
+## Running the development stack
+From the repository root run:
+```bash
+docker compose -f docker-compose-dev.yml -p trinity-dev up -d
+```
+Using the `-p trinity-dev` flag ensures container, volume and network
+names differ from the production stack.
+
+After the containers report **healthy** you can access the services at:
+- `http://localhost:8081` – React frontend
+- `http://localhost:8003/admin/` – Django admin
+- `http://localhost:8004/api/` – FastAPI
+- `http://localhost:5051` – PgAdmin
+
+Requests to `https://trinity-dev.quantmatrixai.com` will reach the
+same services through the Cloudflare tunnel.
+
+The production stack remains unaffected and can run simultaneously
+because ports, network names and the Cloudflare tunnel are all
+separate.

--- a/cloudflared-dev/README.md
+++ b/cloudflared-dev/README.md
@@ -1,0 +1,12 @@
+# Cloudflared Tunnel (Dev)
+
+This directory mirrors `cloudflared/` but provides a separate tunnel
+for the development environment. Copy your dev tunnel credentials into
+`./tunnelCreds` and update `config.yml` with the tunnel ID and
+hostname `trinity-dev.quantmatrixai.com`.
+
+Start the tunnel with:
+
+```bash
+docker compose -p trinity-dev -f docker-compose.yml up -d
+```

--- a/cloudflared-dev/docker-compose.yml
+++ b/cloudflared-dev/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    command: tunnel --config /etc/cloudflared/config.yml run
+    volumes:
+      - ./tunnelCreds:/etc/cloudflared:ro
+    networks:
+      - trinity-dev-net
+
+networks:
+  trinity-dev-net:
+    external: true
+    name: trinity-dev-net

--- a/cloudflared-dev/tunnelCreds/config.yml
+++ b/cloudflared-dev/tunnelCreds/config.yml
@@ -1,0 +1,10 @@
+# Replace DEV_TUNNEL_ID with your Cloudflare tunnel ID
+# and ensure the corresponding credentials JSON exists
+# in this directory with the same ID.
+tunnel: DEV_TUNNEL_ID
+credentials-file: /etc/cloudflared/DEV_TUNNEL_ID.json
+
+ingress:
+  - hostname: trinity-dev.quantmatrixai.com
+    service: http://traefik:80
+  - service: http_status:404

--- a/cloudflared-dev/tunnelCreds/credentials.json.example
+++ b/cloudflared-dev/tunnelCreds/credentials.json.example
@@ -1,0 +1,6 @@
+{
+  "AccountTag": "YOUR_ACCOUNT_TAG",
+  "TunnelID": "e0a883c4-bc43-4742-b47a-96ef902e6bb3",
+  "TunnelName": "trinity-frontend",
+  "TunnelSecret": "REPLACE_WITH_BASE64_SECRET"
+}

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,212 @@
+services:
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: trinity_db
+      POSTGRES_USER: trinity_user
+      POSTGRES_PASSWORD: trinity_pass
+    volumes:
+      - postgres_data:/var/lib/postgresql/data/
+    ports:
+      - "5433:5432"
+    networks:
+      - trinity-dev-net
+
+  mongo:
+    image: mongo:6
+    volumes:
+      - mongo_data:/data/db
+    networks:
+      - trinity-dev-net
+
+  redis:
+    image: redis:7
+    volumes:
+      - redis_data:/data
+    networks:
+      - trinity-dev-net
+
+  minio:
+    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
+    environment:
+      MINIO_ROOT_USER: minio
+      MINIO_ROOT_PASSWORD: minio123
+    command: server /data --console-address ":9001"
+    ports:
+      - "9002:9000"
+      - "9003:9001"
+    volumes:
+      - minio_data:/data
+    networks:
+      - trinity-dev-net
+
+  pgadmin:
+    image: dpage/pgadmin4
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@example.com
+      PGADMIN_DEFAULT_PASSWORD: admin
+    ports:
+      - "5051:80"
+    depends_on:
+      - postgres
+    networks:
+      - trinity-dev-net
+
+  web:
+    build: ./TrinityBackendDjango
+    command: gunicorn config.wsgi:application --bind 0.0.0.0:8000 --workers 3
+    volumes:
+      - ./TrinityBackendDjango:/code
+    env_file:
+      - ./TrinityBackendDjango/.env
+    ports:
+      - "8003:8000"
+    environment:
+      HOST_IP: ${HOST_IP:-10.2.1.242}
+      FRONTEND_PORT: "8081"
+      CORS_ALLOWED_ORIGINS: "http://127.0.0.1:8081,http://${HOST_IP:-10.2.1.242}:8081,http://172.17.48.1:8081,http://10.2.1.65:8081,https://trinity-dev.quantmatrixai.com"
+      CSRF_TRUSTED_ORIGINS: "http://127.0.0.1:8081,http://${HOST_IP:-10.2.1.242}:8081,http://172.17.48.1:8081,http://10.2.1.65:8081,https://trinity-dev.quantmatrixai.com"
+      MONGO_URI: "mongodb://mongo:27017/trinity_dev"
+    depends_on:
+      - postgres
+      - mongo
+      - redis
+      - minio
+    networks:
+      - trinity-dev-net
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.django.rule=Host(`trinity-dev.quantmatrixai.com`) && PathPrefix(`/admin`)"
+      - "traefik.http.routers.django.entrypoints=web"
+      - "traefik.http.routers.django.middlewares=django-strip@docker"
+      - "traefik.http.middlewares.django-strip.stripprefix.prefixes=/admin"
+      - "traefik.http.services.django.loadbalancer.server.port=8000"
+
+  celery:
+    build: ./TrinityBackendDjango
+    command: celery -A config.celery worker --loglevel=info
+    volumes:
+      - ./TrinityBackendDjango:/code
+    env_file:
+      - ./TrinityBackendDjango/.env
+    depends_on:
+      - redis
+      - postgres
+      - mongo
+    networks:
+      - trinity-dev-net
+    environment:
+      MONGO_URI: "mongodb://mongo:27017/trinity_dev"
+
+  fastapi:
+    build: ./TrinityBackendDjango
+    command: uvicorn apps.orchestration.fastapi_app:app --host 0.0.0.0 --port 8001
+    volumes:
+      - ./TrinityBackendDjango:/code
+      - ./TrinityBackendFastAPI:/code/TrinityBackendFastAPI
+    env_file:
+      - ./TrinityBackendDjango/.env
+    environment:
+      MINIO_ENDPOINT: minio:9000
+      MINIO_ACCESS_KEY: minio
+      MINIO_SECRET_KEY: minio123
+      FLIGHT_HOST: flight
+      FLIGHT_PORT: 8815
+      HOST_IP: ${HOST_IP:-10.2.1.242}
+      FASTAPI_CORS_ORIGINS: "http://127.0.0.1:8081,http://${HOST_IP:-10.2.1.242}:8081,http://172.17.48.1:8081,http://10.2.1.65:8081,https://trinity-dev.quantmatrixai.com"
+      MONGO_URI: "mongodb://mongo:27017/trinity_dev"
+    ports:
+      - "8004:8001"
+    depends_on:
+      - postgres
+      - mongo
+      - redis
+      - minio
+    networks:
+      - trinity-dev-net
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.fastapi.rule=Host(`trinity-dev.quantmatrixai.com`) && PathPrefix(`/api`)"
+      - "traefik.http.routers.fastapi.entrypoints=web"
+      - "traefik.http.services.fastapi.loadbalancer.server.port=8001"
+
+  flight:
+    build:
+      context: ./TrinityBackendFastAPI
+      dockerfile: Dockerfile
+    command: python app/flight_server.py
+    env_file:
+      - ./TrinityBackendDjango/.env
+    ports:
+      - "8816:8815"
+    networks:
+      - trinity-dev-net
+
+  trinity-ai:
+    build:
+      context: ./TrinityAI
+      dockerfile: Dockerfile
+    env_file:
+      - ./TrinityBackendDjango/.env
+    environment:
+      OLLAMA_IP: 10.2.1.65
+    ports:
+      - "8005:8002"
+    networks:
+      - trinity-dev-net
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.trinity-ai.rule=Host(`trinity-dev.quantmatrixai.com`) && PathPrefix(`/chat`)"
+      - "traefik.http.routers.trinity-ai.entrypoints=web"
+      - "traefik.http.routers.trinity-ai.priority=100"
+      - "traefik.http.services.trinity-ai.loadbalancer.server.port=8002"
+
+  frontend:
+    build:
+      context: ./TrinityFrontend
+      dockerfile: Dockerfile
+    ports:
+      - "8081:80"
+    networks:
+      - trinity-dev-net
+    depends_on:
+      - web
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.frontend.rule=Host(`trinity-dev.quantmatrixai.com`)"
+      - "traefik.http.routers.frontend.entrypoints=web"
+      - "traefik.http.services.frontend.loadbalancer.server.port=80"
+
+  traefik:
+    image: traefik:v2.11
+    command:
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --entrypoints.web.address=:80
+    ports:
+      - "9081:80"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - trinity-dev-net
+    depends_on:
+      - web
+      - fastapi
+
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    command: tunnel --config /etc/cloudflared/config.yml run
+    volumes:
+      - ./cloudflared-dev/tunnelCreds:/etc/cloudflared:ro
+    networks:
+      - trinity-dev-net
+
+volumes:
+  postgres_data:
+  mongo_data:
+  redis_data:
+  minio_data:
+
+networks:
+  trinity-dev-net:
+    name: trinity-dev-net


### PR DESCRIPTION
## Summary
- add `docker-compose-dev.yml` with separate ports and network
- document how to start a dev environment and tunnel
- provide sample cloudflared config for dev

## Testing
- `docker compose -f docker-compose-dev.yml config` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687df8435cc883219f0fc9f8a99665d1