### PR TITLE
Add Django session state management

### DIFF
--- a/TrinityBackendDjango/apps/session_state/__init__.py
+++ b/TrinityBackendDjango/apps/session_state/__init__.py
@@ -1,1 +1,13 @@
 default_app_config = "apps.session_state.apps.SessionStateConfig"
+
+# Ensure the FastAPI backend package is on the Python path so imports like
+# ``from app.features...`` work when Django loads this app. ``__file__`` lives
+# inside ``TrinityBackendDjango/apps/session_state`` so ``parents[3]`` resolves
+# to the repository root where ``TrinityBackendFastAPI`` sits next to
+# ``TrinityBackendDjango``.
+import sys
+from pathlib import Path
+
+backend_root = Path(__file__).resolve().parents[3] / "TrinityBackendFastAPI"
+sys.path.append(str(backend_root))
+sys.path.append(str(backend_root / "app"))

--- a/TrinityBackendDjango/apps/session_state/__init__.py
+++ b/TrinityBackendDjango/apps/session_state/__init__.py
@@ -1,14 +1,22 @@
 default_app_config = "apps.session_state.apps.SessionStateConfig"
 
 # Ensure the FastAPI backend package is on the Python path so imports like
-# ``from app.features...`` work when Django loads this app. ``__file__`` lives
-# inside ``TrinityBackendDjango/apps/session_state`` so ``parents[3]`` resolves
-# to the repository root where ``TrinityBackendFastAPI`` sits next to
-# ``TrinityBackendDjango``.
+# ``from app.features...`` work when Django loads this app. We search upward
+# from this file's location until we find the ``TrinityBackendFastAPI`` folder
+# that sits alongside ``TrinityBackendDjango`` and add both that directory and
+# its inner ``app`` package to ``sys.path``.
 import sys
 from pathlib import Path
 
-backend_root = Path(__file__).resolve().parents[3] / "TrinityBackendFastAPI"
+root_path = Path(__file__).resolve()
+backend_root = None
+for parent in root_path.parents:
+    candidate = parent / "TrinityBackendFastAPI"
+    if candidate.exists():
+        backend_root = candidate
+        break
+if backend_root is None:
+    backend_root = root_path.parents[2] / "TrinityBackendFastAPI"
 backend_app = backend_root / "app"
 for p in (backend_root, backend_app):
     s = str(p)

--- a/TrinityBackendDjango/apps/session_state/__init__.py
+++ b/TrinityBackendDjango/apps/session_state/__init__.py
@@ -9,5 +9,8 @@ import sys
 from pathlib import Path
 
 backend_root = Path(__file__).resolve().parents[3] / "TrinityBackendFastAPI"
-sys.path.append(str(backend_root))
-sys.path.append(str(backend_root / "app"))
+backend_app = backend_root / "app"
+for p in (backend_root, backend_app):
+    s = str(p)
+    if s not in sys.path:
+        sys.path.insert(0, s)

--- a/TrinityBackendDjango/apps/session_state/__init__.py
+++ b/TrinityBackendDjango/apps/session_state/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = "apps.session_state.apps.SessionStateConfig"

--- a/TrinityBackendDjango/apps/session_state/apps.py
+++ b/TrinityBackendDjango/apps/session_state/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+
+
+class SessionStateConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.session_state"
+    verbose_name = "Session State Management"

--- a/TrinityBackendDjango/apps/session_state/urls.py
+++ b/TrinityBackendDjango/apps/session_state/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+from .views import SessionInitView, SessionStateView, SessionUpdateView, SessionEndView
+
+urlpatterns = [
+    path("init", SessionInitView.as_view(), name="session-init"),
+    path("state", SessionStateView.as_view(), name="session-state"),
+    path("update", SessionUpdateView.as_view(), name="session-update"),
+    path("end", SessionEndView.as_view(), name="session-end"),
+]

--- a/TrinityBackendDjango/apps/session_state/views.py
+++ b/TrinityBackendDjango/apps/session_state/views.py
@@ -105,7 +105,7 @@ class SessionInitView(APIView):
                 "project_name": project_name,
             }
         )
-        redis_client.setex(session_id, TTL, json.dumps(session))
+        redis_client.setex(session_id, TTL, json.dumps(session, default=str))
         redis_client.setex(ns, TTL, session_id)
         return Response({"session_id": session_id, "state": session})
 
@@ -168,7 +168,7 @@ class SessionStateView(APIView):
                     "dimensions": dimensions,
                 }
             if session:
-                redis_client.setex(session_id, TTL, json.dumps(session))
+                redis_client.setex(session_id, TTL, json.dumps(session, default=str))
         return Response({"session_id": session_id, "state": session})
 
 
@@ -191,7 +191,7 @@ class SessionUpdateView(APIView):
             except Exception:
                 pass
         session[key] = value
-        redis_client.setex(session_id, TTL, json.dumps(session))
+        redis_client.setex(session_id, TTL, json.dumps(session, default=str))
         try:
             mc = _mongo_client()
             db = mc.get_default_database()

--- a/TrinityBackendDjango/apps/session_state/views.py
+++ b/TrinityBackendDjango/apps/session_state/views.py
@@ -198,10 +198,21 @@ class SessionUpdateView(APIView):
                 pass
         if key == "navigation":
             nav = session.get("navigation", [])
+
+            def upsert(item: Dict[str, Any]):
+                if isinstance(item, dict) and "atom" in item:
+                    atom = item["atom"]
+                    filtered = [n for n in nav if not (isinstance(n, dict) and n.get("atom") == atom)]
+                    filtered.append(item)
+                    return filtered
+                nav.append(item)
+                return nav
+
             if isinstance(value, list):
-                nav.extend(value)
+                for itm in value:
+                    nav = upsert(itm)
             else:
-                nav.append(value)
+                nav = upsert(value)
             session["navigation"] = nav
         else:
             session[key] = value

--- a/TrinityBackendDjango/apps/session_state/views.py
+++ b/TrinityBackendDjango/apps/session_state/views.py
@@ -1,0 +1,157 @@
+import os
+import json
+from typing import Any, Dict
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status, permissions
+from apps.accounts.views import CsrfExemptSessionAuthentication
+from redis_store.redis_client import redis_client
+from pymongo import MongoClient
+from django.conf import settings
+
+TTL = 3600 * 2  # 2 hours
+
+
+def _session_key(client_id: str, user_id: str, app_id: str, project_id: str) -> str:
+    return f"session:{client_id}:{user_id}:{app_id}:{project_id}"
+
+
+def _mongo_client() -> MongoClient:
+    uri = getattr(settings, "MONGO_URI", "mongodb://mongo:27017/trinity")
+    return MongoClient(uri, serverSelectionTimeoutMS=5000)
+
+
+def _redis_namespace(client_name: str, app_name: str, project_name: str) -> str:
+    return f"{client_name}/{app_name}/{project_name}"
+
+
+@method_decorator(csrf_exempt, name="dispatch")
+class SessionInitView(APIView):
+    authentication_classes = [CsrfExemptSessionAuthentication]
+    permission_classes = [permissions.IsAuthenticated]
+
+    def post(self, request):
+        data = request.data
+        client_id = data.get("client_id", "")
+        user_id = data.get("user_id", str(request.user.id))
+        app_id = data.get("app_id", "")
+        project_id = data.get("project_id", "")
+        client_name = data.get("client_name", "")
+        app_name = data.get("app_name", "")
+        project_name = data.get("project_name", "")
+        session_id = _session_key(client_id, user_id, app_id, project_id)
+        ns = _redis_namespace(client_name, app_name, project_name)
+        raw = redis_client.get(session_id)
+        if raw:
+            try:
+                session = json.loads(raw)
+            except Exception:
+                session = {}
+        else:
+            session = {}
+            try:
+                mc = _mongo_client()
+                db = mc.get_default_database()
+                record = db.session_state.find_one({"_id": session_id})
+                if record and isinstance(record.get("state"), dict):
+                    session = record["state"]
+            except Exception:
+                pass
+        session.update(
+            {
+                "client_id": client_id,
+                "user_id": user_id,
+                "app_id": app_id,
+                "project_id": project_id,
+                "client_name": client_name,
+                "app_name": app_name,
+                "project_name": project_name,
+            }
+        )
+        redis_client.setex(session_id, TTL, json.dumps(session))
+        redis_client.setex(ns, TTL, session_id)
+        return Response({"session_id": session_id, "state": session})
+
+
+@method_decorator(csrf_exempt, name="dispatch")
+class SessionStateView(APIView):
+    authentication_classes = [CsrfExemptSessionAuthentication]
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get(self, request):
+        session_id = request.query_params.get("session_id")
+        if not session_id:
+            return Response({"detail": "session_id required"}, status=status.HTTP_400_BAD_REQUEST)
+        raw = redis_client.get(session_id)
+        if raw:
+            try:
+                session = json.loads(raw)
+            except Exception:
+                session = {}
+        else:
+            session = {}
+            try:
+                mc = _mongo_client()
+                db = mc.get_default_database()
+                record = db.session_state.find_one({"_id": session_id})
+                if record and isinstance(record.get("state"), dict):
+                    session = record["state"]
+            except Exception:
+                pass
+            if session:
+                redis_client.setex(session_id, TTL, json.dumps(session))
+        return Response({"session_id": session_id, "state": session})
+
+
+@method_decorator(csrf_exempt, name="dispatch")
+class SessionUpdateView(APIView):
+    authentication_classes = [CsrfExemptSessionAuthentication]
+    permission_classes = [permissions.IsAuthenticated]
+
+    def patch(self, request):
+        session_id = request.data.get("session_id")
+        key = request.data.get("key")
+        value = request.data.get("value")
+        if not session_id or key is None:
+            return Response({"detail": "session_id and key required"}, status=status.HTTP_400_BAD_REQUEST)
+        raw = redis_client.get(session_id)
+        session: Dict[str, Any] = {}
+        if raw:
+            try:
+                session = json.loads(raw)
+            except Exception:
+                pass
+        session[key] = value
+        redis_client.setex(session_id, TTL, json.dumps(session))
+        try:
+            mc = _mongo_client()
+            db = mc.get_default_database()
+            db.session_state.update_one(
+                {"_id": session_id},
+                {"$set": {"state": session}},
+                upsert=True,
+            )
+        except Exception:
+            pass
+        return Response({"session_id": session_id, "state": session})
+
+
+@method_decorator(csrf_exempt, name="dispatch")
+class SessionEndView(APIView):
+    authentication_classes = [CsrfExemptSessionAuthentication]
+    permission_classes = [permissions.IsAuthenticated]
+
+    def delete(self, request):
+        session_id = request.query_params.get("session_id")
+        if not session_id:
+            return Response({"detail": "session_id required"}, status=status.HTTP_400_BAD_REQUEST)
+        redis_client.delete(session_id)
+        try:
+            mc = _mongo_client()
+            db = mc.get_default_database()
+            db.session_state.delete_one({"_id": session_id})
+        except Exception:
+            pass
+        return Response({"detail": "session ended"})

--- a/TrinityBackendDjango/config/settings.py
+++ b/TrinityBackendDjango/config/settings.py
@@ -118,6 +118,7 @@ TENANT_APPS = [
     "apps.orchestration",
     "apps.roles",
     "apps.audit",
+    "apps.session_state",
 ]
 
 INSTALLED_APPS = SHARED_APPS + [

--- a/TrinityBackendDjango/config/urls.py
+++ b/TrinityBackendDjango/config/urls.py
@@ -17,4 +17,5 @@ urlpatterns = [
     path("api/tenants/", include("apps.tenants.urls")),
     path("api/roles/", include("apps.roles.urls")),
     path("api/audit/", include("apps.audit.urls")),
+    path("api/session/", include("apps.session_state.urls")),
 ]

--- a/TrinityBackendFastAPI/app/core/utils.py
+++ b/TrinityBackendFastAPI/app/core/utils.py
@@ -156,7 +156,7 @@ async def get_env_vars(
                 env.get("APP_NAME", ""),
                 env.get("PROJECT_NAME", ""),
             )
-            redis_client.setex(redis_key, ENV_TTL, json.dumps(env))
+            redis_client.setex(redis_key, ENV_TTL, json.dumps(env, default=str))
 
     print(f"🔧 db_env_vars{key} -> {env}")
     return env

--- a/TrinityBackendFastAPI/app/features/column_classifier/config.py
+++ b/TrinityBackendFastAPI/app/features/column_classifier/config.py
@@ -34,6 +34,8 @@ class Settings(BaseSettings):
     column_classifications_collection: str = "column_classifications"
     business_dimensions_collection: str = "business_dimensions_with_assignments"
     classifier_configs_collection: str = "column_classifier_configs"
+    # Database used for classifier config documents
+    classifier_configs_database: str = "trinity_prod"
     
     # =============================================================================
     # CLASSIFICATION SETTINGS

--- a/TrinityBackendFastAPI/app/features/concat/deps.py
+++ b/TrinityBackendFastAPI/app/features/concat/deps.py
@@ -66,11 +66,12 @@ ensure_minio_bucket()
 
 # MongoDB config
 MONGO_URI = os.getenv("MONGO_URI", "mongodb://mongo:27017/trinity")
+MONGO_DB = os.getenv("MONGO_DB", "trinity")
 mongo_client = AsyncIOMotorClient(MONGO_URI)
-concat_db = mongo_client[os.getenv("CONCAT_DB_NAME", "concat_db")]
+db = mongo_client[MONGO_DB]
 
 def get_concat_results_collection():
-    return concat_db[os.getenv("CONCAT_RESULTS_COLLECTION", "concat_results")]
+    return db[os.getenv("CONCAT_RESULTS_COLLECTION", "concat_results")]
 
 def load_dataframe(object_name: str) -> pd.DataFrame:
     """

--- a/TrinityBackendFastAPI/app/features/concat/deps.py
+++ b/TrinityBackendFastAPI/app/features/concat/deps.py
@@ -70,8 +70,9 @@ MONGO_DB = os.getenv("MONGO_DB", "trinity")
 mongo_client = AsyncIOMotorClient(MONGO_URI)
 db = mongo_client[MONGO_DB]
 
-def get_concat_results_collection():
-    return db[os.getenv("CONCAT_RESULTS_COLLECTION", "concat_results")]
+def get_concat_configuration_collection():
+    """Return the Mongo collection used to store concat configuration."""
+    return db[os.getenv("CONCAT_CONFIG_COLLECTION", "concat_configuration")]
 
 def load_dataframe(object_name: str) -> pd.DataFrame:
     """
@@ -139,7 +140,7 @@ __all__ = [
     'minio_client',
     'load_dataframe',
     'save_concat_result_to_minio',
-    'get_concat_results_collection',
+    'get_concat_configuration_collection',
     'save_concat_metadata_to_mongo',
     'OBJECT_PREFIX',
     'MINIO_BUCKET',

--- a/TrinityBackendFastAPI/app/features/concat/routes.py
+++ b/TrinityBackendFastAPI/app/features/concat/routes.py
@@ -12,9 +12,14 @@ from minio.error import S3Error
 import uuid
 import datetime
 from .deps import (
-    minio_client, load_dataframe,
-    save_concat_result_to_minio, get_concat_results_collection, save_concat_metadata_to_mongo,
-    OBJECT_PREFIX, MINIO_BUCKET, redis_client
+    minio_client,
+    load_dataframe,
+    save_concat_result_to_minio,
+    get_concat_configuration_collection,
+    save_concat_metadata_to_mongo,
+    OBJECT_PREFIX,
+    MINIO_BUCKET,
+    redis_client,
 )
 
 router = APIRouter()
@@ -259,7 +264,7 @@ async def perform_concat(
         redis_client.setex(concat_key, 3600, arrow_bytes)
 
         # Save metadata to MongoDB
-        collection = get_concat_results_collection()
+        collection = get_concat_configuration_collection()
         await save_concat_metadata_to_mongo(collection, {
             "concat_id": concat_id,
             "file1_name": file1,

--- a/TrinityBackendFastAPI/app/features/feature_overview/routes.py
+++ b/TrinityBackendFastAPI/app/features/feature_overview/routes.py
@@ -295,7 +295,7 @@ async def dimension_mapping(req: DimensionMappingRequest):
     mongo_cfg = get_classifier_config_from_mongo(client, app, project)
     if mongo_cfg and mongo_cfg.get("dimensions"):
         print("📦 loaded mapping from MongoDB")
-        redis_client.setex(key, 3600, json.dumps(mongo_cfg))
+        redis_client.setex(key, 3600, json.dumps(mongo_cfg, default=str))
         return {"mapping": mongo_cfg["dimensions"], "config": mongo_cfg}
 
     raise HTTPException(status_code=404, detail="Mapping not found")

--- a/TrinityBackendFastAPI/app/redis_cache.py
+++ b/TrinityBackendFastAPI/app/redis_cache.py
@@ -23,7 +23,7 @@ def cache_master_config(client_id: str, app_id: str, project_id: str, file_key: 
         "config": config,
         "type": "Validation",
     }
-    redis_client.setex(key, TTL, json.dumps(data))
+    redis_client.setex(key, TTL, json.dumps(data, default=str))
 
 
 def get_master_config(client_id: str, app_id: str, project_id: str, file_key: str) -> Dict | None:

--- a/TrinityFrontend/src/components/AtomList/atoms/column-classifier/ColumnClassifierAtom.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/column-classifier/ColumnClassifierAtom.tsx
@@ -13,6 +13,8 @@ import {
 } from '@/components/LaboratoryMode/store/laboratoryStore';
 import { CLASSIFIER_API } from '@/lib/api';
 import { fetchDimensionMapping } from '@/lib/dimensions';
+import { useAuth } from '@/contexts/AuthContext';
+import { logSessionState } from '@/lib/session';
 
 export type ColumnData = ColumnClassifierColumn;
 export type FileClassification = ColumnClassifierFile;
@@ -29,6 +31,7 @@ const ColumnClassifierAtom: React.FC<Props> = ({ atomId }) => {
   };
   const classifierData = settings.data;
   const { toast } = useToast();
+  const { user } = useAuth();
 
   React.useEffect(() => {
     const loadMapping = async () => {
@@ -182,6 +185,7 @@ const ColumnClassifierAtom: React.FC<Props> = ({ atomId }) => {
       } catch (err) {
         console.warn('assignment save result parse error', err);
       }
+      logSessionState(user?.id);
     } else {
       toast({ title: 'Unable to Save Configuration', variant: 'destructive' });
       try {

--- a/TrinityFrontend/src/components/AtomList/atoms/column-classifier/ColumnClassifierAtom.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/column-classifier/ColumnClassifierAtom.tsx
@@ -14,7 +14,7 @@ import {
 import { CLASSIFIER_API } from '@/lib/api';
 import { fetchDimensionMapping } from '@/lib/dimensions';
 import { useAuth } from '@/contexts/AuthContext';
-import { logSessionState, updateSessionState } from '@/lib/session';
+import { logSessionState, updateSessionState, addNavigationItem } from '@/lib/session';
 
 export type ColumnData = ColumnClassifierColumn;
 export type FileClassification = ColumnClassifierFile;
@@ -186,6 +186,12 @@ const ColumnClassifierAtom: React.FC<Props> = ({ atomId }) => {
         console.warn('assignment save result parse error', err);
       }
       updateSessionState(user?.id, {
+        identifiers,
+        measures,
+        dimensions: currentFile.customDimensions,
+      });
+      addNavigationItem(user?.id, {
+        atom: 'column-classifier',
         identifiers,
         measures,
         dimensions: currentFile.customDimensions,

--- a/TrinityFrontend/src/components/AtomList/atoms/column-classifier/ColumnClassifierAtom.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/column-classifier/ColumnClassifierAtom.tsx
@@ -194,6 +194,7 @@ const ColumnClassifierAtom: React.FC<Props> = ({ atomId }) => {
       } catch (err) {
         console.warn('assignment save error parse fail', err);
       }
+      logSessionState(user?.id);
     }
   };
 

--- a/TrinityFrontend/src/components/AtomList/atoms/column-classifier/ColumnClassifierAtom.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/column-classifier/ColumnClassifierAtom.tsx
@@ -14,7 +14,7 @@ import {
 import { CLASSIFIER_API } from '@/lib/api';
 import { fetchDimensionMapping } from '@/lib/dimensions';
 import { useAuth } from '@/contexts/AuthContext';
-import { logSessionState } from '@/lib/session';
+import { logSessionState, updateSessionState } from '@/lib/session';
 
 export type ColumnData = ColumnClassifierColumn;
 export type FileClassification = ColumnClassifierFile;
@@ -185,6 +185,11 @@ const ColumnClassifierAtom: React.FC<Props> = ({ atomId }) => {
       } catch (err) {
         console.warn('assignment save result parse error', err);
       }
+      updateSessionState(user?.id, {
+        identifiers,
+        measures,
+        dimensions: currentFile.customDimensions,
+      });
       logSessionState(user?.id);
     } else {
       toast({ title: 'Unable to Save Configuration', variant: 'destructive' });

--- a/TrinityFrontend/src/components/AtomList/atoms/data-upload-validate/DataUploadValidateAtom.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/data-upload-validate/DataUploadValidateAtom.tsx
@@ -286,7 +286,7 @@ const DataUploadValidateAtom: React.FC<Props> = ({ atomId }) => {
   };
 
   const handleSaveDataFrames = async () => {
-    if (!settings.validatorId) return;
+    if (!settings.validatorId && !settings.bypassMasterUpload) return;
     console.log('🔧 Running save dataframes util');
     try {
       let query = '';
@@ -331,7 +331,8 @@ const DataUploadValidateAtom: React.FC<Props> = ({ atomId }) => {
       /* ignore */
     }
     const form = new FormData();
-    form.append('validator_atom_id', settings.validatorId);
+    const vidSave = settings.validatorId || 'bypass_upload';
+    form.append('validator_atom_id', vidSave);
     const envStr = localStorage.getItem('env');
     if (envStr) {
       try {

--- a/TrinityFrontend/src/components/AtomList/atoms/data-upload-validate/DataUploadValidateAtom.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/data-upload-validate/DataUploadValidateAtom.tsx
@@ -264,6 +264,8 @@ const DataUploadValidateAtom: React.FC<Props> = ({ atomId }) => {
       setValidationResults(results);
       setValidationDetails(details);
       logSessionState(user?.id);
+    } else {
+      logSessionState(user?.id);
     }
   };
 
@@ -375,6 +377,7 @@ const DataUploadValidateAtom: React.FC<Props> = ({ atomId }) => {
       logSessionState(user?.id);
     } else {
       toast({ title: 'Unable to Save Dataframes', variant: 'destructive' });
+      logSessionState(user?.id);
     }
   };
 

--- a/TrinityFrontend/src/components/AtomList/atoms/data-upload-validate/DataUploadValidateAtom.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/data-upload-validate/DataUploadValidateAtom.tsx
@@ -12,7 +12,7 @@ import { useLaboratoryStore, DEFAULT_DATAUPLOAD_SETTINGS, DataUploadSettings } f
 import { VALIDATE_API } from '@/lib/api';
 import { useToast } from '@/hooks/use-toast';
 import { useAuth } from '@/contexts/AuthContext';
-import { logSessionState } from '@/lib/session';
+import { logSessionState, updateSessionState } from '@/lib/session';
 import UploadSection from './components/upload/UploadSection';
 import RequiredFilesSection from './components/required-files/RequiredFilesSection';
 
@@ -346,6 +346,7 @@ const DataUploadValidateAtom: React.FC<Props> = ({ atomId }) => {
       const data = await res.json();
       if (data.environment) {
         console.log('Fetched env vars', data.environment);
+        updateSessionState(user?.id, { envvars: data.environment });
       }
       if (data.prefix) {
         console.log('Saving to MinIO prefix', data.prefix);

--- a/TrinityFrontend/src/components/AtomList/atoms/data-upload-validate/DataUploadValidateAtom.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/data-upload-validate/DataUploadValidateAtom.tsx
@@ -12,7 +12,7 @@ import { useLaboratoryStore, DEFAULT_DATAUPLOAD_SETTINGS, DataUploadSettings } f
 import { VALIDATE_API } from '@/lib/api';
 import { useToast } from '@/hooks/use-toast';
 import { useAuth } from '@/contexts/AuthContext';
-import { logSessionState, updateSessionState } from '@/lib/session';
+import { logSessionState, updateSessionState, addNavigationItem } from '@/lib/session';
 import UploadSection from './components/upload/UploadSection';
 import RequiredFilesSection from './components/required-files/RequiredFilesSection';
 
@@ -375,6 +375,11 @@ const DataUploadValidateAtom: React.FC<Props> = ({ atomId }) => {
       } else {
         toast({ title: 'Dataframes Saved Successfully' });
       }
+      addNavigationItem(user?.id, {
+        atom: 'data-upload-validate',
+        files: uploadedFiles.map(f => f.name),
+        settings
+      });
       logSessionState(user?.id);
     } else {
       toast({ title: 'Unable to Save Dataframes', variant: 'destructive' });

--- a/TrinityFrontend/src/components/AtomList/atoms/data-upload-validate/DataUploadValidateAtom.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/data-upload-validate/DataUploadValidateAtom.tsx
@@ -11,6 +11,8 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/component
 import { useLaboratoryStore, DEFAULT_DATAUPLOAD_SETTINGS, DataUploadSettings } from '@/components/LaboratoryMode/store/laboratoryStore';
 import { VALIDATE_API } from '@/lib/api';
 import { useToast } from '@/hooks/use-toast';
+import { useAuth } from '@/contexts/AuthContext';
+import { logSessionState } from '@/lib/session';
 import UploadSection from './components/upload/UploadSection';
 import RequiredFilesSection from './components/required-files/RequiredFilesSection';
 
@@ -24,6 +26,7 @@ const DataUploadValidateAtom: React.FC<Props> = ({ atomId }) => {
   const settings: DataUploadSettings = atom?.settings || { ...DEFAULT_DATAUPLOAD_SETTINGS };
 
   const { toast } = useToast();
+  const { user } = useAuth();
 
   const [uploadedFiles, setUploadedFiles] = useState<File[]>([]);
   const [isDragOver, setIsDragOver] = useState(false);
@@ -260,6 +263,7 @@ const DataUploadValidateAtom: React.FC<Props> = ({ atomId }) => {
 
       setValidationResults(results);
       setValidationDetails(details);
+      logSessionState(user?.id);
     }
   };
 
@@ -368,6 +372,7 @@ const DataUploadValidateAtom: React.FC<Props> = ({ atomId }) => {
       } else {
         toast({ title: 'Dataframes Saved Successfully' });
       }
+      logSessionState(user?.id);
     } else {
       toast({ title: 'Unable to Save Dataframes', variant: 'destructive' });
     }

--- a/TrinityFrontend/src/components/AtomList/atoms/data-upload-validate/DataUploadValidateAtom.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/data-upload-validate/DataUploadValidateAtom.tsx
@@ -48,9 +48,25 @@ const DataUploadValidateAtom: React.FC<Props> = ({ atomId }) => {
     setUploadedFiles((prev) => [...prev, ...files]);
     updateSettings(atomId, {
       uploadedFiles: [...(settings.uploadedFiles || []), ...files.map((f) => f.name)],
-      fileMappings: { ...fileAssignments, ...Object.fromEntries(files.map(f => [f.name, settings.requiredFiles?.[0] || ''])) }
+      fileMappings: {
+        ...fileAssignments,
+        ...Object.fromEntries(
+          files.map(f => [
+            f.name,
+            settings.bypassMasterUpload ? f.name : settings.requiredFiles?.[0] || ''
+          ])
+        )
+      }
     });
-    setFileAssignments(prev => ({ ...prev, ...Object.fromEntries(files.map(f => [f.name, settings.requiredFiles?.[0] || ''])) }));
+    setFileAssignments(prev => ({
+      ...prev,
+      ...Object.fromEntries(
+        files.map(f => [
+          f.name,
+          settings.bypassMasterUpload ? f.name : settings.requiredFiles?.[0] || ''
+        ])
+      )
+    }));
   };
 
   const handleDrop = (e: React.DragEvent) => {
@@ -489,7 +505,7 @@ const DataUploadValidateAtom: React.FC<Props> = ({ atomId }) => {
                 requiredOptions={settings.requiredFiles || []}
                 onDeleteFile={handleDeleteFile}
                 saveStatus={saveStatus}
-                disabled={(settings.requiredFiles || []).length === 0}
+                disabled={!settings.bypassMasterUpload && (settings.requiredFiles || []).length === 0}
               />
             </div>
 
@@ -505,6 +521,7 @@ const DataUploadValidateAtom: React.FC<Props> = ({ atomId }) => {
                 openFile={openFile}
                 setOpenFile={setOpenFile}
                 getStatusIcon={getStatusIcon}
+                bypassMasterUpload={settings.bypassMasterUpload}
               />
             </div>
           </div>

--- a/TrinityFrontend/src/components/AtomList/atoms/data-upload-validate/DataUploadValidateAtom.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/data-upload-validate/DataUploadValidateAtom.tsx
@@ -464,8 +464,10 @@ const DataUploadValidateAtom: React.FC<Props> = ({ atomId }) => {
     );
   };
 
-  const allValid = Object.values(validationResults).length > 0 &&
-    Object.values(validationResults).every(v => v.includes('Success'));
+  const allValid = settings.bypassMasterUpload || (
+    Object.values(validationResults).length > 0 &&
+    Object.values(validationResults).every(v => v.includes('Success'))
+  );
 
   return (
     <div className="w-full h-full bg-gradient-to-br from-slate-50 to-blue-50 rounded-xl border border-gray-200 shadow-xl overflow-hidden flex">
@@ -501,6 +503,7 @@ const DataUploadValidateAtom: React.FC<Props> = ({ atomId }) => {
                 onValidateFiles={handleValidateFiles}
                 onSaveDataFrames={handleSaveDataFrames}
                 saveEnabled={allValid}
+                disableValidation={settings.bypassMasterUpload}
                 isDragOver={isDragOver}
                 requiredOptions={settings.requiredFiles || []}
                 onDeleteFile={handleDeleteFile}

--- a/TrinityFrontend/src/components/AtomList/atoms/data-upload-validate/components/properties/DataUploadValidateProperties.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/data-upload-validate/components/properties/DataUploadValidateProperties.tsx
@@ -12,6 +12,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Checkbox } from "@/components/ui/checkbox";
+import { Switch } from "@/components/ui/switch";
 import {
   Tooltip,
   TooltipTrigger,
@@ -54,6 +55,7 @@ const DataUploadValidateProperties: React.FC<Props> = ({ atomId }) => {
   const [renameMap, setRenameMap] = useState<Record<string, string>>({});
   const [skipFetch, setSkipFetch] = useState(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [bypassMasterUpload, setBypassMasterUpload] = useState<boolean>(settings.bypassMasterUpload || false);
   const [validatorId, setValidatorId] = useState<string>(
     settings.validatorId || "",
   );
@@ -126,6 +128,10 @@ const DataUploadValidateProperties: React.FC<Props> = ({ atomId }) => {
   const [categoricalColumns, setCategoricalColumns] = useState<string[]>([]);
   const [continuousColumns, setContinuousColumns] = useState<string[]>([]);
   const [schemaSamples, setSchemaSamples] = useState<Record<string, any>>({});
+
+  useEffect(() => {
+    setBypassMasterUpload(settings.bypassMasterUpload || false);
+  }, [settings.bypassMasterUpload]);
 
   // Load existing configuration if validator id already present
   useEffect(() => {
@@ -320,6 +326,11 @@ const DataUploadValidateProperties: React.FC<Props> = ({ atomId }) => {
     const newMap = { ...(settings.fileKeyMap || {}) } as Record<string, string>;
     delete newMap[name];
     updateSettings(atomId, { fileKeyMap: newMap });
+  };
+
+  const handleBypassToggle = (val: boolean) => {
+    setBypassMasterUpload(val);
+    updateSettings(atomId, { bypassMasterUpload: val });
   };
 
   const handleDataTypeChange = (column: string, value: string) => {
@@ -790,6 +801,14 @@ const DataUploadValidateProperties: React.FC<Props> = ({ atomId }) => {
       </div>
 
       <div className="flex-1 overflow-y-auto overflow-x-hidden scrollbar-thin scrollbar-thumb-gray-300">
+        <div className="p-4 border-b border-gray-200 bg-gray-50 flex items-center justify-between">
+          <span className="text-sm font-medium text-gray-700">Bypass Master File Upload (Allow any file to be uploaded)</span>
+          <Switch
+            checked={bypassMasterUpload}
+            onCheckedChange={handleBypassToggle}
+            className="data-[state=checked]:bg-[#458EE2]"
+          />
+        </div>
         {/* Master File Upload Section */}
         <div className="p-4 border-b border-gray-200 bg-gray-50">
           <div className="space-y-4">

--- a/TrinityFrontend/src/components/AtomList/atoms/data-upload-validate/components/required-files/RequiredFilesSection.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/data-upload-validate/components/required-files/RequiredFilesSection.tsx
@@ -22,6 +22,7 @@ interface RequiredFilesSectionProps {
   openFile: string | null;
   setOpenFile: (n: string | null) => void;
   getStatusIcon: (status: string, required: boolean) => React.ReactNode;
+  bypassMasterUpload?: boolean;
 }
 
 const RequiredFilesSection: React.FC<RequiredFilesSectionProps> = ({
@@ -34,7 +35,8 @@ const RequiredFilesSection: React.FC<RequiredFilesSectionProps> = ({
   commitRename,
   openFile,
   setOpenFile,
-  getStatusIcon
+  getStatusIcon,
+  bypassMasterUpload
 }) => (
   <Card className="h-full shadow-sm border-0 bg-white">
     <div className="p-4 border-b border-gray-100">
@@ -45,7 +47,7 @@ const RequiredFilesSection: React.FC<RequiredFilesSectionProps> = ({
       <p className="text-xs text-gray-600 mt-1">Upload these files for complete data validation</p>
     </div>
     <div className="p-4 space-y-3 overflow-y-auto h-[calc(100%-80px)]">
-      {files.length === 0 && (
+      {files.length === 0 && !bypassMasterUpload && (
         <p className="text-sm text-gray-500 text-center">
           Upload a Master File in Properties section to begin upload.
         </p>

--- a/TrinityFrontend/src/components/AtomList/atoms/data-upload-validate/components/upload/UploadSection.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/data-upload-validate/components/upload/UploadSection.tsx
@@ -32,6 +32,8 @@ interface UploadSectionProps {
   onDeleteFile: (name: string) => void;
   saveStatus: Record<string, string>;
   disabled?: boolean;
+  /** When true, disable the validate button */
+  disableValidation?: boolean;
 }
 
 const UploadSection: React.FC<UploadSectionProps> = ({
@@ -54,7 +56,8 @@ const UploadSection: React.FC<UploadSectionProps> = ({
   requiredOptions,
   onDeleteFile,
   saveStatus,
-  disabled = false
+  disabled = false,
+  disableValidation = false
 }) => (
   <Card className="h-full flex flex-col shadow-sm border-0 bg-white">
     <div className="p-4 border-b border-gray-100">
@@ -140,7 +143,7 @@ const UploadSection: React.FC<UploadSectionProps> = ({
         </label>
       </div>
       {uploadedFiles.length > 0 && (
-        <Button className="w-full mt-4" onClick={onValidateFiles}>
+        <Button className="w-full mt-4" onClick={onValidateFiles} disabled={disableValidation}>
           Validate Files
         </Button>
       )}

--- a/TrinityFrontend/src/components/AtomList/atoms/feature-overview/components/FeatureOverviewCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/feature-overview/components/FeatureOverviewCanvas.tsx
@@ -16,7 +16,7 @@ import { BarChart3, TrendingUp, Maximize2 } from "lucide-react";
 import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";
 import D3LineChart from "./D3LineChart";
 import { useAuth } from "@/contexts/AuthContext";
-import { logSessionState } from "@/lib/session";
+import { logSessionState, addNavigationItem } from "@/lib/session";
 
 interface ColumnInfo {
   column: string;
@@ -199,6 +199,12 @@ const FeatureOverviewCanvas: React.FC<FeatureOverviewCanvasProps> = ({
       }
       }
       onUpdateSettings(newSettings);
+      addNavigationItem(user?.id, {
+        atom: 'feature-overview',
+        action: 'displaySkus',
+        dataSource: settings.dataSource,
+        dimensionMap,
+      });
       logSessionState(user?.id);
     } catch (e: any) {
       console.error("⚠️ failed to display SKUs", e);
@@ -246,6 +252,12 @@ const FeatureOverviewCanvas: React.FC<FeatureOverviewCanvasProps> = ({
         statDataMap: result,
         activeMetric: settings.yAxes[0],
         activeRow: row.id,
+      });
+      addNavigationItem(user?.id, {
+        atom: 'feature-overview',
+        action: 'viewStats',
+        metric: settings.yAxes[0],
+        combination: combo,
       });
       logSessionState(user?.id);
     } catch (e: any) {

--- a/TrinityFrontend/src/components/AtomList/atoms/feature-overview/components/FeatureOverviewCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/feature-overview/components/FeatureOverviewCanvas.tsx
@@ -15,6 +15,8 @@ import { fetchDimensionMapping } from "@/lib/dimensions";
 import { BarChart3, TrendingUp, Maximize2 } from "lucide-react";
 import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";
 import D3LineChart from "./D3LineChart";
+import { useAuth } from "@/contexts/AuthContext";
+import { logSessionState } from "@/lib/session";
 
 interface ColumnInfo {
   column: string;
@@ -32,6 +34,7 @@ const FeatureOverviewCanvas: React.FC<FeatureOverviewCanvasProps> = ({
   settings,
   onUpdateSettings,
 }) => {
+  const { user } = useAuth();
   const [dimensionMap, setDimensionMap] = useState<Record<string, string[]>>(
     settings.dimensionMap || {},
   );
@@ -191,11 +194,12 @@ const FeatureOverviewCanvas: React.FC<FeatureOverviewCanvasProps> = ({
         const defaults = ["salesvalue", "volume"].filter((d) =>
           lower.includes(d),
         );
-        if (defaults.length > 0) {
-          newSettings.yAxes = defaults;
-        }
+      if (defaults.length > 0) {
+        newSettings.yAxes = defaults;
+      }
       }
       onUpdateSettings(newSettings);
+      logSessionState(user?.id);
     } catch (e: any) {
       console.error("⚠️ failed to display SKUs", e);
       setError(e.message || "Error displaying SKUs");
@@ -242,6 +246,7 @@ const FeatureOverviewCanvas: React.FC<FeatureOverviewCanvasProps> = ({
         activeMetric: settings.yAxes[0],
         activeRow: row.id,
       });
+      logSessionState(user?.id);
     } catch (e: any) {
       setError(e.message || "Error fetching statistics");
     }

--- a/TrinityFrontend/src/components/AtomList/atoms/feature-overview/components/FeatureOverviewCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/feature-overview/components/FeatureOverviewCanvas.tsx
@@ -203,6 +203,7 @@ const FeatureOverviewCanvas: React.FC<FeatureOverviewCanvasProps> = ({
     } catch (e: any) {
       console.error("⚠️ failed to display SKUs", e);
       setError(e.message || "Error displaying SKUs");
+      logSessionState(user?.id);
     }
   };
 
@@ -249,6 +250,7 @@ const FeatureOverviewCanvas: React.FC<FeatureOverviewCanvasProps> = ({
       logSessionState(user?.id);
     } catch (e: any) {
       setError(e.message || "Error fetching statistics");
+      logSessionState(user?.id);
     }
   };
 

--- a/TrinityFrontend/src/components/LaboratoryMode/LaboratoryMode.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/LaboratoryMode.tsx
@@ -12,6 +12,8 @@ import FloatingNavigationList from './components/FloatingNavigationList';
 import { useExhibitionStore } from '@/components/ExhibitionMode/store/exhibitionStore';
 import { REGISTRY_API, LAB_ACTIONS_API } from '@/lib/api';
 import { useLaboratoryStore } from './store/laboratoryStore';
+import { useAuth } from '@/contexts/AuthContext';
+import { addNavigationItem, logSessionState } from '@/lib/session';
 
 const LaboratoryMode = () => {
   const [selectedAtomId, setSelectedAtomId] = useState<string>();
@@ -23,6 +25,7 @@ const LaboratoryMode = () => {
   const { toast } = useToast();
   const { cards, setCards } = useExhibitionStore();
   const setLabCards = useLaboratoryStore(state => state.setCards);
+  const { user } = useAuth();
 
   const handleUndo = async () => {
     const current = localStorage.getItem('current-project');
@@ -120,6 +123,17 @@ const LaboratoryMode = () => {
         description: `Laboratory configuration saved successfully. ${exhibitedCards.length} card(s) marked for exhibition.`,
       });
       setError(null);
+      const allAtoms = cards.flatMap(card =>
+        card.atoms.map(atom => ({
+          id: atom.id,
+          title: atom.title,
+          category: atom.category,
+          color: atom.color,
+          cardId: card.id,
+        }))
+      );
+      addNavigationItem(user?.id, { atom: 'laboratory-save', atoms: allAtoms });
+      logSessionState(user?.id);
     } catch (error) {
       console.error('Save error:', error);
       setError('Failed to save configuration. Please try again.');

--- a/TrinityFrontend/src/components/LaboratoryMode/store/laboratoryStore.ts
+++ b/TrinityFrontend/src/components/LaboratoryMode/store/laboratoryStore.ts
@@ -40,6 +40,8 @@ export const DEFAULT_TEXTBOX_SETTINGS: TextBoxSettings = {
 export interface DataUploadSettings {
   masterFile: string;
   fileValidation: boolean;
+  /** When true, allow uploads without selecting a master file */
+  bypassMasterUpload?: boolean;
   columnConfig: Record<string, Record<string, string>>;
   frequency: string;
   dimensions: Record<string, unknown>;
@@ -56,6 +58,7 @@ export interface DataUploadSettings {
 export const DEFAULT_DATAUPLOAD_SETTINGS: DataUploadSettings = {
   masterFile: "",
   fileValidation: true,
+  bypassMasterUpload: false,
   columnConfig: {},
   frequency: "monthly",
   dimensions: {},

--- a/TrinityFrontend/src/lib/api.ts
+++ b/TrinityFrontend/src/lib/api.ts
@@ -88,6 +88,10 @@ export const MERGE_API =
   normalizeUrl(import.meta.env.VITE_MERGE_API) ||
   `${backendOrigin.replace(new RegExp(`:${djangoPort}$`), `:${fastapiPort}`)}/api/merge`;
 
+export const SESSION_API =
+  normalizeUrl(import.meta.env.VITE_SESSION_API) ||
+  `${backendOrigin}${djangoPrefix}/session`;
+
 export const FEATURE_OVERVIEW_API =
   normalizeUrl(import.meta.env.VITE_FEATURE_OVERVIEW_API) ||
   `${backendOrigin.replace(new RegExp(`:${djangoPort}$`), `:${fastapiPort}`)}/api/feature-overview`;

--- a/TrinityFrontend/src/lib/session.ts
+++ b/TrinityFrontend/src/lib/session.ts
@@ -1,23 +1,56 @@
 import { SESSION_API } from './api';
 
-export async function logSessionState(userId: number | string | null | undefined) {
+function buildSession(userId: number | string | null | undefined) {
   const envStr = localStorage.getItem('env');
-  if (!envStr || userId === null || userId === undefined) {
-    console.warn('No env or user id for session state log');
-    return;
-  }
+  if (!envStr || userId === null || userId === undefined) return null;
   try {
     const env = JSON.parse(envStr);
     const sessionId = `session:${env.CLIENT_ID}:${userId}:${env.APP_ID}:${env.PROJECT_ID}`;
     const namespace = `${env.CLIENT_NAME}/${env.APP_NAME}/${env.PROJECT_NAME}`;
+    return { sessionId, namespace };
+  } catch {
+    return null;
+  }
+}
+
+export async function updateSessionState(
+  userId: number | string | null | undefined,
+  updates: Record<string, any>
+) {
+  const session = buildSession(userId);
+  if (!session) {
+    console.warn('No env or user id for session state update');
+    return;
+  }
+  for (const [key, value] of Object.entries(updates)) {
+    try {
+      await fetch(`${SESSION_API}/update`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ session_id: session.sessionId, key, value }),
+      });
+    } catch (err) {
+      console.warn('session state update error', err);
+    }
+  }
+}
+
+export async function logSessionState(userId: number | string | null | undefined) {
+  const session = buildSession(userId);
+  if (!session) {
+    console.warn('No env or user id for session state log');
+    return;
+  }
+  try {
     const res = await fetch(
-      `${SESSION_API}/state?session_id=${encodeURIComponent(sessionId)}`,
+      `${SESSION_API}/state?session_id=${encodeURIComponent(session.sessionId)}`,
       { credentials: 'include' }
     );
     if (res.ok) {
       const data = await res.json();
-      console.log('\uD83D\uDD11 redis namespace', namespace);
-      console.log('\uD83C\uDF10 session id', sessionId);
+      console.log('\uD83D\uDD11 redis namespace', session.namespace);
+      console.log('\uD83C\uDF10 session id', session.sessionId);
       console.log('\uD83D\uDCCA session state', data.state);
     } else {
       console.warn('\u26A0\uFE0F failed to fetch session state', res.status);

--- a/TrinityFrontend/src/lib/session.ts
+++ b/TrinityFrontend/src/lib/session.ts
@@ -1,0 +1,27 @@
+import { SESSION_API } from './api';
+
+export async function logSessionState(userId: number | string | null | undefined) {
+  const envStr = localStorage.getItem('env');
+  if (!envStr || userId === null || userId === undefined) {
+    console.warn('No env or user id for session state log');
+    return;
+  }
+  try {
+    const env = JSON.parse(envStr);
+    const sessionId = `session:${env.CLIENT_ID}:${userId}:${env.APP_ID}:${env.PROJECT_ID}`;
+    const namespace = `${env.CLIENT_NAME}/${env.APP_NAME}/${env.PROJECT_NAME}`;
+    const res = await fetch(
+      `${SESSION_API}/state?session_id=${encodeURIComponent(sessionId)}`,
+      { credentials: 'include' }
+    );
+    if (res.ok) {
+      const data = await res.json();
+      console.log('\uD83D\uDD11 redis namespace', namespace);
+      console.log('\uD83D\uDCCA session state', data.state);
+    } else {
+      console.warn('\u26A0\uFE0F failed to fetch session state', res.status);
+    }
+  } catch (err) {
+    console.warn('session state retrieval error', err);
+  }
+}

--- a/TrinityFrontend/src/lib/session.ts
+++ b/TrinityFrontend/src/lib/session.ts
@@ -17,6 +17,7 @@ export async function logSessionState(userId: number | string | null | undefined
     if (res.ok) {
       const data = await res.json();
       console.log('\uD83D\uDD11 redis namespace', namespace);
+      console.log('\uD83C\uDF10 session id', sessionId);
       console.log('\uD83D\uDCCA session state', data.state);
     } else {
       console.warn('\u26A0\uFE0F failed to fetch session state', res.status);

--- a/TrinityFrontend/src/lib/session.ts
+++ b/TrinityFrontend/src/lib/session.ts
@@ -36,6 +36,13 @@ export async function updateSessionState(
   }
 }
 
+export async function addNavigationItem(
+  userId: number | string | null | undefined,
+  item: Record<string, any>
+) {
+  await updateSessionState(userId, { navigation: item });
+}
+
 export async function logSessionState(userId: number | string | null | undefined) {
   const session = buildSession(userId);
   if (!session) {

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -105,6 +105,7 @@ services:
     command: celery -A config.celery worker --loglevel=info
     volumes:
       - ./TrinityBackendDjango:/code
+      - ./TrinityBackendFastAPI:/code/TrinityBackendFastAPI
     env_file:
       - ./TrinityBackendDjango/.env
     depends_on:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -72,6 +72,7 @@ services:
     command: gunicorn config.wsgi:application --bind 0.0.0.0:8000 --workers 3
     volumes:
       - ./TrinityBackendDjango:/code
+      - ./TrinityBackendFastAPI:/code/TrinityBackendFastAPI
     env_file:
       - ./TrinityBackendDjango/.env
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,6 +105,7 @@ services:
     command: celery -A config.celery worker --loglevel=info
     volumes:
       - ./TrinityBackendDjango:/code
+      - ./TrinityBackendFastAPI:/code/TrinityBackendFastAPI
     env_file:
       - ./TrinityBackendDjango/.env
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,7 @@ services:
     command: gunicorn config.wsgi:application --bind 0.0.0.0:8000 --workers 3
     volumes:
       - ./TrinityBackendDjango:/code
+      - ./TrinityBackendFastAPI:/code/TrinityBackendFastAPI
     env_file:
       - ./TrinityBackendDjango/.env
     ports:


### PR DESCRIPTION
## Summary
- add SessionState Django app for managing user project sessions
- store sessions in Redis with MongoDB fallback
- expose /api/session endpoints
- include app in settings and urls

## Testing
- `python manage.py check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68871ecfc72c8321a53b73b57564face