### PR TITLE
Implement project rename/delete tracking

### DIFF
--- a/EnvironmentUpdateGuide.txt
+++ b/EnvironmentUpdateGuide.txt
@@ -49,3 +49,18 @@ docker compose -f docker-compose.yml -f docker-compose.dev.yml -p trinity_dev ru
 ```bash
 docker compose -f docker-compose.yml -f docker-compose.prod.yml -p trinity_prod run --rm web python create_tenant.py
 ```
+
+## Applying updates
+If you pull new commits that include Django migrations, run the tenant setup script again so the changes apply to both the public and tenant schemas before restarting the containers.
+
+### Development environment
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml -p trinity_dev run --rm web python create_tenant.py
+```
+
+### Production environment
+```bash
+docker compose -f docker-compose.yml -f docker-compose.prod.yml -p trinity_prod run --rm web python create_tenant.py
+```
+
+Running this step ensures new columns like `Project.previous_name` are added and avoids errors when fetching or creating projects.

--- a/README.md
+++ b/README.md
@@ -239,7 +239,9 @@ a duplicate domain. Ensure the request is sent to the public host (e.g.
    form parsing, are installed from `TrinityBackendDjango/requirements.txt`.
    When a project is created the backend ensures a corresponding
    `client/app/project/` folder exists in the `trinity` bucket so atoms operate
-   solely within that directory.
+   solely within that directory. Renaming or deleting a project also updates the
+   folder and stores the previous name in the new `previous_name` column so
+   history is preserved.
 
 With these steps the Django orchestration layer, FastAPI features and the
 React frontend are fully connected.

--- a/README.md
+++ b/README.md
@@ -237,6 +237,9 @@ a duplicate domain. Ensure the request is sent to the public host (e.g.
 2. The FastAPI container also relies on the MinIO client. The required Python
    packages, including `motor` for MongoDB access and `python-multipart` for
    form parsing, are installed from `TrinityBackendDjango/requirements.txt`.
+   When a project is created the backend ensures a corresponding
+   `client/app/project/` folder exists in the `trinity` bucket so atoms operate
+   solely within that directory.
 
 With these steps the Django orchestration layer, FastAPI features and the
 React frontend are fully connected.

--- a/TrinityBackendDjango/apps/registry/migrations/0009_project_previous_name.py
+++ b/TrinityBackendDjango/apps/registry/migrations/0009_project_previous_name.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('registry', '0008_arrowdataset_unique'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='project',
+            name='previous_name',
+            field=models.CharField(blank=True, max_length=150, help_text='Previous project name if renamed or deleted'),
+        ),
+        migrations.AddField(
+            model_name='historicalproject',
+            name='previous_name',
+            field=models.CharField(blank=True, max_length=150, help_text='Previous project name if renamed or deleted'),
+        ),
+    ]

--- a/TrinityBackendDjango/apps/registry/migrations/0009_project_previous_name.py
+++ b/TrinityBackendDjango/apps/registry/migrations/0009_project_previous_name.py
@@ -15,7 +15,6 @@ class Migration(migrations.Migration):
                 default='',
                 help_text='Previous project name if renamed or deleted',
             ),
-            preserve_default=False,
         ),
         migrations.AddField(
             model_name='historicalproject',
@@ -26,6 +25,5 @@ class Migration(migrations.Migration):
                 default='',
                 help_text='Previous project name if renamed or deleted',
             ),
-            preserve_default=False,
         ),
     ]

--- a/TrinityBackendDjango/apps/registry/migrations/0009_project_previous_name.py
+++ b/TrinityBackendDjango/apps/registry/migrations/0009_project_previous_name.py
@@ -9,11 +9,23 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='project',
             name='previous_name',
-            field=models.CharField(blank=True, max_length=150, help_text='Previous project name if renamed or deleted'),
+            field=models.CharField(
+                max_length=150,
+                blank=True,
+                default='',
+                help_text='Previous project name if renamed or deleted',
+            ),
+            preserve_default=False,
         ),
         migrations.AddField(
             model_name='historicalproject',
             name='previous_name',
-            field=models.CharField(blank=True, max_length=150, help_text='Previous project name if renamed or deleted'),
+            field=models.CharField(
+                max_length=150,
+                blank=True,
+                default='',
+                help_text='Previous project name if renamed or deleted',
+            ),
+            preserve_default=False,
         ),
     ]

--- a/TrinityBackendDjango/apps/registry/models.py
+++ b/TrinityBackendDjango/apps/registry/models.py
@@ -32,6 +32,7 @@ class Project(models.Model):
     previous_name = models.CharField(
         max_length=150,
         blank=True,
+        default="",
         help_text="Previous project name if renamed or deleted",
     )
     description = models.TextField(blank=True)

--- a/TrinityBackendDjango/apps/registry/models.py
+++ b/TrinityBackendDjango/apps/registry/models.py
@@ -29,6 +29,11 @@ class Project(models.Model):
     """
     name = models.CharField(max_length=150)
     slug = models.SlugField(max_length=150)
+    previous_name = models.CharField(
+        max_length=150,
+        blank=True,
+        help_text="Previous project name if renamed or deleted",
+    )
     description = models.TextField(blank=True)
     owner = models.ForeignKey(
         User, on_delete=models.CASCADE, related_name="projects"

--- a/TrinityBackendDjango/apps/registry/serializers.py
+++ b/TrinityBackendDjango/apps/registry/serializers.py
@@ -26,6 +26,7 @@ class ProjectSerializer(serializers.ModelSerializer):
             "id",
             "name",
             "slug",
+            "previous_name",
             "description",
             "owner",
             "app",

--- a/TrinityBackendDjango/apps/registry/storage_utils.py
+++ b/TrinityBackendDjango/apps/registry/storage_utils.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import sys
 import asyncio
 from .models import ArrowDataset
+from asgiref.sync import async_to_sync
 
 # Ensure FastAPI utilities are importable for DB helpers
 FASTAPI_APP = Path(__file__).resolve().parents[3] / "TrinityBackendFastAPI" / "app"
@@ -55,7 +56,9 @@ def project_prefix(user_id: int, project_id: int) -> str:
     project = os.getenv("PROJECT_NAME", "default_project")
     if fetch_client_app_project is not None:
         try:
-            client, app, project = asyncio.run(fetch_client_app_project(user_id, project_id))
+            client, app, project = async_to_sync(fetch_client_app_project)(
+                user_id, project_id
+            )
         except Exception:
             pass
     return f"{client}/{app}/{project}/"

--- a/TrinityBackendDjango/apps/registry/storage_utils.py
+++ b/TrinityBackendDjango/apps/registry/storage_utils.py
@@ -1,0 +1,61 @@
+import os
+from minio import Minio
+from minio.error import S3Error
+from minio.commonconfig import CopySource
+from pathlib import Path
+import sys
+import asyncio
+from .models import ArrowDataset
+
+# Ensure FastAPI utilities are importable for DB helpers
+FASTAPI_APP = Path(__file__).resolve().parents[3] / "TrinityBackendFastAPI" / "app"
+if str(FASTAPI_APP) not in sys.path:
+    sys.path.append(str(FASTAPI_APP))
+try:
+    from DataStorageRetrieval.db import fetch_client_app_project
+except Exception:  # pragma: no cover - helper not available
+    fetch_client_app_project = None
+
+MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT", "minio:9000")
+MINIO_ACCESS_KEY = os.getenv("MINIO_ACCESS_KEY", "minio")
+MINIO_SECRET_KEY = os.getenv("MINIO_SECRET_KEY", "minio123")
+MINIO_BUCKET = os.getenv("MINIO_BUCKET", "trinity")
+
+_client = Minio(
+    MINIO_ENDPOINT,
+    access_key=MINIO_ACCESS_KEY,
+    secret_key=MINIO_SECRET_KEY,
+    secure=False,
+)
+
+def project_prefix(user_id: int, project_id: int) -> str:
+    """Return storage prefix for given user and project."""
+    client = os.getenv("CLIENT_NAME", "default_client")
+    app = os.getenv("APP_NAME", "default_app")
+    project = os.getenv("PROJECT_NAME", "default_project")
+    if fetch_client_app_project is not None:
+        try:
+            client, app, project = asyncio.run(fetch_client_app_project(user_id, project_id))
+        except Exception:
+            pass
+    return f"{client}/{app}/{project}/"
+
+def rename_prefix(old_prefix: str, new_prefix: str) -> None:
+    """Rename all objects under ``old_prefix`` to ``new_prefix``."""
+    for obj in _client.list_objects(MINIO_BUCKET, prefix=old_prefix, recursive=True):
+        new_name = new_prefix + obj.object_name[len(old_prefix):]
+        _client.copy_object(MINIO_BUCKET, new_name, CopySource(MINIO_BUCKET, obj.object_name))
+        try:
+            _client.remove_object(MINIO_BUCKET, obj.object_name)
+        except S3Error:
+            pass
+        ArrowDataset.objects.filter(arrow_object=obj.object_name).update(arrow_object=new_name)
+
+def delete_prefix(prefix: str) -> None:
+    """Delete all objects under ``prefix`` and remove DB entries."""
+    for obj in _client.list_objects(MINIO_BUCKET, prefix=prefix, recursive=True):
+        try:
+            _client.remove_object(MINIO_BUCKET, obj.object_name)
+        except S3Error:
+            pass
+        ArrowDataset.objects.filter(arrow_object=obj.object_name).delete()

--- a/TrinityBackendDjango/apps/registry/views.py
+++ b/TrinityBackendDjango/apps/registry/views.py
@@ -8,7 +8,12 @@ from .serializers import (
     LaboratoryActionSerializer,
     ArrowDatasetSerializer,
 )
-from .storage_utils import rename_prefix, delete_prefix, project_prefix
+from .storage_utils import (
+    rename_prefix,
+    delete_prefix,
+    project_prefix,
+    ensure_prefix,
+)
 
 
 class AppViewSet(viewsets.ModelViewSet):
@@ -57,6 +62,11 @@ class ProjectViewSet(viewsets.ModelViewSet):
 
     def perform_create(self, serializer):
         serializer.save(owner=self.request.user)
+        prefix = project_prefix(serializer.instance.owner_id, serializer.instance.id)
+        try:
+            ensure_prefix(prefix)
+        except Exception:
+            pass
 
     def perform_update(self, serializer):
         instance = self.get_object()

--- a/TrinityBackendFastAPI/app/features/concat/deps.py
+++ b/TrinityBackendFastAPI/app/features/concat/deps.py
@@ -27,20 +27,21 @@ REDIS_PORT = int(os.getenv("REDIS_PORT", 6379))
 redis_client = redis.Redis(host=REDIS_HOST, port=REDIS_PORT, decode_responses=False)
 
 
-def load_names_from_db() -> None:
-    global CLIENT_NAME, APP_NAME, PROJECT_NAME
+async def init_object_prefix() -> None:
+    """Initialize names and prefix from Postgres."""
+    global CLIENT_NAME, APP_NAME, PROJECT_NAME, OBJECT_PREFIX
     if USER_ID and PROJECT_ID:
         try:
-            CLIENT_NAME_DB, APP_NAME_DB, PROJECT_NAME_DB = asyncio.run(
-                fetch_client_app_project(USER_ID, PROJECT_ID)
+            CLIENT_NAME_DB, APP_NAME_DB, PROJECT_NAME_DB = await fetch_client_app_project(
+                USER_ID, PROJECT_ID
             )
             CLIENT_NAME = CLIENT_NAME_DB or CLIENT_NAME
             APP_NAME = APP_NAME_DB or APP_NAME
             PROJECT_NAME = PROJECT_NAME_DB or PROJECT_NAME
         except Exception as exc:
             print(f"⚠️ Failed to load names from DB: {exc}")
+    OBJECT_PREFIX = f"{CLIENT_NAME}/{APP_NAME}/{PROJECT_NAME}/"
 
-load_names_from_db()
 
 OBJECT_PREFIX = f"{CLIENT_NAME}/{APP_NAME}/{PROJECT_NAME}/"
 
@@ -141,4 +142,5 @@ __all__ = [
     'OBJECT_PREFIX',
     'MINIO_BUCKET',
     'redis_client',
+    'init_object_prefix',
 ]

--- a/TrinityBackendFastAPI/app/features/concat/main.py
+++ b/TrinityBackendFastAPI/app/features/concat/main.py
@@ -4,6 +4,11 @@ from .routes import router as concat_router
 app = FastAPI(title="Concatinate Atom")
 app.include_router(concat_router,prefix="/concat", tags=["concat"])
 
+@app.on_event("startup")
+async def startup_event() -> None:
+    from . import deps
+    await deps.init_object_prefix()
+
 from fastapi.middleware.cors import CORSMiddleware
 
 app.add_middleware(

--- a/TrinityBackendFastAPI/app/features/data_upload_validate/app/main.py
+++ b/TrinityBackendFastAPI/app/features/data_upload_validate/app/main.py
@@ -51,6 +51,8 @@ async def startup_event():
     print("🚀 Validate Atom API starting up...")
     print("📊 Available validators: base, price_elasticity, mmm, innovation, custom")
     print("📖 API Documentation: http://localhost:8000/docs")
+    from . import routes
+    await routes.init_object_prefix()
 
 @app.on_event("shutdown")
 async def shutdown_event():

--- a/TrinityBackendFastAPI/app/features/data_upload_validate/app/routes.py
+++ b/TrinityBackendFastAPI/app/features/data_upload_validate/app/routes.py
@@ -139,23 +139,23 @@ CLIENT_NAME = os.getenv("CLIENT_NAME", "default_client")
 APP_NAME = os.getenv("APP_NAME", "default_app")
 PROJECT_NAME = os.getenv("PROJECT_NAME", "default_project")
 
-def load_names_from_db() -> None:
-    """Lookup client/app/project names from Postgres if ids are provided."""
-    global CLIENT_NAME, APP_NAME, PROJECT_NAME
+async def init_object_prefix() -> None:
+    """Initialize the names and object prefix from Postgres."""
+    global CLIENT_NAME, APP_NAME, PROJECT_NAME, OBJECT_PREFIX
     if USER_ID and PROJECT_ID:
         try:
-            CLIENT_NAME_DB, APP_NAME_DB, PROJECT_NAME_DB = asyncio.run(
-                fetch_client_app_project(USER_ID, PROJECT_ID)
+            CLIENT_NAME_DB, APP_NAME_DB, PROJECT_NAME_DB = await fetch_client_app_project(
+                USER_ID, PROJECT_ID
             )
             CLIENT_NAME = CLIENT_NAME_DB or CLIENT_NAME
             APP_NAME = APP_NAME_DB or APP_NAME
             PROJECT_NAME = PROJECT_NAME_DB or PROJECT_NAME
         except Exception as exc:
             print(f"⚠️ Failed to load names from DB: {exc}")
+    OBJECT_PREFIX = await get_object_prefix(USER_ID, PROJECT_ID)
 
-load_names_from_db()
 
-OBJECT_PREFIX = asyncio.run(get_object_prefix(USER_ID, PROJECT_ID))
+OBJECT_PREFIX = f"{CLIENT_NAME}/{APP_NAME}/{PROJECT_NAME}/"
 
 # Initialize MinIO client
 minio_client = get_client()

--- a/TrinityBackendFastAPI/app/features/data_upload_validate/app/routes.py
+++ b/TrinityBackendFastAPI/app/features/data_upload_validate/app/routes.py
@@ -117,6 +117,7 @@ from app.DataStorageRetrieval.minio_utils import (
     upload_to_minio,
     get_client,
     ARROW_DIR,
+    get_object_prefix,
 )
 import pyarrow as pa
 import pyarrow.ipc as ipc
@@ -154,7 +155,7 @@ def load_names_from_db() -> None:
 
 load_names_from_db()
 
-OBJECT_PREFIX = f"{CLIENT_NAME}/{APP_NAME}/{PROJECT_NAME}/"
+OBJECT_PREFIX = asyncio.run(get_object_prefix(USER_ID, PROJECT_ID))
 
 # Initialize MinIO client
 minio_client = get_client()

--- a/TrinityBackendFastAPI/app/features/feature_overview/main.py
+++ b/TrinityBackendFastAPI/app/features/feature_overview/main.py
@@ -16,3 +16,8 @@ app.add_middleware(
 # Register routes
 app.include_router(feature_overview_router, prefix="/feature-overview", tags=["Feature Overview"])
 
+@app.on_event("startup")
+async def startup_event() -> None:
+    from . import routes
+    await routes.init_object_prefix()
+

--- a/TrinityBackendFastAPI/app/features/feature_overview/routes.py
+++ b/TrinityBackendFastAPI/app/features/feature_overview/routes.py
@@ -33,6 +33,7 @@ from .feature_overview.base import (
     unique_count,
 )
 from app.DataStorageRetrieval.db import fetch_client_app_project
+from app.DataStorageRetrieval.minio_utils import get_object_prefix
 from app.DataStorageRetrieval.arrow_client import (
     download_dataframe,
     download_table_bytes,
@@ -77,7 +78,7 @@ def load_names_from_db() -> None:
 
 load_names_from_db()
 
-OBJECT_PREFIX = f"{CLIENT_NAME}/{APP_NAME}/{PROJECT_NAME}/"
+OBJECT_PREFIX = asyncio.run(get_object_prefix(USER_ID, PROJECT_ID))
 
 minio_client = Minio(
     MINIO_ENDPOINT,

--- a/TrinityBackendFastAPI/app/features/feature_overview/routes.py
+++ b/TrinityBackendFastAPI/app/features/feature_overview/routes.py
@@ -62,23 +62,23 @@ APP_NAME = os.getenv("APP_NAME", "default_app")
 PROJECT_NAME = os.getenv("PROJECT_NAME", "default_project")
 
 
-def load_names_from_db() -> None:
-    global CLIENT_NAME, APP_NAME, PROJECT_NAME
+async def init_object_prefix() -> None:
+    """Load names and prefix from Postgres."""
+    global CLIENT_NAME, APP_NAME, PROJECT_NAME, OBJECT_PREFIX
     if USER_ID and PROJECT_ID:
         try:
-            CLIENT_NAME_DB, APP_NAME_DB, PROJECT_NAME_DB = asyncio.run(
-                fetch_client_app_project(USER_ID, PROJECT_ID)
+            CLIENT_NAME_DB, APP_NAME_DB, PROJECT_NAME_DB = await fetch_client_app_project(
+                USER_ID, PROJECT_ID
             )
             CLIENT_NAME = CLIENT_NAME_DB or CLIENT_NAME
             APP_NAME = APP_NAME_DB or APP_NAME
             PROJECT_NAME = PROJECT_NAME_DB or PROJECT_NAME
         except Exception as exc:
             print(f"⚠️ Failed to load names from DB: {exc}")
+    OBJECT_PREFIX = await get_object_prefix(USER_ID, PROJECT_ID)
 
 
-load_names_from_db()
-
-OBJECT_PREFIX = asyncio.run(get_object_prefix(USER_ID, PROJECT_ID))
+OBJECT_PREFIX = f"{CLIENT_NAME}/{APP_NAME}/{PROJECT_NAME}/"
 
 minio_client = Minio(
     MINIO_ENDPOINT,

--- a/TrinityBackendFastAPI/app/features/merge/deps.py
+++ b/TrinityBackendFastAPI/app/features/merge/deps.py
@@ -25,7 +25,13 @@ REDIS_HOST = os.getenv("REDIS_HOST", "redis")
 REDIS_PORT = int(os.getenv("REDIS_PORT", 6379))
 redis_client = redis.Redis(host=REDIS_HOST, port=REDIS_PORT, decode_responses=False)
 
-OBJECT_PREFIX = asyncio.run(get_object_prefix(USER_ID, PROJECT_ID))
+async def init_object_prefix() -> None:
+    """Load object prefix from Postgres."""
+    global OBJECT_PREFIX
+    OBJECT_PREFIX = await get_object_prefix(USER_ID, PROJECT_ID)
+
+
+OBJECT_PREFIX = f"{CLIENT_NAME}/{APP_NAME}/{PROJECT_NAME}/"
 
 minio_client = Minio(
     MINIO_ENDPOINT,
@@ -56,5 +62,6 @@ __all__ = [
     'OBJECT_PREFIX',
     'MINIO_BUCKET',
     'redis_client',
+    'init_object_prefix',
 ]
 

--- a/TrinityBackendFastAPI/app/features/merge/deps.py
+++ b/TrinityBackendFastAPI/app/features/merge/deps.py
@@ -3,7 +3,9 @@ import pandas as pd
 import io
 from minio import Minio
 import redis
+import asyncio
 from io import BytesIO
+from app.DataStorageRetrieval.minio_utils import get_object_prefix
 
 # MinIO config
 MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT", "minio:9000")
@@ -23,7 +25,7 @@ REDIS_HOST = os.getenv("REDIS_HOST", "redis")
 REDIS_PORT = int(os.getenv("REDIS_PORT", 6379))
 redis_client = redis.Redis(host=REDIS_HOST, port=REDIS_PORT, decode_responses=False)
 
-OBJECT_PREFIX = f"{CLIENT_NAME}/{APP_NAME}/{PROJECT_NAME}/"
+OBJECT_PREFIX = asyncio.run(get_object_prefix(USER_ID, PROJECT_ID))
 
 minio_client = Minio(
     MINIO_ENDPOINT,

--- a/TrinityBackendFastAPI/app/features/merge/main.py
+++ b/TrinityBackendFastAPI/app/features/merge/main.py
@@ -7,6 +7,11 @@ from fastapi.middleware.cors import CORSMiddleware
 app = FastAPI(title="Merge Atom")
 app.include_router(merge_router,prefix="/merge", tags=["merge"])
 
+@app.on_event("startup")
+async def startup_event() -> None:
+    from . import deps
+    await deps.init_object_prefix()
+
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],  # or replace "*" with ["http://localhost:3000"]


### PR DESCRIPTION
## Summary
- add previous_name field to Project and historical model
- manage prefix renames or deletions using MinIO
- update serializer and viewset logic for renaming/deleting projects
- include migration for new field

## Testing
- `pytest -q TrinityBackendFastAPI/tests/test_arrow_flight.py::test_delete_dataframe_route -q`
- `pytest -q TrinityBackendFastAPI/tests/test_arrow_flight.py`

------
https://chatgpt.com/codex/tasks/task_e_688070a728a08321b845de49722c6437