### PR TITLE
Use Postgres env vars for TrinityAI

### DIFF
--- a/TrinityBackendDjango/apps/roles/models.py
+++ b/TrinityBackendDjango/apps/roles/models.py
@@ -29,3 +29,9 @@ class RoleDefinition(models.Model):
     def __str__(self):
         return self.name
 
+
+# Backwards compatibility alias expected by old scripts
+class UserRole(RoleDefinition):
+    class Meta:
+        proxy = True
+

--- a/TrinityBackendDjango/apps/roles/models.py
+++ b/TrinityBackendDjango/apps/roles/models.py
@@ -29,6 +29,3 @@ class RoleDefinition(models.Model):
     def __str__(self):
         return self.name
 
-
-# Backwards compatibility for older imports
-UserRole = RoleDefinition

--- a/TrinityBackendDjango/apps/roles/models.py
+++ b/TrinityBackendDjango/apps/roles/models.py
@@ -28,3 +28,7 @@ class RoleDefinition(models.Model):
 
     def __str__(self):
         return self.name
+
+
+# Backwards compatibility for older imports
+UserRole = RoleDefinition

--- a/TrinityBackendFastAPI/app/DataStorageRetrieval/arrow_client.py
+++ b/TrinityBackendFastAPI/app/DataStorageRetrieval/arrow_client.py
@@ -71,19 +71,15 @@ def load_env_from_redis() -> Dict[str, str]:
 def get_current_names() -> tuple[str, str, str]:
     """Return (client, app, project) using Redis and Postgres."""
     env = load_env_from_redis()
-    client = os.getenv("CLIENT_NAME", env.get("CLIENT_NAME", "default_client"))
-    app = os.getenv("APP_NAME", env.get("APP_NAME", "default_app"))
-    project = os.getenv(
-        "PROJECT_NAME", env.get("PROJECT_NAME", "default_project")
-    )
-    if (
-        client == "default_client" or app == "default_app" or project == "default_project"
-    ):
+    client = os.getenv("CLIENT_NAME", env.get("CLIENT_NAME", ""))
+    app = os.getenv("APP_NAME", env.get("APP_NAME", ""))
+    project = os.getenv("PROJECT_NAME", env.get("PROJECT_NAME", ""))
+    if not client or not app or not project:
         try:
             import asyncio
             from app.DataStorageRetrieval.db.environment import fetch_environment_names
 
-            schema = client if client != "default_client" else os.getenv("TENANT_SCHEMA", "")
+            schema = os.getenv("TENANT_SCHEMA", client)
             if schema:
                 names = asyncio.run(fetch_environment_names(schema))
                 if names:

--- a/TrinityBackendFastAPI/app/DataStorageRetrieval/db/environment.py
+++ b/TrinityBackendFastAPI/app/DataStorageRetrieval/db/environment.py
@@ -63,6 +63,24 @@ async def init_environment_registry(schema: str | None = None) -> None:
     finally:
         await conn.close()
 
+async def fetch_environment_names(schema: str) -> tuple[str, str, str] | None:
+    """Return the latest client/app/project names for a tenant schema."""
+    conn = await _connect(schema)
+    if conn is None:
+        return None
+    try:
+        await _ensure_table(conn)
+        row = await conn.fetchrow(
+            "SELECT client_name, app_name, project_name"
+            " FROM registry_environment"
+            " ORDER BY updated_at DESC LIMIT 1"
+        )
+        if row:
+            return row["client_name"], row["app_name"], row["project_name"]
+    finally:
+        await conn.close()
+    return None
+
 async def upsert_environment(
     client_name: str,
     app_name: str,

--- a/TrinityFrontend/src/components/AtomList/atoms/concat/components/ConcatCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/concat/components/ConcatCanvas.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/components/ui/pagination';
 import { Loader2 } from 'lucide-react';
 import { Database, ArrowDown } from 'lucide-react';
+import { logMinioPrefix } from '@/utils/logPrefix';
 
 interface ConcatCanvasProps {
   concatId?: string;
@@ -84,6 +85,7 @@ const ConcatCanvas: React.FC<ConcatCanvasProps> = ({ concatId, resultFilePath, f
     
     try {
       // console.log(`[ConcatCanvas] Fetching: ${CONCAT_API}/cached_dataframe?object_name=${encodeURIComponent(resultFilePath)}&page=${page}&page_size=25`);
+      logMinioPrefix(resultFilePath);
       const response = await fetch(
         `${CONCAT_API}/cached_dataframe?object_name=${encodeURIComponent(resultFilePath)}&page=${page}&page_size=20`
       );

--- a/TrinityFrontend/src/components/AtomList/atoms/createcolumn/components/CreateColumnCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/createcolumn/components/CreateColumnCanvas.tsx
@@ -10,6 +10,7 @@ import { Save, Eye, Calculator, Trash2, Plus, ChevronUp, ChevronDown } from 'luc
 import { useToast } from '@/hooks/use-toast';
 import { useLaboratoryStore } from '@/components/LaboratoryMode/store/laboratoryStore';
 import { CREATECOLUMN_API, FEATURE_OVERVIEW_API } from '@/lib/api';
+import { logMinioPrefix } from '@/utils/logPrefix';
 import {
   Pagination,
   PaginationContent,
@@ -432,6 +433,7 @@ const CreateColumnCanvas: React.FC<CreateColumnCanvasProps> = ({
   const fetchPreviewData = async (file: string, page: number = 1) => {
     setPreviewLoading(true);
     try {
+      logMinioPrefix(file);
       const response = await fetch(
         `${CREATECOLUMN_API}/cached_dataframe?object_name=${encodeURIComponent(file)}&page=${page}&page_size=20`
       );

--- a/TrinityFrontend/src/components/AtomList/atoms/data-upload-validate/DataFrameView.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/data-upload-validate/DataFrameView.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { logMinioPrefix } from '@/utils/logPrefix';
 import { Link, useSearchParams } from 'react-router-dom';
 import { FEATURE_OVERVIEW_API } from '@/lib/api';
 import { TrinityAssets } from '@/components/PrimaryMenu';
@@ -67,6 +68,7 @@ const DataFrameView = () => {
 
   useEffect(() => {
     if (!name) return;
+    logMinioPrefix(name);
     fetch(`${FEATURE_OVERVIEW_API}/cached_dataframe?object_name=${encodeURIComponent(name)}`)
       .then(res => res.text())
       .then(text => {

--- a/TrinityFrontend/src/components/AtomList/atoms/feature-overview/components/FeatureOverviewCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/feature-overview/components/FeatureOverviewCanvas.tsx
@@ -17,6 +17,7 @@ import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";
 import D3LineChart from "./D3LineChart";
 import { useAuth } from "@/contexts/AuthContext";
 import { logSessionState, addNavigationItem } from "@/lib/session";
+import { logMinioPrefix } from '@/utils/logPrefix';
 
 interface ColumnInfo {
   column: string;
@@ -153,6 +154,7 @@ const FeatureOverviewCanvas: React.FC<FeatureOverviewCanvasProps> = ({
     setError(null);
     try {
       console.log("🔎 fetching cached dataframe for", settings.dataSource);
+      logMinioPrefix(settings.dataSource);
       const res = await fetch(
         `${FEATURE_OVERVIEW_API}/cached_dataframe?object_name=${encodeURIComponent(
           settings.dataSource,

--- a/TrinityFrontend/src/components/AtomList/atoms/merge/components/MergeCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/merge/components/MergeCanvas.tsx
@@ -20,6 +20,7 @@ import {
   PaginationPrevious,
 } from '@/components/ui/pagination';
 import { Loader2, Database, GitMerge } from 'lucide-react';
+import { logMinioPrefix } from '@/utils/logPrefix';
 
 interface MergeCanvasProps {
   mergeId?: string;
@@ -146,7 +147,8 @@ const MergeCanvas: React.FC<MergeCanvasProps> = ({
         // Fetch from saved file
         const url = `${MERGE_API}/cached_dataframe?object_name=${encodeURIComponent(resultFilePath)}&page=${page}&page_size=20`;
         console.log('[MergeCanvas] Making request to:', url);
-        
+        logMinioPrefix(resultFilePath);
+
         const response = await fetch(url);
         
         console.log('[MergeCanvas] Response status:', response.status);

--- a/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea/index.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea/index.tsx
@@ -27,6 +27,7 @@ import ScopeSelectorAtom from '@/components/AtomList/atoms/scope-selector/ScopeS
 import CreateColumnAtom from '@/components/AtomList/atoms/createcolumn/CreateColumnAtom';
 import GroupByAtom from '@/components/AtomList/atoms/groupby-wtg-avg/GroupByAtom';
 import { fetchDimensionMapping } from '@/lib/dimensions';
+import { logMinioPrefix } from '@/utils/logPrefix';
 
 import {
   useLaboratoryStore,
@@ -105,6 +106,7 @@ const CanvasArea: React.FC<CanvasAreaProps> = ({ onAtomSelect, onCardSelect, sel
   const prefetchDataframe = async (name: string) => {
     if (!name) return;
     try {
+      logMinioPrefix(name);
       console.log('✈️ fetching flight table', name);
       const fr = await fetch(
         `${FEATURE_OVERVIEW_API}/flight_table?object_name=${encodeURIComponent(name)}`,

--- a/TrinityFrontend/src/components/TrinityAI/AIChatBot.tsx
+++ b/TrinityFrontend/src/components/TrinityAI/AIChatBot.tsx
@@ -7,6 +7,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { Send, X, MessageSquare, Bot, User, Sparkles } from 'lucide-react';
 import ChatSuggestions from './ChatSuggestions';
 import { TRINITY_AI_API } from '@/lib/api';
+import { logMinioPrefix } from '@/utils/logPrefix';
 
 interface Message {
   id: string;
@@ -61,6 +62,16 @@ const AIChatBot: React.FC<AIChatBotProps> = ({ cardId, cardTitle, onAddAtom, dis
     setShowSuggestions(false);
 
     try {
+      try {
+        const envRes = await fetch(`${TRINITY_AI_API}/env`);
+        if (envRes.ok) {
+          const envData = await envRes.json();
+          console.log('TrinityAI environment', envData);
+          logMinioPrefix(envData.prefix);
+        }
+      } catch (err) {
+        console.log('Env fetch error', err);
+      }
       const res = await fetch(`${TRINITY_AI_API}/chat`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/TrinityFrontend/src/components/TrinityAI/AtomAIChatBot.tsx
+++ b/TrinityFrontend/src/components/TrinityAI/AtomAIChatBot.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Sparkles, Bot, User, X, MessageSquare, Send } from 'lucide-react';
 import { TRINITY_AI_API, CONCAT_API, MERGE_API } from '@/lib/api';
+import { logMinioPrefix } from '@/utils/logPrefix';
 import { useLaboratoryStore } from '@/components/LaboratoryMode/store/laboratoryStore';
 
 interface Message {
@@ -56,13 +57,23 @@ const AtomAIChatBot: React.FC<AtomAIChatBotProps> = ({ atomId, atomType, atomTit
     const performEndpoint = PERFORM_ENDPOINTS[atomType];
     if (!inputValue.trim() || !endpoint) return;
 
-    const userMsg: Message = { id: Date.now().toString(), content: inputValue, sender: 'user', timestamp: new Date() };
-    setMessages(prev => [...prev, userMsg]);
-    setInputValue('');
-    setIsLoading(true);
+  const userMsg: Message = { id: Date.now().toString(), content: inputValue, sender: 'user', timestamp: new Date() };
+  setMessages(prev => [...prev, userMsg]);
+  setInputValue('');
+  setIsLoading(true);
 
+  try {
     try {
-      const res = await fetch(endpoint, {
+      const envRes = await fetch(`${TRINITY_AI_API}/env`);
+      if (envRes.ok) {
+        const envData = await envRes.json();
+        console.log('TrinityAI environment', envData);
+        logMinioPrefix(envData.prefix);
+      }
+    } catch (err) {
+      console.log('Env fetch error', err);
+    }
+    const res = await fetch(endpoint, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ prompt: userMsg.content }),

--- a/TrinityFrontend/src/utils/logPrefix.ts
+++ b/TrinityFrontend/src/utils/logPrefix.ts
@@ -1,0 +1,8 @@
+export function logMinioPrefix(objectName: string) {
+  if (!objectName) return;
+  const parts = objectName.split('/');
+  if (parts.length >= 3) {
+    const prefix = parts.slice(0, 3).join('/');
+    console.log('MinIO prefix', prefix);
+  }
+}


### PR DESCRIPTION
## Summary
- fetch client/app/project from `registry_environment` using tenant schema
- fall back to Postgres in arrow client when names are defaults
- expose `/env` endpoint in TrinityAI and log resolved names
- log environment and MinIO prefix in TrinityAI chat bots
- log prefix whenever a dataframe is requested from the frontend
- add utility helper `logMinioPrefix`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b44e6f724832192c498b8875d00c0