### PR TITLE
Add Mongo Express service for dev and prod

### DIFF
--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -49,6 +49,7 @@ After the containers report **healthy** you can access the services at:
 - `http://localhost:8003/admin/` – Django admin
 - `http://localhost:8004/api/` – FastAPI
 - `http://localhost:5051` – PgAdmin
+- `http://localhost:8082` – Mongo Express
 
 The frontend automatically detects when it is served from port `8081` and
 adjusts API calls to the backend ports `8003`–`8005`. If you create a custom

--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -49,7 +49,7 @@ After the containers report **healthy** you can access the services at:
 - `http://localhost:8003/admin/` – Django admin
 - `http://localhost:8004/api/` – FastAPI
 - `http://localhost:5051` – PgAdmin
-- `http://localhost:8082` – Mongo Express
+- `http://localhost:8083` – Mongo Express
 
 The frontend automatically detects when it is served from port `8081` and
 adjusts API calls to the backend ports `8003`–`8005`. If you create a custom

--- a/MongoExpressUsageGuide.txt
+++ b/MongoExpressUsageGuide.txt
@@ -1,0 +1,50 @@
+Mongo Express Usage Guide
+=========================
+
+This project now includes a `mongo-express` container for both the development
+and production stacks. Mongo Express provides a simple web UI for inspecting the
+MongoDB databases used by the Django and FastAPI services.
+
+## Accessing Mongo Express
+
+* **Development**: http://localhost:8082
+* **Production**: http://localhost:8083
+
+When prompted for credentials use:
+
+```
+username: admin
+password: admin
+```
+
+These credentials protect the web interface only. The underlying MongoDB
+instances currently run without authentication so Mongo Express connects
+straight to the `mongo` service defined in `docker-compose`.
+
+## Browsing databases and collections
+
+1. After logging in you will see a list of available databases. The main
+   application databases are `trinity_dev` for the development stack and
+   `trinity_prod` in production.
+2. Click the desired database name to view its collections. Collections are
+   equivalent to tables in relational databases.
+3. Selecting a collection shows its documents. Use the **Filter** box at the top
+   to run ad-hoc queries by entering a JSON filter object. For example:
+
+   ```json
+   {"status": "active"}
+   ```
+
+   filters documents where the `status` field equals `active`.
+4. Click **New Document** to insert records or **Delete** to remove them.
+   Mongo Express also allows editing individual fields by clicking the **Edit**
+   button next to a document.
+
+## Exporting collections
+
+Each collection page includes options to export all documents as JSON. This can
+be useful for backups or migrating data between environments.
+
+Refer to the official Mongo Express documentation for additional features such
+as indexing and gridFS support. The interface is quite intuitive and mirrors the
+structure of the underlying MongoDB instance.

--- a/MongoExpressUsageGuide.txt
+++ b/MongoExpressUsageGuide.txt
@@ -7,8 +7,8 @@ MongoDB databases used by the Django and FastAPI services.
 
 ## Accessing Mongo Express
 
-* **Development**: http://localhost:8082
-* **Production**: http://localhost:8083
+* **Development**: http://localhost:8083
+* **Production**: http://localhost:8082
 
 When prompted for credentials use:
 

--- a/PROD_SETUP.md
+++ b/PROD_SETUP.md
@@ -1,0 +1,47 @@
+# Production Environment Setup
+
+This guide explains how to run the Trinity services using the main
+`docker-compose.yml` file. The containers expose the application on the
+standard production ports and connect to the `trinity-net` Docker network.
+
+## Files
+- `docker-compose.yml` – defines the production services and network
+  `trinity-net`.
+- `cloudflared/` – compose file and credentials for the Cloudflare tunnel
+  exposing `trinity.quantmatrixai.com`.
+
+## Preparing the Cloudflare tunnel
+1. Install the `cloudflared` CLI and authenticate with your
+   Cloudflare account.
+2. Create a tunnel and DNS record for the production domain:
+   ```bash
+   cloudflared tunnel create trinity-prod
+   cloudflared tunnel route dns trinity-prod trinity.quantmatrixai.com
+   ```
+3. Copy the generated credentials JSON into `cloudflared/tunnelCreds/` and
+   update `cloudflared/tunnelCreds/config.yml` with the tunnel ID. The config
+   forwards traffic to the Traefik container.
+
+Start the tunnel:
+```bash
+cd cloudflared
+docker compose up -d
+```
+
+## Running the production stack
+From the repository root run:
+```bash
+docker compose up -d
+```
+The default project name `trinity-prod` is derived from the
+`name:` field in `docker-compose.yml`.
+
+After the containers report **healthy** you can access the services at:
+- `http://localhost:8080` – React frontend
+- `http://localhost:8000/admin/` – Django admin
+- `http://localhost:8001/api/` – FastAPI
+- `http://localhost:5050` – PgAdmin
+- `http://localhost:8082` – Mongo Express
+
+Requests to `https://trinity.quantmatrixai.com` will reach the same
+services through the Cloudflare tunnel.

--- a/TrinityAI/Agent_concat/main_app.py
+++ b/TrinityAI/Agent_concat/main_app.py
@@ -1,29 +1,33 @@
 # main_concat.py
 
 import os
+import sys
+from pathlib import Path
 from fastapi import FastAPI
 from pydantic import BaseModel
 from typing import Optional
 import time
 from llm_concat import SmartConcatAgent
 
-# Configuration
-LLM_API_URL = "http://10.2.1.65:11434/api/chat"
-LLM_MODEL_NAME = "deepseek-r1:32b"
-LLM_BEARER_TOKEN = "aakash_api_key"
+# Allow importing helpers from the parent folder
+PARENT_DIR = Path(__file__).resolve().parent.parent
+sys.path.append(str(PARENT_DIR))
+from main_api import get_llm_config, get_minio_config
 
-MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT", "minio:9000")
-MINIO_ACCESS_KEY = os.getenv("MINIO_ACCESS_KEY", "admin_dev")
-MINIO_SECRET_KEY = os.getenv("MINIO_SECRET_KEY", "pass_dev")
-MINIO_BUCKET = os.getenv("MINIO_BUCKET", "trinity")
-MINIO_PREFIX = os.getenv("MINIO_PREFIX", "data_setss/")
+cfg_llm = get_llm_config()
+cfg_minio = get_minio_config()
 
 # Initialize app and agent
 app = FastAPI(title="Smart Concatenation Agent", version="1.0.0")
 agent = SmartConcatAgent(
-    LLM_API_URL, LLM_MODEL_NAME, LLM_BEARER_TOKEN,
-    MINIO_ENDPOINT, MINIO_ACCESS_KEY, MINIO_SECRET_KEY,
-    MINIO_BUCKET, MINIO_PREFIX
+    cfg_llm["api_url"],
+    cfg_llm["model_name"],
+    cfg_llm["bearer_token"],
+    cfg_minio["endpoint"],
+    cfg_minio["access_key"],
+    cfg_minio["secret_key"],
+    cfg_minio["bucket"],
+    cfg_minio["prefix"],
 )
 
 class ConcatRequest(BaseModel):
@@ -103,4 +107,4 @@ def health_check():
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=8001)
+    uvicorn.run(app, host="0.0.0.0", port=int(os.getenv("AI_PORT", 8002)))

--- a/TrinityAI/main_api.py
+++ b/TrinityAI/main_api.py
@@ -24,14 +24,16 @@ def get_llm_config() -> Dict[str, str]:
 
 def get_minio_config() -> Dict[str, str]:
     """Return MinIO configuration from environment variables."""
+    client = os.getenv("CURRENT_CLIENT_NAME", os.getenv("CLIENT_NAME", "default_client"))
+    app = os.getenv("CURRENT_APP_NAME", os.getenv("APP_NAME", "default_app"))
+    project = os.getenv("CURRENT_PROJECT_NAME", os.getenv("PROJECT_NAME", "default_project"))
+    prefix_default = f"{client}/{app}/{project}/"
     return {
         "endpoint": os.getenv("MINIO_ENDPOINT", "minio:9000"),
         "access_key": os.getenv("MINIO_ACCESS_KEY", "minio"),
         "secret_key": os.getenv("MINIO_SECRET_KEY", "minio123"),
         "bucket": os.getenv("MINIO_BUCKET", "trinity"),
-        "prefix": os.getenv(
-            "MINIO_PREFIX", "default_client/default_app/default_project/"
-        ),
+        "prefix": os.getenv("MINIO_PREFIX", prefix_default),
     }
 
 # Ensure the Agent_fetch_atom folder is on the Python path so we can import its modules

--- a/TrinityFrontend/src/components/TrinityAI/AtomAIChatBot.tsx
+++ b/TrinityFrontend/src/components/TrinityAI/AtomAIChatBot.tsx
@@ -69,7 +69,9 @@ const AtomAIChatBot: React.FC<AtomAIChatBotProps> = ({ atomId, atomType, atomTit
       });
       if (res.ok) {
         const data = await res.json();
-        const aiText = data.message || data.response || data.final_response || 'AI response';
+        const aiText = Array.isArray(data.suggestions) && data.suggestions.length
+          ? data.suggestions.join('\n')
+          : (data.message || data.response || data.final_response || 'AI response');
         const aiMsg: Message = { id: (Date.now() + 1).toString(), content: aiText, sender: 'ai', timestamp: new Date() };
         setMessages(prev => [...prev, aiMsg]);
         if (atomType === 'concat' && data.concat_json) {

--- a/TrinityFrontend/src/components/TrinityAI/AtomAIChatBot.tsx
+++ b/TrinityFrontend/src/components/TrinityAI/AtomAIChatBot.tsx
@@ -196,7 +196,13 @@ const AtomAIChatBot: React.FC<AtomAIChatBotProps> = ({ atomId, atomType, atomTit
           <Sparkles className={cn('w-3.5 h-3.5', disabled ? 'text-gray-300' : 'text-purple-500')} />
         </button>
       </PopoverTrigger>
-      <PopoverContent className="w-80 h-72 p-0 flex flex-col" align="start" side="bottom" sideOffset={8}>
+      <PopoverContent
+        className="w-96 h-80 p-0 flex flex-col"
+        align="start"
+        side="bottom"
+        sideOffset={8}
+        style={{ resize: 'both', overflow: 'auto' }}
+      >
         <div className="p-2 border-b border-gray-200 bg-white rounded-t-md flex items-center justify-between">
           <div className="flex items-center space-x-2">
             <MessageSquare className="w-4 h-4 text-purple-600" />

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -54,6 +54,20 @@ services:
     networks:
       - trinity-dev-net
 
+  mongo-express:
+    image: mongo-express
+    environment:
+      ME_CONFIG_MONGODB_SERVER: mongo
+      ME_CONFIG_MONGODB_ENABLE_ADMIN: 'true'
+      ME_CONFIG_BASICAUTH_USERNAME: admin
+      ME_CONFIG_BASICAUTH_PASSWORD: admin
+    ports:
+      - "8082:8081"
+    depends_on:
+      - mongo
+    networks:
+      - trinity-dev-net
+
   web:
     build: ./TrinityBackendDjango
     command: gunicorn config.wsgi:application --bind 0.0.0.0:8000 --workers 3

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -62,7 +62,7 @@ services:
       ME_CONFIG_BASICAUTH_USERNAME: admin
       ME_CONFIG_BASICAUTH_PASSWORD: admin
     ports:
-      - "8082:8081"
+      - "8083:8081"
     depends_on:
       - mongo
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
       ME_CONFIG_BASICAUTH_USERNAME: admin
       ME_CONFIG_BASICAUTH_PASSWORD: admin
     ports:
-      - "8083:8081"
+      - "8082:8081"
     depends_on:
       - mongo
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,20 @@ services:
     networks:
       - trinity-net
 
+  mongo-express:
+    image: mongo-express
+    environment:
+      ME_CONFIG_MONGODB_SERVER: mongo
+      ME_CONFIG_MONGODB_ENABLE_ADMIN: 'true'
+      ME_CONFIG_BASICAUTH_USERNAME: admin
+      ME_CONFIG_BASICAUTH_PASSWORD: admin
+    ports:
+      - "8083:8081"
+    depends_on:
+      - mongo
+    networks:
+      - trinity-net
+
   web:
     build: ./TrinityBackendDjango
     command: gunicorn config.wsgi:application --bind 0.0.0.0:8000 --workers 3


### PR DESCRIPTION
## Summary
- add `mongo-express` service in both compose files
- document the service's port in `DEV_SETUP.md`
- provide `MongoExpressUsageGuide.txt` with instructions on using the UI

## Testing
- `python3 - <<'PY'
import yaml,sys
yaml.safe_load(open('docker-compose.yml'))
yaml.safe_load(open('docker-compose-dev.yml'))
print('both loaded')
PY
`

------
https://chatgpt.com/codex/tasks/task_e_6881e4db27b48321ab73621ee027f547