### PR TITLE
Fix AI URL handling for Trinity frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Follow the steps below to run all services together.
    tenant creation fails.
    The frontend `.env` includes `VITE_SUBSCRIPTIONS_API` which should point to
   the Django subscription endpoints and `VITE_TRINITY_AI_API` for the AI
-  service.
+  service. When setting `VITE_TRINITY_AI_API`, provide only the base host and
+  port as the `/trinityai` prefix is appended automatically.
   When exposing the app via Cloudflare Tunnel, you can set
   `VITE_BACKEND_ORIGIN=https://trinity.quantmatrixai.com` so the frontend sends
   API requests through Traefik. The `.env.example` file leaves this variable

--- a/TrinityFrontend/.env.example
+++ b/TrinityFrontend/.env.example
@@ -14,11 +14,11 @@ VITE_VALIDATE_API=
 # Use the external host address (e.g. 10.2.1.242) rather than the Docker
 # gateway 172.x.x.x so the browser can reach the API.
 # AI endpoint (defaults to port 8002 when using docker-compose)
+# Base URL of the AI service (do NOT include the '/trinityai' suffix).
 VITE_TRINITY_AI_API=
-# When VITE_BACKEND_ORIGIN points at a public domain this value should end with
-# '/trinityai' so routes like '/trinityai/concat' reach the AI service.
-# Leaving it blank uses the backend origin with the AI port and adds '/trinityai'
-# automatically when needed.
+# When unset, the frontend derives the URL from VITE_BACKEND_ORIGIN and
+# automatically appends '/trinityai'.
+# If you override this variable provide only the scheme, host and port.
 # Base URL of the backend API if you don't want to use VITE_HOST_IP.
 # Base URL of the backend API. Leave empty when developing locally so the
 # application automatically points at http://${VITE_HOST_IP}:${VITE_DJANGO_PORT}.

--- a/TrinityFrontend/src/lib/api.ts
+++ b/TrinityFrontend/src/lib/api.ts
@@ -106,12 +106,15 @@ export const CREATECOLUMN_API =
 export const GROUPBY_API =
   import.meta.env.VITE_GROUPBY_API || `${backendOrigin.replace(/:8000$/, ':8001')}/api/groupby`;
 
-const aiBase =
-  normalizeUrl(import.meta.env.VITE_TRINITY_AI_API) ||
-  backendOrigin.replace(new RegExp(`:${djangoPort}$`), `:${aiPort}`);
-
-// All Trinity AI endpoints are served under the `/trinityai` prefix
-export const TRINITY_AI_API = `${aiBase}/trinityai`;
+let aiBase = normalizeUrl(import.meta.env.VITE_TRINITY_AI_API);
+if (!aiBase) {
+  aiBase = backendOrigin.replace(new RegExp(`:${djangoPort}$`), `:${aiPort}`);
+}
+// Ensure the base URL ends with the `/trinityai` prefix exactly once
+const normalizedAiBase = aiBase.replace(/\/?$/, '');
+export const TRINITY_AI_API = normalizedAiBase.endsWith('/trinityai')
+  ? normalizedAiBase
+  : `${normalizedAiBase}/trinityai`;
 
 export const LAB_ACTIONS_API = `${REGISTRY_API}/laboratory-actions`;
 


### PR DESCRIPTION
## Summary
- adjust TRINITY_AI_API computation so `/trinityai` isn't doubled
- update env example with clearer AI endpoint instructions
- clarify README about setting `VITE_TRINITY_AI_API`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889cbace0a083218cbafd7088055c2a