### PR TITLE
fix arrow data save prefix

### DIFF
--- a/TrinityBackendDjango/apps/accounts/views.py
+++ b/TrinityBackendDjango/apps/accounts/views.py
@@ -71,12 +71,22 @@ class LoginView(APIView):
             login(request, user)
             tenant = getattr(request, "tenant", None)
             if tenant is not None:
-                os.environ["CLIENT_NAME"] = getattr(tenant, "schema_name", tenant.name if hasattr(tenant, "name") else str(tenant))
+                os.environ["CLIENT_NAME"] = getattr(
+                    tenant,
+                    "schema_name",
+                    tenant.name if hasattr(tenant, "name") else str(tenant),
+                )
             os.environ["USER_ID"] = str(user.id)
             print(
                 f"✅ login: USER_ID={os.environ['USER_ID']} CLIENT_NAME={os.environ.get('CLIENT_NAME')}"
             )
-            return Response(UserSerializer(user).data)
+            data = UserSerializer(user).data
+            data["environment"] = {
+                "CLIENT_NAME": os.environ.get("CLIENT_NAME"),
+                "APP_NAME": os.environ.get("APP_NAME"),
+                "PROJECT_NAME": os.environ.get("PROJECT_NAME"),
+            }
+            return Response(data)
         return Response({"detail": "Invalid credentials"}, status=status.HTTP_400_BAD_REQUEST)
 
 

--- a/TrinityBackendDjango/apps/accounts/views.py
+++ b/TrinityBackendDjango/apps/accounts/views.py
@@ -1,4 +1,5 @@
 from django.contrib.auth import authenticate, login, logout
+import os
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework import viewsets, permissions, status
@@ -68,6 +69,9 @@ class LoginView(APIView):
         user = authenticate(request, username=username, password=password)
         if user is not None:
             login(request, user)
+            tenant = getattr(request, "tenant", None)
+            if tenant is not None:
+                os.environ["CLIENT_NAME"] = getattr(tenant, "schema_name", tenant.name if hasattr(tenant, "name") else str(tenant))
             return Response(UserSerializer(user).data)
         return Response({"detail": "Invalid credentials"}, status=status.HTTP_400_BAD_REQUEST)
 

--- a/TrinityBackendDjango/apps/accounts/views.py
+++ b/TrinityBackendDjango/apps/accounts/views.py
@@ -72,6 +72,10 @@ class LoginView(APIView):
             tenant = getattr(request, "tenant", None)
             if tenant is not None:
                 os.environ["CLIENT_NAME"] = getattr(tenant, "schema_name", tenant.name if hasattr(tenant, "name") else str(tenant))
+            os.environ["USER_ID"] = str(user.id)
+            print(
+                f"✅ login: USER_ID={os.environ['USER_ID']} CLIENT_NAME={os.environ.get('CLIENT_NAME')}"
+            )
             return Response(UserSerializer(user).data)
         return Response({"detail": "Invalid credentials"}, status=status.HTTP_400_BAD_REQUEST)
 

--- a/TrinityBackendDjango/apps/registry/views.py
+++ b/TrinityBackendDjango/apps/registry/views.py
@@ -32,7 +32,13 @@ class AppViewSet(viewsets.ModelViewSet):
         os.environ["APP_NAME"] = app_obj.slug
         print(f"✅ app selected: APP_NAME={os.environ['APP_NAME']}")
         serializer = self.get_serializer(app_obj)
-        return Response(serializer.data)
+        data = serializer.data
+        data["environment"] = {
+            "CLIENT_NAME": os.environ.get("CLIENT_NAME"),
+            "APP_NAME": os.environ.get("APP_NAME"),
+            "PROJECT_NAME": os.environ.get("PROJECT_NAME"),
+        }
+        return Response(data)
 
 
 class ProjectViewSet(viewsets.ModelViewSet):
@@ -74,7 +80,13 @@ class ProjectViewSet(viewsets.ModelViewSet):
             f"✅ project selected: PROJECT_ID={os.environ['PROJECT_ID']} PROJECT_NAME={os.environ['PROJECT_NAME']}"
         )
         serializer = self.get_serializer(project_obj)
-        return Response(serializer.data)
+        data = serializer.data
+        data["environment"] = {
+            "CLIENT_NAME": os.environ.get("CLIENT_NAME"),
+            "APP_NAME": os.environ.get("APP_NAME"),
+            "PROJECT_NAME": os.environ.get("PROJECT_NAME"),
+        }
+        return Response(data)
 
 
 class SessionViewSet(viewsets.ModelViewSet):

--- a/TrinityBackendDjango/apps/registry/views.py
+++ b/TrinityBackendDjango/apps/registry/views.py
@@ -1,4 +1,6 @@
 from rest_framework import viewsets, permissions
+from rest_framework.response import Response
+import os
 from apps.accounts.views import CsrfExemptSessionAuthentication
 from .models import App, Project, Session, LaboratoryAction, ArrowDataset
 from .serializers import (
@@ -24,6 +26,12 @@ class AppViewSet(viewsets.ModelViewSet):
         if self.action in ("create", "update", "partial_update", "destroy"):
             return [permissions.IsAdminUser()]
         return super().get_permissions()
+
+    def retrieve(self, request, *args, **kwargs):
+        app_obj = self.get_object()
+        os.environ["APP_NAME"] = app_obj.slug
+        serializer = self.get_serializer(app_obj)
+        return Response(serializer.data)
 
 
 class ProjectViewSet(viewsets.ModelViewSet):
@@ -56,6 +64,12 @@ class ProjectViewSet(viewsets.ModelViewSet):
 
     def perform_create(self, serializer):
         serializer.save(owner=self.request.user)
+
+    def retrieve(self, request, *args, **kwargs):
+        project_obj = self.get_object()
+        os.environ["PROJECT_NAME"] = project_obj.slug
+        serializer = self.get_serializer(project_obj)
+        return Response(serializer.data)
 
 
 class SessionViewSet(viewsets.ModelViewSet):

--- a/TrinityBackendDjango/apps/registry/views.py
+++ b/TrinityBackendDjango/apps/registry/views.py
@@ -30,6 +30,7 @@ class AppViewSet(viewsets.ModelViewSet):
     def retrieve(self, request, *args, **kwargs):
         app_obj = self.get_object()
         os.environ["APP_NAME"] = app_obj.slug
+        print(f"✅ app selected: APP_NAME={os.environ['APP_NAME']}")
         serializer = self.get_serializer(app_obj)
         return Response(serializer.data)
 
@@ -68,6 +69,10 @@ class ProjectViewSet(viewsets.ModelViewSet):
     def retrieve(self, request, *args, **kwargs):
         project_obj = self.get_object()
         os.environ["PROJECT_NAME"] = project_obj.slug
+        os.environ["PROJECT_ID"] = str(project_obj.id)
+        print(
+            f"✅ project selected: PROJECT_ID={os.environ['PROJECT_ID']} PROJECT_NAME={os.environ['PROJECT_NAME']}"
+        )
         serializer = self.get_serializer(project_obj)
         return Response(serializer.data)
 

--- a/TrinityBackendFastAPI/app/DataStorageRetrieval/minio_utils.py
+++ b/TrinityBackendFastAPI/app/DataStorageRetrieval/minio_utils.py
@@ -39,6 +39,16 @@ ARROW_DIR = Path("arrow_data")
 ARROW_DIR.mkdir(exist_ok=True)
 
 
+def get_arrow_dir() -> Path:
+    """Return the arrow directory for the current client/app/project."""
+    client = os.getenv("CLIENT_NAME", "default_client")
+    app = os.getenv("APP_NAME", "default_app")
+    project = os.getenv("PROJECT_NAME", "default_project")
+    dir_path = ARROW_DIR / client / app / project
+    dir_path.mkdir(parents=True, exist_ok=True)
+    return dir_path
+
+
 def save_arrow_table(df: pd.DataFrame, path: Path) -> None:
     """Save a DataFrame to a local Arrow file."""
     table = pa.Table.from_pandas(df)

--- a/TrinityBackendFastAPI/app/DataStorageRetrieval/minio_utils.py
+++ b/TrinityBackendFastAPI/app/DataStorageRetrieval/minio_utils.py
@@ -46,6 +46,9 @@ def get_arrow_dir() -> Path:
     project = os.getenv("PROJECT_NAME", "default_project")
     dir_path = ARROW_DIR / client / app / project
     dir_path.mkdir(parents=True, exist_ok=True)
+    print(
+        f"📁 arrow dir {dir_path} (client={client} app={app} project={project})"
+    )
     return dir_path
 
 
@@ -63,6 +66,7 @@ def upload_to_minio(file_content_bytes: bytes, filename: str, object_prefix: str
     try:
         timestamp = pd.Timestamp.now().strftime("%Y%m%d_%H%M%S")
         object_name = f"{object_prefix}{timestamp}_{filename}"
+        print(f"⬆️ uploading to minio: {object_name}")
         file_content = io.BytesIO(file_content_bytes)
         file_content.seek(0, os.SEEK_END)
         size = file_content.tell()

--- a/TrinityBackendFastAPI/app/features/data_upload_validate/app/routes.py
+++ b/TrinityBackendFastAPI/app/features/data_upload_validate/app/routes.py
@@ -117,6 +117,7 @@ from app.DataStorageRetrieval.minio_utils import (
     upload_to_minio,
     get_client,
     ARROW_DIR,
+    get_arrow_dir,
 )
 import pyarrow as pa
 import pyarrow.ipc as ipc
@@ -134,17 +135,12 @@ MINIO_BUCKET = os.getenv("MINIO_BUCKET", "trinity")
 USER_ID = int(os.getenv("USER_ID", "0"))
 PROJECT_ID = int(os.getenv("PROJECT_ID", "0"))
 
-DEFAULT_CLIENT = os.getenv("CLIENT_NAME", "default_client")
-DEFAULT_APP = os.getenv("APP_NAME", "default_app")
-DEFAULT_PROJECT = os.getenv("PROJECT_NAME", "default_project")
-
-
 async def get_object_prefix() -> str:
     """Return the MinIO prefix for the current client/app/project."""
 
-    client = DEFAULT_CLIENT
-    app = DEFAULT_APP
-    project = DEFAULT_PROJECT
+    client = os.getenv("CLIENT_NAME", "default_client")
+    app = os.getenv("APP_NAME", "default_app")
+    project = os.getenv("PROJECT_NAME", "default_project")
     if USER_ID and PROJECT_ID:
         try:
             client_db, app_db, project_db = await fetch_client_app_project(
@@ -1379,7 +1375,7 @@ async def validate(
     flight_uploads: list = []
     if validation_results["overall_status"] in ["passed", "passed_with_warnings"]:
         for (_, filename, key), (_, df) in zip(file_contents, files_data):
-            arrow_file = ARROW_DIR / f"{validator_atom_id}_{key}.arrow"
+            arrow_file = get_arrow_dir() / f"{validator_atom_id}_{key}.arrow"
             save_arrow_table(df, arrow_file)
 
             flight_path = f"{validator_atom_id}/{key}"

--- a/TrinityBackendFastAPI/app/features/data_upload_validate/app/routes.py
+++ b/TrinityBackendFastAPI/app/features/data_upload_validate/app/routes.py
@@ -155,8 +155,11 @@ async def get_object_prefix() -> str:
     os.environ["CLIENT_NAME"] = client
     os.environ["APP_NAME"] = app
     os.environ["PROJECT_NAME"] = project
-
-    return f"{client}/{app}/{project}/"
+    prefix = f"{client}/{app}/{project}/"
+    print(
+        f"📦 prefix {prefix} (USER_ID={USER_ID} PROJECT_ID={PROJECT_ID})"
+    )
+    return prefix
 
 # Initialize MinIO client
 minio_client = get_client()
@@ -1376,6 +1379,7 @@ async def validate(
     if validation_results["overall_status"] in ["passed", "passed_with_warnings"]:
         for (_, filename, key), (_, df) in zip(file_contents, files_data):
             arrow_file = get_arrow_dir() / f"{validator_atom_id}_{key}.arrow"
+            print(f"📝 saving arrow {arrow_file}")
             save_arrow_table(df, arrow_file)
 
             flight_path = f"{validator_atom_id}/{key}"
@@ -2515,6 +2519,7 @@ async def save_dataframes(
             writer.write_table(table)
 
         prefix = await get_object_prefix()
+        print(f"📤 saving to prefix {prefix}")
         result = upload_to_minio(arrow_buf.getvalue(), arrow_name, prefix)
         saved_name = Path(result.get("object_name", "")).name or arrow_name
         flight_path = f"{validator_atom_id}/{saved_name}"

--- a/TrinityBackendFastAPI/app/main.py
+++ b/TrinityBackendFastAPI/app/main.py
@@ -40,3 +40,15 @@ app.include_router(api_router, prefix="/api")
 # Include the text router under /api/text
 app.include_router(text_router, prefix="/api/t")
 
+
+@app.on_event("startup")
+async def log_env():
+    print(
+        "🚀 env CLIENT_NAME=%s APP_NAME=%s PROJECT_NAME=%s"
+        % (
+            os.getenv("CLIENT_NAME"),
+            os.getenv("APP_NAME"),
+            os.getenv("PROJECT_NAME"),
+        )
+    )
+

--- a/TrinityFrontend/src/components/AtomList/atoms/data-upload-validate/DataUploadValidateAtom.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/data-upload-validate/DataUploadValidateAtom.tsx
@@ -277,6 +277,12 @@ const DataUploadValidateAtom: React.FC<Props> = ({ atomId }) => {
     const res = await fetch(`${VALIDATE_API}/save_dataframes`, { method: 'POST', body: form });
     if (res.ok) {
       const data = await res.json();
+      if (data.environment) {
+        console.log('Save dataframes env', data.environment);
+      }
+      if (data.prefix) {
+        console.log('Saving to MinIO prefix', data.prefix);
+      }
       const newStatus: Record<string, string> = {};
       data.minio_uploads.forEach((r: any, idx: number) => {
         if (r.already_saved) {

--- a/TrinityFrontend/src/components/WorkflowMode/WorkflowMode.tsx
+++ b/TrinityFrontend/src/components/WorkflowMode/WorkflowMode.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import { safeStringify } from '@/utils/safeStringify';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
@@ -22,6 +22,18 @@ const WorkflowMode = () => {
   const [canvasMolecules, setCanvasMolecules] = useState<any[]>([]);
   const { toast } = useToast();
   const navigate = useNavigate();
+
+  useEffect(() => {
+    const envStr = localStorage.getItem('env');
+    if (envStr) {
+      try {
+        const env = JSON.parse(envStr);
+        console.log('Environment in app', env);
+      } catch {
+        /* ignore */
+      }
+    }
+  }, []);
 
   const handleMoleculeSelect = (moleculeId: string) => {
     setSelectedMoleculeId(moleculeId);

--- a/TrinityFrontend/src/contexts/AuthContext.tsx
+++ b/TrinityFrontend/src/contexts/AuthContext.tsx
@@ -104,6 +104,10 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       if (res.ok) {
         const data = await res.json();
         console.log('Login success, user:', data.username);
+        if (data.environment) {
+          console.log('Environment after login', data.environment);
+          localStorage.setItem('env', JSON.stringify(data.environment));
+        }
 
         // Verify that a session cookie was actually set. Without a
         // valid session further requests (like fetching the apps list)

--- a/TrinityFrontend/src/pages/Apps.tsx
+++ b/TrinityFrontend/src/pages/Apps.tsx
@@ -108,6 +108,20 @@ const handleAppSelect = async (appId: string) => {
     'current-app',
     JSON.stringify({ id: backendId, slug: appId })
   );
+  try {
+    const res = await fetch(`${REGISTRY_API}/apps/${backendId}/`, {
+      credentials: 'include'
+    });
+    if (res.ok) {
+      const data = await res.json();
+      if (data.environment) {
+        console.log('Environment after app select', data.environment);
+        localStorage.setItem('env', JSON.stringify(data.environment));
+      }
+    }
+  } catch (err) {
+    console.log('App select env fetch error', err);
+  }
   navigate(`/projects?app=${appId}`);
 };
 

--- a/TrinityFrontend/src/pages/Projects.tsx
+++ b/TrinityFrontend/src/pages/Projects.tsx
@@ -167,6 +167,21 @@ const Projects = () => {
         const project = await res.json();
         localStorage.setItem('current-project', JSON.stringify(project));
 
+        try {
+          const envRes = await fetch(`${REGISTRY_API}/projects/${project.id}/`, {
+            credentials: 'include'
+          });
+          if (envRes.ok) {
+            const envData = await envRes.json();
+            if (envData.environment) {
+              console.log('Environment after project creation', envData.environment);
+              localStorage.setItem('env', JSON.stringify(envData.environment));
+            }
+          }
+        } catch (err) {
+          console.log('Project env fetch error', err);
+        }
+
         const ids = templates[appSlug] || [];
         let layout: any[] = [];
         if (ids.length > 0) {
@@ -282,6 +297,10 @@ const Projects = () => {
       const res = await fetch(`${REGISTRY_API}/projects/${project.id}/`, { credentials: 'include' });
       if (res.ok) {
         const data = await res.json();
+        if (data.environment) {
+          console.log('Environment after project select', data.environment);
+          localStorage.setItem('env', JSON.stringify(data.environment));
+        }
         if (data.state && data.state.workflow_canvas) {
           localStorage.setItem('workflow-canvas-molecules', safeStringify(data.state.workflow_canvas));
         } else {


### PR DESCRIPTION
## Summary
- fix object prefix retrieval by reading env vars during each call
- add helper to compute arrow data directory using client/app/project
- store validated arrow tables under tenant-specific directories

## Testing
- `pip install -q -r requirements.txt && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880dceffa408321a585b8d1f587387f