### PR TITLE
Add detailed environment fetch logging

### DIFF
--- a/TrinityAI/main_api.py
+++ b/TrinityAI/main_api.py
@@ -101,6 +101,7 @@ def _fetch_names_from_db() -> tuple[str, str, str]:
                 project_name=project,
             )
         )
+        logger.debug("get_env_vars returned %s", env)
         if env:
             client = env.get("CLIENT_NAME", client)
             app = env.get("APP_NAME", app)
@@ -112,6 +113,7 @@ def _fetch_names_from_db() -> tuple[str, str, str]:
 
             schema = os.getenv("TENANT_SCHEMA", client)
             names = asyncio.run(fetch_environment_names(schema))
+            logger.debug("fetch_environment_names(%s) -> %s", schema, names)
             if names:
                 client, app, project = names
         except Exception:
@@ -123,6 +125,14 @@ def _fetch_names_from_db() -> tuple[str, str, str]:
                 if user_id and project_id:
                     client_db, app_db, project_db = asyncio.run(
                         fetch_client_app_project(user_id, project_id)
+                    )
+                    logger.debug(
+                        "fetch_client_app_project(%s,%s) -> %s %s %s",
+                        user_id,
+                        project_id,
+                        client_db,
+                        app_db,
+                        project_db,
                     )
                     client = client_db or client
                     app = app_db or app

--- a/TrinityFrontend/src/components/TrinityAI/AIChatBot.tsx
+++ b/TrinityFrontend/src/components/TrinityAI/AIChatBot.tsx
@@ -63,7 +63,12 @@ const AIChatBot: React.FC<AIChatBotProps> = ({ cardId, cardTitle, onAddAtom, dis
 
     try {
       try {
-        const envRes = await fetch(`${TRINITY_AI_API}/env`);
+        const envUrl = `${TRINITY_AI_API}/env`;
+        const parsed = new URL(envUrl);
+        console.log(
+          `Fetching TrinityAI env from ${envUrl} (host=${parsed.hostname} port=${parsed.port} path=${parsed.pathname})`
+        );
+        const envRes = await fetch(envUrl);
         if (envRes.ok) {
           const envData = await envRes.json();
           console.log('TrinityAI environment', envData);

--- a/TrinityFrontend/src/components/TrinityAI/AtomAIChatBot.tsx
+++ b/TrinityFrontend/src/components/TrinityAI/AtomAIChatBot.tsx
@@ -64,7 +64,12 @@ const AtomAIChatBot: React.FC<AtomAIChatBotProps> = ({ atomId, atomType, atomTit
 
   try {
     try {
-      const envRes = await fetch(`${TRINITY_AI_API}/env`);
+      const envUrl = `${TRINITY_AI_API}/env`;
+      const parsed = new URL(envUrl);
+      console.log(
+        `Fetching TrinityAI env from ${envUrl} (host=${parsed.hostname} port=${parsed.port} path=${parsed.pathname})`
+      );
+      const envRes = await fetch(envUrl);
       if (envRes.ok) {
         const envData = await envRes.json();
         console.log('TrinityAI environment', envData);


### PR DESCRIPTION
## Summary
- log where Trinity AI frontend fetches `/env`
- add extensive debug logs around environment retrieval in the AI backend

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b6692bbec83219a351b211caf4cc1