### PR TITLE
Implement project state persistence

### DIFF
--- a/EnsurePersistance.txt
+++ b/EnsurePersistance.txt
@@ -1,0 +1,25 @@
+# Persisting Project State
+
+The backend now records atom configurations and overall project state in three
+different stores:
+
+1. **Postgres** – `registry_projectstate` table stores `client_id`,
+   `app_id`, `project_id` and the JSON state. The table is created on demand
+   when saving for the first time. Upserts keep only the latest state for a
+   project.
+2. **Redis** – the active session state is cached under the key
+   `projstate:{client}:{app}:{project}` with a TTL of one hour so reloads during a
+   session are instant.
+3. **MinIO snapshots** – every time state is saved, a copy is uploaded to
+   `Client/App/Project/snapshots/<timestamp>.json`. When Redis and Postgres do
+   not contain the data, the most recent snapshot is fetched.
+
+The API exposes two endpoints:
+
+- `POST /api/project-state/save` – body includes the three IDs and the state
+  object.
+- `GET /api/project-state/{client_id}/{app_id}/{project_id}` – returns the
+  stored state, loading from Redis, Postgres or the latest snapshot as needed.
+
+These mechanisms ensure that dropping atoms and saving will persist across
+sessions even if the Redis cache expires or the database entry is removed.

--- a/TrinityBackendFastAPI/tests/test_session_state.py
+++ b/TrinityBackendFastAPI/tests/test_session_state.py
@@ -1,0 +1,53 @@
+import asyncio, json, types, sys
+from pathlib import Path
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "app"))
+import app.session_state as ss
+
+class DummyRedis:
+    def __init__(self):
+        self.store = {}
+    def get(self, k):
+        return self.store.get(k)
+    def setex(self, k, t, v):
+        self.store[k] = v
+
+class DummyMinio:
+    def __init__(self):
+        self.objects = {}
+    def put_object(self, bucket, name, data, length, content_type=None):
+        self.objects[name] = data.read()
+    def list_objects(self, bucket, prefix=""):
+        return [types.SimpleNamespace(object_name=n, last_modified=i)
+                for i, n in enumerate(self.objects) if n.startswith(prefix)]
+    def get_object(self, bucket, name):
+        return types.SimpleNamespace(read=lambda: self.objects[name])
+
+async def dummy_upsert(c,a,p,state):
+    dummy_upsert.store[p] = state
+
+dummy_upsert.store = {}
+
+async def dummy_fetch(p):
+    return dummy_upsert.store.get(p)
+
+
+def test_save_and_load(monkeypatch):
+    redis = DummyRedis()
+    minio = DummyMinio()
+    monkeypatch.setattr(ss, "redis_client", redis)
+    monkeypatch.setattr(ss, "get_client", lambda: minio)
+    monkeypatch.setattr(ss, "MINIO_BUCKET", "bucket")
+    monkeypatch.setattr(ss, "upsert_project_state", dummy_upsert)
+    monkeypatch.setattr(ss, "fetch_project_state", dummy_fetch)
+
+    asyncio.run(ss.save_state("c","a","p", {"x":1}))
+    assert json.loads(redis.store[ss._redis_key("c","a","p")]) == {"x":1}
+
+    redis.store.clear()
+    state = asyncio.run(ss.load_state("c","a","p"))
+    assert state == {"x":1}
+
+    redis.store.clear(); dummy_upsert.store.clear()
+    state2 = asyncio.run(ss.load_state("c","a","p"))
+    assert state2 == {"x":1}


### PR DESCRIPTION
## Summary
- add `EnsurePersistance.txt` describing how project state is stored
- test project state save/load logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688215932aac8321a0b42bbfd9bc1b69