### PR TITLE
Fix Traefik router conflicts between envs

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -75,6 +75,7 @@ services:
     networks:
       - trinity-dev-net
     labels:
+      - "environment=dev"
       - "traefik.enable=true"
       - "traefik.http.routers.django.rule=Host(`trinity-dev.quantmatrixai.com`) && PathPrefix(`/admin`)"
       - "traefik.http.routers.django.entrypoints=web"
@@ -125,6 +126,7 @@ services:
     networks:
       - trinity-dev-net
     labels:
+      - "environment=dev"
       - "traefik.enable=true"
       - "traefik.http.routers.fastapi.rule=Host(`trinity-dev.quantmatrixai.com`) && PathPrefix(`/api`)"
       - "traefik.http.routers.fastapi.entrypoints=web"
@@ -155,6 +157,7 @@ services:
     networks:
       - trinity-dev-net
     labels:
+      - "environment=dev"
       - "traefik.enable=true"
       - "traefik.http.routers.trinity-ai.rule=Host(`trinity-dev.quantmatrixai.com`) && PathPrefix(`/chat`)"
       - "traefik.http.routers.trinity-ai.entrypoints=web"
@@ -172,6 +175,7 @@ services:
     depends_on:
       - web
     labels:
+      - "environment=dev"
       - "traefik.enable=true"
       - "traefik.http.routers.frontend.rule=Host(`trinity-dev.quantmatrixai.com`)"
       - "traefik.http.routers.frontend.entrypoints=web"
@@ -183,6 +187,7 @@ services:
       - --providers.docker=true
       - --providers.docker.exposedbydefault=false
       - --entrypoints.web.address=:80
+      - --providers.docker.constraints=Label(`environment=dev`)
     ports:
       - "9081:80"
     volumes:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,3 +1,5 @@
+name: trinity-dev
+
 services:
   postgres:
     image: postgres:15
@@ -139,6 +141,8 @@ services:
     command: python app/flight_server.py
     env_file:
       - ./TrinityBackendDjango/.env
+    labels:
+      - "environment=dev"
     ports:
       - "8816:8815"
     networks:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -187,7 +187,7 @@ services:
       - --providers.docker=true
       - --providers.docker.exposedbydefault=false
       - --entrypoints.web.address=:80
-      - --providers.docker.constraints=Label(`environment=dev`)
+      - --providers.docker.constraints=Label(`environment`,`dev`)
     ports:
       - "9081:80"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -186,7 +186,7 @@ services:
       - --providers.docker=true
       - --providers.docker.exposedbydefault=false
       - --entrypoints.web.address=:80
-      - --providers.docker.constraints=Label(`environment=prod`)
+      - --providers.docker.constraints=Label(`environment`,`prod`)
     ports:
       - "9080:80"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+name: trinity-prod
+
 services:
   postgres:
     image: postgres:15
@@ -139,6 +141,8 @@ services:
     command: python app/flight_server.py
     env_file:
       - ./TrinityBackendDjango/.env
+    labels:
+      - "environment=prod"
     ports:
       - "8815:8815"
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,7 @@ services:
     networks:
       - trinity-net
     labels:
+      - "environment=prod"
       - "traefik.enable=true"
       - "traefik.http.routers.django.rule=Host(`trinity.quantmatrixai.com`) && PathPrefix(`/admin`)"
       - "traefik.http.routers.django.entrypoints=web"
@@ -125,6 +126,7 @@ services:
     networks:
       - trinity-net
     labels:
+      - "environment=prod"
       - "traefik.enable=true"
       - "traefik.http.routers.fastapi.rule=Host(`trinity.quantmatrixai.com`) && PathPrefix(`/api`)"
       - "traefik.http.routers.fastapi.entrypoints=web"
@@ -155,6 +157,7 @@ services:
     networks:
       - trinity-net
     labels:
+      - "environment=prod"
       - "traefik.enable=true"
       - "traefik.http.routers.trinity-ai.rule=Host(`trinity.quantmatrixai.com`) && PathPrefix(`/chat`)"
       - "traefik.http.routers.trinity-ai.entrypoints=web"
@@ -172,6 +175,7 @@ services:
     depends_on:
       - web
     labels:
+      - "environment=prod"
       - "traefik.enable=true"
       - "traefik.http.routers.frontend.rule=Host(`trinity.quantmatrixai.com`)"
       - "traefik.http.routers.frontend.entrypoints=web"
@@ -182,6 +186,7 @@ services:
       - --providers.docker=true
       - --providers.docker.exposedbydefault=false
       - --entrypoints.web.address=:80
+      - --providers.docker.constraints=Label(`environment=prod`)
     ports:
       - "9080:80"
     volumes:


### PR DESCRIPTION
## Summary
- label prod and dev services with environment tags
- filter Traefik containers to only see their own environment

## Testing
- `docker compose -f docker-compose.yml config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e31cbee1c8321aa702bad84ffca63