### PR TITLE
Add Redis-backed environment variable cache

### DIFF
--- a/TrinityAI/README.md
+++ b/TrinityAI/README.md
@@ -12,5 +12,6 @@ The frontend references these URLs directly so the host and port must match your
 See the individual READMEs for details and exact endpoints.
 
 The AI agents read `MINIO_ENDPOINT`, `MINIO_ACCESS_KEY` and
-`MINIO_SECRET_KEY` from the environment to fetch files. By default the
-endpoint resolves to `minio:9000` which matches the compose setup.
+`MINIO_SECRET_KEY` from the environment to fetch files. The endpoint
+value comes from your `.env` or docker-compose configuration so dev and
+prod agents can target their respective MinIO services.

--- a/TrinityAI/main_api.py
+++ b/TrinityAI/main_api.py
@@ -55,7 +55,7 @@ def get_minio_config() -> Dict[str, str]:
     client, app, project = _fetch_names_from_db()
     prefix_default = f"{client}/{app}/{project}/"
     return {
-        "endpoint": os.getenv("MINIO_ENDPOINT", "minio:9000"),
+        "endpoint": os.getenv("MINIO_ENDPOINT"),
         "access_key": os.getenv("MINIO_ACCESS_KEY", "minio"),
         "secret_key": os.getenv("MINIO_SECRET_KEY", "minio123"),
         "bucket": os.getenv("MINIO_BUCKET", "trinity"),

--- a/TrinityAI/main_api.py
+++ b/TrinityAI/main_api.py
@@ -55,7 +55,8 @@ def get_minio_config() -> Dict[str, str]:
     client, app, project = _fetch_names_from_db()
     prefix_default = f"{client}/{app}/{project}/"
     return {
-        "endpoint": os.getenv("MINIO_ENDPOINT"),
+        # Default to the development MinIO service if not explicitly configured
+        "endpoint": os.getenv("MINIO_ENDPOINT", "minio:9000"),
         "access_key": os.getenv("MINIO_ACCESS_KEY", "minio"),
         "secret_key": os.getenv("MINIO_SECRET_KEY", "minio123"),
         "bucket": os.getenv("MINIO_BUCKET", "trinity"),

--- a/TrinityBackendDjango/apps/accounts/utils.py
+++ b/TrinityBackendDjango/apps/accounts/utils.py
@@ -16,6 +16,7 @@ def load_env_vars(user) -> dict:
         os.getenv("CLIENT_ID", ""),
         os.getenv("APP_ID", ""),
         os.getenv("PROJECT_ID", ""),
+        user_id=str(getattr(user, "id", user)),
         client_name=os.getenv("CLIENT_NAME", ""),
         app_name=os.getenv("APP_NAME", ""),
         project_name=os.getenv("PROJECT_NAME", ""),
@@ -77,6 +78,7 @@ def get_env_dict(user):
         os.getenv("CLIENT_ID", ""),
         os.getenv("APP_ID", ""),
         os.getenv("PROJECT_ID", ""),
+        user_id=str(getattr(user, "id", user)),
         client_name=os.getenv("CLIENT_NAME", ""),
         app_name=os.getenv("APP_NAME", ""),
         project_name=os.getenv("PROJECT_NAME", ""),
@@ -106,16 +108,20 @@ async def get_env_vars(
     app_id: str = "",
     project_id: str = "",
     *,
+    user_id: str | None = None,
     client_name: str = "",
     app_name: str = "",
     project_name: str = "",
     use_cache: bool = True,
 ) -> dict:
     """Fetch environment variables using Redis-backed cache."""
+    if user_id is None:
+        user_id = os.getenv("USER_ID", "")
     env = await sync_to_async(cache_get_env_vars)(
         client_id,
         app_id,
         project_id,
+        user_id=user_id,
         client_name=client_name,
         app_name=app_name,
         project_name=project_name,

--- a/TrinityBackendDjango/apps/accounts/utils.py
+++ b/TrinityBackendDjango/apps/accounts/utils.py
@@ -11,8 +11,15 @@ from redis_store.env_cache import (
 
 
 def load_env_vars(user) -> dict:
-    """Load saved environment variables for the user into ``os.environ``."""
-    envs = get_env_dict(user)
+    """Load saved environment variables for the current context from Redis."""
+    envs = cache_get_env_vars(
+        os.getenv("CLIENT_ID", ""),
+        os.getenv("APP_ID", ""),
+        os.getenv("PROJECT_ID", ""),
+        client_name=os.getenv("CLIENT_NAME", ""),
+        app_name=os.getenv("APP_NAME", ""),
+        project_name=os.getenv("PROJECT_NAME", ""),
+    )
     for k, v in envs.items():
         os.environ[k] = v
     return envs
@@ -65,9 +72,15 @@ def save_env_var(user, key, value) -> None:
     )
 
 def get_env_dict(user):
-    """Return the user's environment variables as a simple dict."""
-    envs = UserEnvironmentVariable.objects.filter(user=user)
-    return {e.key: e.value for e in envs}
+    """Return environment variables for the current client/app/project from Redis."""
+    return cache_get_env_vars(
+        os.getenv("CLIENT_ID", ""),
+        os.getenv("APP_ID", ""),
+        os.getenv("PROJECT_ID", ""),
+        client_name=os.getenv("CLIENT_NAME", ""),
+        app_name=os.getenv("APP_NAME", ""),
+        project_name=os.getenv("PROJECT_NAME", ""),
+    )
 
 
 @sync_to_async

--- a/TrinityBackendDjango/apps/accounts/utils.py
+++ b/TrinityBackendDjango/apps/accounts/utils.py
@@ -1,7 +1,6 @@
 import os
 import time
 from django.utils import timezone
-from django.core.cache import cache
 from asgiref.sync import sync_to_async
 from .models import UserEnvironmentVariable
 from redis_store.env_cache import (
@@ -100,25 +99,6 @@ def get_env_dict(user):
         app_name=current.get("app_name", os.getenv("APP_NAME", "")),
         project_name=current.get("project_name", os.getenv("PROJECT_NAME", "")),
     )
-
-
-@sync_to_async
-def _query_env_vars(client_id: str, app_id: str, project_id: str):
-    qs = UserEnvironmentVariable.objects.filter(
-        client_id=client_id, app_id=app_id, project_id=project_id
-    )
-    return {e.key: e.value for e in qs}
-
-
-@sync_to_async
-def _query_env_vars_by_names(client_name: str, app_name: str, project_name: str):
-    qs = UserEnvironmentVariable.objects.filter(
-        client_name=client_name, project_name=project_name
-    )
-    if app_name:
-        qs = qs.filter(app_name=app_name)
-    return {e.key: e.value for e in qs}
-
 
 async def get_env_vars(
     client_id: str = "",

--- a/TrinityBackendDjango/apps/registry/signals.py
+++ b/TrinityBackendDjango/apps/registry/signals.py
@@ -78,3 +78,11 @@ def update_env_vars_on_rename(sender, instance, **kwargs):
                 app_name=entry["app_name"],
                 project_name=entry["project_name"],
             )
+        tenant = _current_tenant_name()
+        app_slug = instance.app.slug
+        old_slug = old.name.replace(" ", "_")
+        new_slug = instance.name.replace(" ", "_")
+        print(
+            f"🚚 Project renamed: renaming MinIO folder {old_slug} -> {new_slug}"
+        )
+        rename_project_folder(tenant, app_slug, old_slug, new_slug)

--- a/TrinityBackendDjango/apps/registry/signals.py
+++ b/TrinityBackendDjango/apps/registry/signals.py
@@ -26,7 +26,7 @@ def create_project_folder(sender, instance, created, **kwargs):
 
 
 @receiver(pre_save, sender=Project)
-def rename_project_folder(sender, instance, **kwargs):
+def rename_project_folder_signal(sender, instance, **kwargs):
     if not instance.pk:
         return
     try:
@@ -36,6 +36,10 @@ def rename_project_folder(sender, instance, **kwargs):
     if old.slug != instance.slug:
         tenant = _current_tenant_name()
         app_slug = instance.app.slug
+        # perform the folder rename in MinIO and log the update
+        print(
+            f"🚚 Project slug changed: renaming MinIO folder {old.slug} -> {instance.slug}"
+        )
         rename_project_folder(tenant, app_slug, old.slug, instance.slug)
 
 

--- a/TrinityBackendDjango/apps/registry/signals.py
+++ b/TrinityBackendDjango/apps/registry/signals.py
@@ -3,7 +3,7 @@ from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 from django.db import connection
 from .models import Project
-from common.minio_utils import create_prefix, rename_prefix
+from common.minio_utils import create_prefix, rename_prefix, rename_project_folder
 from apps.tenants.models import Tenant
 from apps.accounts.models import UserEnvironmentVariable
 from redis_store.env_cache import invalidate_env
@@ -36,9 +36,7 @@ def rename_project_folder(sender, instance, **kwargs):
     if old.slug != instance.slug:
         tenant = _current_tenant_name()
         app_slug = instance.app.slug
-        old_prefix = f"{tenant}/{app_slug}/{old.slug}"
-        new_prefix = f"{tenant}/{app_slug}/{instance.slug}"
-        rename_prefix(old_prefix, new_prefix)
+        rename_project_folder(tenant, app_slug, old.slug, instance.slug)
 
 
 @receiver(pre_save, sender=Project)

--- a/TrinityBackendDjango/common/minio_utils.py
+++ b/TrinityBackendDjango/common/minio_utils.py
@@ -63,3 +63,16 @@ def rename_prefix(old_prefix: str, new_prefix: str) -> None:
         dest = obj.object_name.replace(old_prefix, new_prefix, 1)
         _client.copy_object(MINIO_BUCKET, dest, CopySource(MINIO_BUCKET, obj.object_name))
         _client.remove_object(MINIO_BUCKET, obj.object_name)
+
+
+def rename_project_folder(
+    client_slug: str,
+    app_slug: str,
+    old_project_slug: str,
+    new_project_slug: str,
+) -> None:
+    """Rename a project's folder prefix when the project is renamed."""
+    old_prefix = f"{client_slug}/{app_slug}/{old_project_slug}"
+    new_prefix = f"{client_slug}/{app_slug}/{new_project_slug}"
+    rename_prefix(old_prefix, new_prefix)
+

--- a/TrinityBackendDjango/common/minio_utils.py
+++ b/TrinityBackendDjango/common/minio_utils.py
@@ -4,7 +4,7 @@ from minio import Minio
 from minio.error import S3Error
 from minio.commonconfig import CopySource
 
-MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT", "minio:9000")
+MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT")
 MINIO_ACCESS_KEY = os.getenv("MINIO_ACCESS_KEY", "minio")
 MINIO_SECRET_KEY = os.getenv("MINIO_SECRET_KEY", "minio123")
 MINIO_BUCKET = os.getenv("MINIO_BUCKET", "trinity")

--- a/TrinityBackendDjango/common/minio_utils.py
+++ b/TrinityBackendDjango/common/minio_utils.py
@@ -4,7 +4,8 @@ from minio import Minio
 from minio.error import S3Error
 from minio.commonconfig import CopySource
 
-MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT")
+# Default to the development MinIO service if not explicitly configured
+MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT", "minio:9000")
 MINIO_ACCESS_KEY = os.getenv("MINIO_ACCESS_KEY", "minio")
 MINIO_SECRET_KEY = os.getenv("MINIO_SECRET_KEY", "minio123")
 MINIO_BUCKET = os.getenv("MINIO_BUCKET", "trinity")

--- a/TrinityBackendDjango/common/minio_utils.py
+++ b/TrinityBackendDjango/common/minio_utils.py
@@ -59,10 +59,12 @@ def rename_prefix(old_prefix: str, new_prefix: str) -> None:
         except S3Error:
             pass
         return
+    print(f"🔄 Renaming prefix in MinIO: {old_prefix} -> {new_prefix}")
     for obj in objects:
         dest = obj.object_name.replace(old_prefix, new_prefix, 1)
         _client.copy_object(MINIO_BUCKET, dest, CopySource(MINIO_BUCKET, obj.object_name))
         _client.remove_object(MINIO_BUCKET, obj.object_name)
+    print(f"✅ Prefix renamed to {new_prefix}")
 
 
 def rename_project_folder(
@@ -74,5 +76,9 @@ def rename_project_folder(
     """Rename a project's folder prefix when the project is renamed."""
     old_prefix = f"{client_slug}/{app_slug}/{old_project_slug}"
     new_prefix = f"{client_slug}/{app_slug}/{new_project_slug}"
+    print(
+        f"📁 Renaming project folder in MinIO: {old_prefix} -> {new_prefix}"
+    )
     rename_prefix(old_prefix, new_prefix)
+    print(f"📁 MinIO project folder updated: {new_prefix}")
 

--- a/TrinityBackendDjango/redis_store/env_cache.py
+++ b/TrinityBackendDjango/redis_store/env_cache.py
@@ -1,0 +1,176 @@
+"""Redis based environment variable store with namespacing."""
+
+from typing import Dict, Optional
+
+from django.db import transaction
+from django.utils import timezone
+
+from apps.accounts.models import UserEnvironmentVariable
+
+from .redis_client import redis_client
+
+ENV_NAMESPACE = "env"
+SET_NAMESPACE = "envkeys"
+TTL = 3600  # 1 hour TTL for cache entries
+
+
+def _ns(client_id: str, app_id: str, project_id: str,
+        client_name: str = "", app_name: str = "", project_name: str = "") -> str:
+    """Return namespace string for the environment."""
+    return f"{client_id}:{app_id}:{project_id}:{client_name}:{app_name}:{project_name}"
+
+
+def _env_key(
+    client_id: str,
+    app_id: str,
+    project_id: str,
+    key: str,
+    client_name: str = "",
+    app_name: str = "",
+    project_name: str = "",
+) -> str:
+    ns = _ns(client_id, app_id, project_id, client_name, app_name, project_name)
+    return f"{ENV_NAMESPACE}:{ns}:{key}"
+
+
+def _set_key(
+    client_id: str,
+    app_id: str,
+    project_id: str,
+    client_name: str = "",
+    app_name: str = "",
+    project_name: str = "",
+) -> str:
+    ns = _ns(client_id, app_id, project_id, client_name, app_name, project_name)
+    return f"{SET_NAMESPACE}:{ns}"
+
+
+def _fetch_from_db(
+    client_id: str,
+    app_id: str,
+    project_id: str,
+    client_name: str = "",
+    app_name: str = "",
+    project_name: str = "",
+) -> Dict[str, str]:
+    qs = UserEnvironmentVariable.objects.all()
+    if client_id or app_id or project_id:
+        qs = qs.filter(client_id=client_id, app_id=app_id, project_id=project_id)
+    elif client_name and project_name:
+        qs = qs.filter(client_name=client_name, project_name=project_name)
+        if app_name:
+            qs = qs.filter(app_name=app_name)
+    else:
+        return {}
+
+    return {o.key: o.value for o in qs}
+
+
+def get_env_vars(
+    client_id: str = "",
+    app_id: str = "",
+    project_id: str = "",
+    *,
+    client_name: str = "",
+    app_name: str = "",
+    project_name: str = "",
+    use_cache: bool = True,
+) -> Dict[str, str]:
+    """Read environment variables using read-through cache pattern."""
+    set_key = _set_key(client_id, app_id, project_id, client_name, app_name, project_name)
+    if use_cache:
+        keys = list(redis_client.smembers(set_key))
+        if keys:
+            values = redis_client.mget(keys)
+            if all(v is not None for v in values):
+                result = {}
+                for k, v in zip(keys, values):
+                    short_key = k.split(":")[-1]
+                    result[short_key] = v
+                return result
+
+    # Fallback to DB
+    env = _fetch_from_db(client_id, app_id, project_id, client_name, app_name, project_name)
+    if env and use_cache:
+        pipe = redis_client.pipeline()
+        for k, v in env.items():
+            full_key = _env_key(client_id, app_id, project_id, k, client_name, app_name, project_name)
+            pipe.set(full_key, v, ex=TTL)
+            pipe.sadd(set_key, full_key)
+        pipe.expire(set_key, TTL)
+        pipe.execute()
+    return env
+
+
+def set_env_var(
+    user,
+    client_id: str,
+    app_id: str,
+    project_id: str,
+    key: str,
+    value: str,
+    *,
+    client_name: str = "",
+    app_name: str = "",
+    project_name: str = "",
+) -> UserEnvironmentVariable:
+    """Write-through cache update for environment variables."""
+    with transaction.atomic():
+        obj, _ = UserEnvironmentVariable.objects.update_or_create(
+            user=user,
+            client_id=client_id,
+            app_id=app_id,
+            project_id=project_id,
+            key=key,
+            defaults={
+                "value": value,
+                "client_name": client_name,
+                "app_name": app_name,
+                "project_name": project_name,
+                "last_used": timezone.now(),
+            },
+        )
+
+    full_key = _env_key(client_id, app_id, project_id, key, client_name, app_name, project_name)
+    set_key = _set_key(client_id, app_id, project_id, client_name, app_name, project_name)
+    redis_client.set(full_key, value, ex=TTL)
+    redis_client.sadd(set_key, full_key)
+    redis_client.expire(set_key, TTL)
+    return obj
+
+
+def delete_env_var(
+    client_id: str,
+    app_id: str,
+    project_id: str,
+    key: str,
+    *,
+    client_name: str = "",
+    app_name: str = "",
+    project_name: str = "",
+) -> None:
+    """Delete an environment variable from DB and cache."""
+    UserEnvironmentVariable.objects.filter(
+        client_id=client_id, app_id=app_id, project_id=project_id, key=key
+    ).delete()
+    full_key = _env_key(client_id, app_id, project_id, key, client_name, app_name, project_name)
+    set_key = _set_key(client_id, app_id, project_id, client_name, app_name, project_name)
+    redis_client.delete(full_key)
+    redis_client.srem(set_key, full_key)
+
+
+def invalidate_env(
+    client_id: str,
+    app_id: str,
+    project_id: str,
+    *,
+    client_name: str = "",
+    app_name: str = "",
+    project_name: str = "",
+) -> None:
+    """Remove all cached keys for given namespace."""
+    set_key = _set_key(client_id, app_id, project_id, client_name, app_name, project_name)
+    keys = list(redis_client.smembers(set_key))
+    if keys:
+        redis_client.delete(*keys)
+    redis_client.delete(set_key)

--- a/TrinityBackendDjango/redis_store/env_cache.py
+++ b/TrinityBackendDjango/redis_store/env_cache.py
@@ -197,3 +197,37 @@ def invalidate_env(
     if keys:
         redis_client.delete(*keys)
     redis_client.delete(set_key)
+
+
+CURRENT_ENV_PREFIX = "currentenv"
+
+
+def set_current_env(
+    user_id: str,
+    *,
+    client_id: str = "",
+    app_id: str = "",
+    project_id: str = "",
+    client_name: str = "",
+    app_name: str = "",
+    project_name: str = "",
+) -> None:
+    """Persist the latest environment selection for a user."""
+    key = f"{CURRENT_ENV_PREFIX}:{user_id}"
+    redis_client.hset(
+        key,
+        mapping={
+            "client_id": client_id,
+            "app_id": app_id,
+            "project_id": project_id,
+            "client_name": client_name,
+            "app_name": app_name,
+            "project_name": project_name,
+        },
+    )
+
+
+def get_current_env(user_id: str) -> Dict[str, str]:
+    """Return the last stored environment selection for a user."""
+    key = f"{CURRENT_ENV_PREFIX}:{user_id}"
+    return redis_client.hgetall(key)

--- a/TrinityBackendDjango/redis_store/redis_client.py
+++ b/TrinityBackendDjango/redis_store/redis_client.py
@@ -1,0 +1,10 @@
+import os
+import redis
+
+# Use the REDIS_URL from Django settings or environment
+REDIS_URL = os.getenv("REDIS_URL", "redis://redis:6379/0")
+
+# Create a StrictRedis client from URL
+redis_client = redis.StrictRedis.from_url(REDIS_URL, decode_responses=True)
+
+__all__ = ["redis_client"]

--- a/TrinityBackendFastAPI/app/DataStorageRetrieval/arrow_client.py
+++ b/TrinityBackendFastAPI/app/DataStorageRetrieval/arrow_client.py
@@ -54,7 +54,7 @@ def download_dataframe(path: str) -> pd.DataFrame:
         try:
             bucket = os.getenv("MINIO_BUCKET", "trinity")
             m_client = Minio(
-                os.getenv("MINIO_ENDPOINT", "minio:9000"),
+                os.getenv("MINIO_ENDPOINT"),
                 access_key=os.getenv("MINIO_ACCESS_KEY", "admin_dev"),
                 secret_key=os.getenv("MINIO_SECRET_KEY", "pass_dev"),
                 secure=False,
@@ -113,7 +113,7 @@ def download_table_bytes(path: str) -> bytes:
         try:
             bucket = os.getenv("MINIO_BUCKET", "trinity")
             m_client = Minio(
-                os.getenv("MINIO_ENDPOINT", "minio:9000"),
+                os.getenv("MINIO_ENDPOINT"),
                 access_key=os.getenv("MINIO_ACCESS_KEY", "admin_dev"),
                 secret_key=os.getenv("MINIO_SECRET_KEY", "pass_dev"),
                 secure=False,

--- a/TrinityBackendFastAPI/app/DataStorageRetrieval/arrow_client.py
+++ b/TrinityBackendFastAPI/app/DataStorageRetrieval/arrow_client.py
@@ -54,7 +54,7 @@ def download_dataframe(path: str) -> pd.DataFrame:
         try:
             bucket = os.getenv("MINIO_BUCKET", "trinity")
             m_client = Minio(
-                os.getenv("MINIO_ENDPOINT"),
+                os.getenv("MINIO_ENDPOINT", "minio:9000"),
                 access_key=os.getenv("MINIO_ACCESS_KEY", "admin_dev"),
                 secret_key=os.getenv("MINIO_SECRET_KEY", "pass_dev"),
                 secure=False,
@@ -113,7 +113,7 @@ def download_table_bytes(path: str) -> bytes:
         try:
             bucket = os.getenv("MINIO_BUCKET", "trinity")
             m_client = Minio(
-                os.getenv("MINIO_ENDPOINT"),
+                os.getenv("MINIO_ENDPOINT", "minio:9000"),
                 access_key=os.getenv("MINIO_ACCESS_KEY", "admin_dev"),
                 secret_key=os.getenv("MINIO_SECRET_KEY", "pass_dev"),
                 secure=False,

--- a/TrinityBackendFastAPI/app/DataStorageRetrieval/db.py
+++ b/TrinityBackendFastAPI/app/DataStorageRetrieval/db.py
@@ -250,7 +250,7 @@ async def arrow_dataset_exists(project_id: int, atom_id: str, file_key: str) -> 
 
             bucket = os.getenv("MINIO_BUCKET", "trinity")
             client = Minio(
-                os.getenv("MINIO_ENDPOINT"),
+                os.getenv("MINIO_ENDPOINT", "minio:9000"),
                 access_key=os.getenv("MINIO_ACCESS_KEY", "minio"),
                 secret_key=os.getenv("MINIO_SECRET_KEY", "minio123"),
                 secure=False,

--- a/TrinityBackendFastAPI/app/DataStorageRetrieval/db.py
+++ b/TrinityBackendFastAPI/app/DataStorageRetrieval/db.py
@@ -250,7 +250,7 @@ async def arrow_dataset_exists(project_id: int, atom_id: str, file_key: str) -> 
 
             bucket = os.getenv("MINIO_BUCKET", "trinity")
             client = Minio(
-                os.getenv("MINIO_ENDPOINT", "minio:9000"),
+                os.getenv("MINIO_ENDPOINT"),
                 access_key=os.getenv("MINIO_ACCESS_KEY", "minio"),
                 secret_key=os.getenv("MINIO_SECRET_KEY", "minio123"),
                 secure=False,

--- a/TrinityBackendFastAPI/app/DataStorageRetrieval/minio_utils.py
+++ b/TrinityBackendFastAPI/app/DataStorageRetrieval/minio_utils.py
@@ -7,7 +7,8 @@ import pyarrow.ipc as ipc
 from minio import Minio
 from minio.error import S3Error
 
-MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT")
+# Default to the development MinIO service if not explicitly configured
+MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT", "minio:9000")
 MINIO_ACCESS_KEY = os.getenv("MINIO_ACCESS_KEY", "minio")
 MINIO_SECRET_KEY = os.getenv("MINIO_SECRET_KEY", "minio123")
 MINIO_BUCKET = os.getenv("MINIO_BUCKET", "trinity")

--- a/TrinityBackendFastAPI/app/DataStorageRetrieval/minio_utils.py
+++ b/TrinityBackendFastAPI/app/DataStorageRetrieval/minio_utils.py
@@ -7,7 +7,7 @@ import pyarrow.ipc as ipc
 from minio import Minio
 from minio.error import S3Error
 
-MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT", "minio:9000")
+MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT")
 MINIO_ACCESS_KEY = os.getenv("MINIO_ACCESS_KEY", "minio")
 MINIO_SECRET_KEY = os.getenv("MINIO_SECRET_KEY", "minio123")
 MINIO_BUCKET = os.getenv("MINIO_BUCKET", "trinity")

--- a/TrinityBackendFastAPI/app/features/concat/deps.py
+++ b/TrinityBackendFastAPI/app/features/concat/deps.py
@@ -9,7 +9,7 @@ import asyncio
 import redis  # <-- Add Redis import
 
 # MinIO config
-MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT", "minio:9000")
+MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT")
 MINIO_ACCESS_KEY = os.getenv("MINIO_ACCESS_KEY", "admin_dev")
 MINIO_SECRET_KEY = os.getenv("MINIO_SECRET_KEY", "pass_dev")
 MINIO_BUCKET = os.getenv("MINIO_BUCKET", "trinity")

--- a/TrinityBackendFastAPI/app/features/concat/deps.py
+++ b/TrinityBackendFastAPI/app/features/concat/deps.py
@@ -9,7 +9,8 @@ import asyncio
 import redis  # <-- Add Redis import
 
 # MinIO config
-MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT")
+# Default to the development MinIO service if not explicitly configured
+MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT", "minio:9000")
 MINIO_ACCESS_KEY = os.getenv("MINIO_ACCESS_KEY", "admin_dev")
 MINIO_SECRET_KEY = os.getenv("MINIO_SECRET_KEY", "pass_dev")
 MINIO_BUCKET = os.getenv("MINIO_BUCKET", "trinity")

--- a/TrinityBackendFastAPI/app/features/data_upload_validate/app/routes.py
+++ b/TrinityBackendFastAPI/app/features/data_upload_validate/app/routes.py
@@ -127,7 +127,7 @@ import asyncio
 import os
 
 # ✅ MINIO CONFIGURATION - values come from docker-compose/.env
-MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT", "minio:9000")
+MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT")
 MINIO_ACCESS_KEY = os.getenv("MINIO_ACCESS_KEY", "minio")
 MINIO_SECRET_KEY = os.getenv("MINIO_SECRET_KEY", "minio123")
 MINIO_BUCKET = os.getenv("MINIO_BUCKET", "trinity")

--- a/TrinityBackendFastAPI/app/features/data_upload_validate/app/routes.py
+++ b/TrinityBackendFastAPI/app/features/data_upload_validate/app/routes.py
@@ -127,7 +127,8 @@ import asyncio
 import os
 
 # ✅ MINIO CONFIGURATION - values come from docker-compose/.env
-MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT")
+# Default to the development MinIO service if not explicitly configured
+MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT", "minio:9000")
 MINIO_ACCESS_KEY = os.getenv("MINIO_ACCESS_KEY", "minio")
 MINIO_SECRET_KEY = os.getenv("MINIO_SECRET_KEY", "minio123")
 MINIO_BUCKET = os.getenv("MINIO_BUCKET", "trinity")

--- a/TrinityBackendFastAPI/app/features/feature_overview/routes.py
+++ b/TrinityBackendFastAPI/app/features/feature_overview/routes.py
@@ -48,7 +48,8 @@ import asyncio
 
 
 # MinIO client initialization
-MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT")
+# Default to the development MinIO service if not explicitly configured
+MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT", "minio:9000")
 MINIO_ACCESS_KEY = os.getenv("MINIO_ACCESS_KEY", "admin_dev")
 MINIO_SECRET_KEY = os.getenv("MINIO_SECRET_KEY", "pass_dev")
 MINIO_BUCKET = os.getenv("MINIO_BUCKET", "trinity")

--- a/TrinityBackendFastAPI/app/features/feature_overview/routes.py
+++ b/TrinityBackendFastAPI/app/features/feature_overview/routes.py
@@ -48,7 +48,7 @@ import asyncio
 
 
 # MinIO client initialization
-MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT", "minio:9000")
+MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT")
 MINIO_ACCESS_KEY = os.getenv("MINIO_ACCESS_KEY", "admin_dev")
 MINIO_SECRET_KEY = os.getenv("MINIO_SECRET_KEY", "pass_dev")
 MINIO_BUCKET = os.getenv("MINIO_BUCKET", "trinity")

--- a/TrinityBackendFastAPI/app/features/merge/deps.py
+++ b/TrinityBackendFastAPI/app/features/merge/deps.py
@@ -6,7 +6,8 @@ import redis
 from io import BytesIO
 
 # MinIO config
-MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT")
+# Default to the development MinIO service if not explicitly configured
+MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT", "minio:9000")
 MINIO_ACCESS_KEY = os.getenv("MINIO_ACCESS_KEY", "admin_dev")
 MINIO_SECRET_KEY = os.getenv("MINIO_SECRET_KEY", "pass_dev")
 MINIO_BUCKET = os.getenv("MINIO_BUCKET", "trinity")

--- a/TrinityBackendFastAPI/app/features/merge/deps.py
+++ b/TrinityBackendFastAPI/app/features/merge/deps.py
@@ -6,7 +6,7 @@ import redis
 from io import BytesIO
 
 # MinIO config
-MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT", "minio:9000")
+MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT")
 MINIO_ACCESS_KEY = os.getenv("MINIO_ACCESS_KEY", "admin_dev")
 MINIO_SECRET_KEY = os.getenv("MINIO_SECRET_KEY", "pass_dev")
 MINIO_BUCKET = os.getenv("MINIO_BUCKET", "trinity")

--- a/TrinityFrontend/src/components/PrimaryMenu/AppIdentity/AppIdentity.tsx
+++ b/TrinityFrontend/src/components/PrimaryMenu/AppIdentity/AppIdentity.tsx
@@ -33,7 +33,22 @@ const AppIdentity: React.FC<AppIdentityProps> = ({ projectName, onGoBack, onRena
         });
         if (res.ok) {
           const updated = await res.json();
+          console.log('Project renamed from primary menu', updated);
           localStorage.setItem('current-project', JSON.stringify(updated));
+          try {
+            const envRes = await fetch(`${REGISTRY_API}/projects/${proj.id}/`, {
+              credentials: 'include'
+            });
+            if (envRes.ok) {
+              const envData = await envRes.json();
+              if (envData.environment) {
+                console.log('Environment after project rename', envData.environment);
+                localStorage.setItem('env', JSON.stringify(envData.environment));
+              }
+            }
+          } catch (err) {
+            console.log('Rename env fetch error', err);
+          }
           onRename?.(updated.name);
           return;
         }

--- a/TrinityFrontend/src/pages/Projects.tsx
+++ b/TrinityFrontend/src/pages/Projects.tsx
@@ -259,6 +259,7 @@ const Projects = () => {
       });
       if (res.ok) {
         const updated = await res.json();
+        console.log('Project renamed from projects page', updated);
         setProjects(prev =>
           prev.map(p =>
             p.id === updated.id
@@ -266,6 +267,20 @@ const Projects = () => {
               : p
           )
         );
+        try {
+          const envRes = await fetch(`${REGISTRY_API}/projects/${updated.id}/`, {
+            credentials: 'include'
+          });
+          if (envRes.ok) {
+            const envData = await envRes.json();
+            if (envData.environment) {
+              console.log('Environment after project rename', envData.environment);
+              localStorage.setItem('env', JSON.stringify(envData.environment));
+            }
+          }
+        } catch (err) {
+          console.log('Rename env fetch error', err);
+        }
       }
     } catch {
       /* ignore */


### PR DESCRIPTION
## Summary
- add `redis_store` package in Django backend
- implement read-through/write-through cache for env variables in Redis
- wire account utils to use Redis cache

## Testing
- `python -m py_compile TrinityBackendDjango/redis_store/*.py TrinityBackendDjango/apps/accounts/utils.py`

------
https://chatgpt.com/codex/tasks/task_e_6881c367c01083218d913f9c498b0cfa