### PR TITLE
fix: show all saved dataframes in project folder

### DIFF
--- a/TrinityBackendFastAPI/app/features/data_upload_validate/app/routes.py
+++ b/TrinityBackendFastAPI/app/features/data_upload_validate/app/routes.py
@@ -2661,6 +2661,7 @@ async def list_saved_dataframes(
     )
 
     try:
+        print(f"🪣 listing from bucket '{MINIO_BUCKET}' prefix '{prefix}'")
         objects = list(
             minio_client.list_objects(
                 MINIO_BUCKET, prefix=prefix, recursive=True
@@ -2676,13 +2677,23 @@ async def list_saved_dataframes(
             }
             for obj in sorted(objects, key=lambda o: o.object_name)
         ]
-        return {"files": files}
+        return {"bucket": MINIO_BUCKET, "prefix": prefix, "files": files}
     except S3Error as e:
         if getattr(e, "code", "") == "NoSuchBucket":
-            return {"files": []}
-        return {"files": [], "error": str(e)}
+            return {"bucket": MINIO_BUCKET, "prefix": prefix, "files": []}
+        return {
+            "bucket": MINIO_BUCKET,
+            "prefix": prefix,
+            "files": [],
+            "error": str(e),
+        }
     except Exception as e:  # pragma: no cover - unexpected error
-        return {"files": [], "error": str(e)}
+        return {
+            "bucket": MINIO_BUCKET,
+            "prefix": prefix,
+            "files": [],
+            "error": str(e),
+        }
 
 
 @router.get("/latest_ticket/{file_key}")

--- a/TrinityBackendFastAPI/app/features/data_upload_validate/app/routes.py
+++ b/TrinityBackendFastAPI/app/features/data_upload_validate/app/routes.py
@@ -2659,9 +2659,16 @@ async def list_saved_dataframes(
         app_name=app_name,
         project_name=project_name,
     )
+    env = {
+        "CLIENT_NAME": os.getenv("CLIENT_NAME"),
+        "APP_NAME": os.getenv("APP_NAME"),
+        "PROJECT_NAME": os.getenv("PROJECT_NAME"),
+    }
 
     try:
-        print(f"🪣 listing from bucket '{MINIO_BUCKET}' prefix '{prefix}'")
+        print(
+            f"🪣 listing from bucket '{MINIO_BUCKET}' prefix '{prefix}'"
+        )
         objects = list(
             minio_client.list_objects(
                 MINIO_BUCKET, prefix=prefix, recursive=True
@@ -2677,15 +2684,26 @@ async def list_saved_dataframes(
             }
             for obj in sorted(objects, key=lambda o: o.object_name)
         ]
-        return {"bucket": MINIO_BUCKET, "prefix": prefix, "files": files}
+        return {
+            "bucket": MINIO_BUCKET,
+            "prefix": prefix,
+            "files": files,
+            "environment": env,
+        }
     except S3Error as e:
         if getattr(e, "code", "") == "NoSuchBucket":
-            return {"bucket": MINIO_BUCKET, "prefix": prefix, "files": []}
+            return {
+                "bucket": MINIO_BUCKET,
+                "prefix": prefix,
+                "files": [],
+                "environment": env,
+            }
         return {
             "bucket": MINIO_BUCKET,
             "prefix": prefix,
             "files": [],
             "error": str(e),
+            "environment": env,
         }
     except Exception as e:  # pragma: no cover - unexpected error
         return {
@@ -2693,6 +2711,7 @@ async def list_saved_dataframes(
             "prefix": prefix,
             "files": [],
             "error": str(e),
+            "environment": env,
         }
 
 

--- a/TrinityBackendFastAPI/app/features/data_upload_validate/app/routes.py
+++ b/TrinityBackendFastAPI/app/features/data_upload_validate/app/routes.py
@@ -175,10 +175,13 @@ async def get_object_prefix(
             app_r = redis_client.get(f"{base}:APP_NAME")
             project_r = redis_client.get(f"{base}:PROJECT_NAME")
             if client_r and project_r:
+                def _decode(val):
+                    return val.decode() if isinstance(val, bytes) else val
+
                 env = {
-                    "CLIENT_NAME": client_r,
-                    "APP_NAME": app_r or "default_app",
-                    "PROJECT_NAME": project_r,
+                    "CLIENT_NAME": _decode(client_r),
+                    "APP_NAME": _decode(app_r) if app_r else "default_app",
+                    "PROJECT_NAME": _decode(project_r),
                 }
         except Exception:
             env = {}

--- a/TrinityBackendFastAPI/app/features/data_upload_validate/app/routes.py
+++ b/TrinityBackendFastAPI/app/features/data_upload_validate/app/routes.py
@@ -195,15 +195,9 @@ async def get_object_prefix(
         client_id_env,
         app_id_env,
         project_id_env,
-        client_name=env.get("CLIENT_NAME")
-        or client_name
-        or os.getenv("CLIENT_NAME", ""),
-        app_name=env.get("APP_NAME")
-        or app_name
-        or os.getenv("APP_NAME", ""),
-        project_name=env.get("PROJECT_NAME")
-        or project_name
-        or os.getenv("PROJECT_NAME", ""),
+        client_name=client_name or os.getenv("CLIENT_NAME", ""),
+        app_name=app_name or os.getenv("APP_NAME", ""),
+        project_name=project_name or os.getenv("PROJECT_NAME", ""),
         use_cache=False,
     )
     if fresh_env:

--- a/TrinityBackendFastAPI/app/features/dataframe_operations/app/routes.py
+++ b/TrinityBackendFastAPI/app/features/dataframe_operations/app/routes.py
@@ -124,27 +124,3 @@ async def save_dataframe(
         }
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))
-
-@router.get("/list_saved_dataframes")
-async def list_saved_dataframes():
-    print("[DFOPS] --- /list_saved_dataframes called ---")
-    try:
-        files = []
-        # List all objects in the bucket and filter for .arrow files
-        objects = minio_client.list_objects(MINIO_BUCKET, recursive=True)
-        for obj in objects:
-            if obj.object_name.endswith('.arrow'):
-                # Extract a display name for the UI
-                display_name = obj.object_name.split('/')[-1] if '/' in obj.object_name else obj.object_name
-                files.append({
-                    "object_name": obj.object_name,
-                    "csv_name": obj.object_name,  # Use full path for API calls
-                    "size": obj.size,
-                    "last_modified": obj.last_modified.isoformat() if obj.last_modified else None,
-                    "display_name": display_name
-                })
-        print(f"[DFOPS] Found {len(files)} files")
-        return {"files": files}
-    except Exception as e:
-        print(f"[DFOPS] list_saved_dataframes error: {e}")
-        return {"files": []} 

--- a/TrinityBackendFastAPI/tests/test_arrow_flight.py
+++ b/TrinityBackendFastAPI/tests/test_arrow_flight.py
@@ -413,6 +413,9 @@ def test_list_saved_dataframes_env(monkeypatch):
     monkeypatch.setattr(routes, "MINIO_BUCKET", "bucket")
 
     async def dummy_prefix(*a, **k):
+        os.environ["CLIENT_NAME"] = "client"
+        os.environ["APP_NAME"] = "app"
+        os.environ["PROJECT_NAME"] = "proj"
         return "pref/"
 
     monkeypatch.setattr(routes, "get_object_prefix", dummy_prefix)
@@ -433,4 +436,7 @@ def test_list_saved_dataframes_env(monkeypatch):
     assert len(data["files"]) == 2
     for f in data["files"]:
         assert "arrow_name" in f
+    assert data["environment"]["CLIENT_NAME"] == "client"
+    assert data["environment"]["APP_NAME"] == "app"
+    assert data["environment"]["PROJECT_NAME"] == "proj"
 

--- a/TrinityBackendFastAPI/tests/test_arrow_flight.py
+++ b/TrinityBackendFastAPI/tests/test_arrow_flight.py
@@ -428,6 +428,8 @@ def test_list_saved_dataframes_env(monkeypatch):
 
     assert resp.status_code == 200
     data = resp.json()
+    assert data["bucket"] == "bucket"
+    assert data["prefix"] == "pref/"
     assert len(data["files"]) == 2
     for f in data["files"]:
         assert "arrow_name" in f

--- a/TrinityBackendFastAPI/tests/test_arrow_flight.py
+++ b/TrinityBackendFastAPI/tests/test_arrow_flight.py
@@ -419,9 +419,9 @@ def test_list_saved_dataframes_env(monkeypatch):
         "redis_client",
         DummyRedis(
             {
-                "env:1:2:3:CLIENT_NAME": "client",
-                "env:1:2:3:APP_NAME": "app",
-                "env:1:2:3:PROJECT_NAME": "proj",
+                "env:1:2:3:CLIENT_NAME": b"client",
+                "env:1:2:3:APP_NAME": b"app",
+                "env:1:2:3:PROJECT_NAME": b"proj",
             }
         ),
     )

--- a/TrinityFrontend/src/components/AtomList/atoms/dataframe-operations/components/DataFrameOperationsCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/dataframe-operations/components/DataFrameOperationsCanvas.tsx
@@ -23,7 +23,7 @@ import {
   ChevronDown, ChevronUp, X, PlusCircle, MinusCircle, Save
 } from 'lucide-react';
 import { DataFrameData, DataFrameSettings } from '../DataFrameOperationsAtom';
-import { DATAFRAME_OPERATIONS_API } from '@/lib/api';
+import { DATAFRAME_OPERATIONS_API, VALIDATE_API } from '@/lib/api';
 import { toast } from '@/components/ui/use-toast';
 
 interface DataFrameOperationsCanvasProps {
@@ -133,7 +133,9 @@ const DataFrameOperationsCanvas: React.FC<DataFrameOperationsCanvasProps> = ({
 
   const fetchSavedDataFrames = async () => {
     try {
-      const res = await fetch('/dataframe-operations/list_saved_dataframes');
+      const res = await fetch(`${VALIDATE_API}/list_saved_dataframes`, {
+        credentials: 'include'
+      });
       const data = await res.json();
       setSavedFiles(data.files || []);
     } catch (e) {

--- a/TrinityFrontend/src/components/LaboratoryMode/components/SavedDataFramesPanel.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/components/SavedDataFramesPanel.tsx
@@ -31,9 +31,6 @@ const SavedDataFramesPanel: React.FC<Props> = ({ isOpen, onToggle }) => {
     if (envStr) {
       try {
         const env = JSON.parse(envStr);
-        const pref = `${env.CLIENT_NAME}/${env.APP_NAME}/${env.PROJECT_NAME}/`;
-        setPrefix(pref);
-        console.log('📁 SavedDataFramesPanel looking in MinIO:', pref);
         query =
           '?' +
           new URLSearchParams({
@@ -44,12 +41,16 @@ const SavedDataFramesPanel: React.FC<Props> = ({ isOpen, onToggle }) => {
       } catch (err) {
         console.error('Failed to parse env from localStorage', err);
       }
-    } else {
-      console.log('📁 SavedDataFramesPanel looking in MinIO root');
     }
     fetch(`${VALIDATE_API}/list_saved_dataframes${query}`, { credentials: 'include' })
       .then(res => res.json())
-      .then(data => setFiles(Array.isArray(data.files) ? data.files : []))
+      .then(data => {
+        setPrefix(data.prefix || '');
+        console.log(
+          `📁 SavedDataFramesPanel looking in MinIO bucket "${data.bucket}" folder "${data.prefix}"`
+        );
+        setFiles(Array.isArray(data.files) ? data.files : []);
+      })
       .catch(err => {
         console.error('Failed to load saved dataframes', err);
         setFiles([]);

--- a/TrinityFrontend/src/components/LaboratoryMode/components/SavedDataFramesPanel.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/components/SavedDataFramesPanel.tsx
@@ -104,7 +104,7 @@ const SavedDataFramesPanel: React.FC<Props> = ({ isOpen, onToggle }) => {
   };
 
   const buildTree = (frames: Frame[], pref: string): TreeNode[] => {
-    const root: any = {};
+    const root: any = { children: {} };
     frames.forEach(f => {
       const rel = f.object_name.startsWith(pref)
         ? f.object_name.slice(pref.length)
@@ -114,7 +114,6 @@ const SavedDataFramesPanel: React.FC<Props> = ({ isOpen, onToggle }) => {
       let currentPath = pref;
       parts.forEach((part, idx) => {
         currentPath += part + (idx < parts.length - 1 ? '/' : '');
-        node.children = node.children || {};
         if (!node.children[part]) {
           node.children[part] = { name: part, path: currentPath, children: {} };
         }
@@ -131,7 +130,7 @@ const SavedDataFramesPanel: React.FC<Props> = ({ isOpen, onToggle }) => {
         frame: c.frame,
         children: toArr(c)
       }));
-    return toArr({ children: root });
+    return toArr(root);
   };
 
   const tree = buildTree(files, prefix);

--- a/TrinityFrontend/src/components/LaboratoryMode/components/SavedDataFramesPanel.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/components/SavedDataFramesPanel.tsx
@@ -31,7 +31,9 @@ const SavedDataFramesPanel: React.FC<Props> = ({ isOpen, onToggle }) => {
     if (envStr) {
       try {
         const env = JSON.parse(envStr);
-        setPrefix(`${env.CLIENT_NAME}/${env.APP_NAME}/${env.PROJECT_NAME}/`);
+        const pref = `${env.CLIENT_NAME}/${env.APP_NAME}/${env.PROJECT_NAME}/`;
+        setPrefix(pref);
+        console.log('📁 SavedDataFramesPanel looking in MinIO:', pref);
         query =
           '?' +
           new URLSearchParams({
@@ -39,14 +41,19 @@ const SavedDataFramesPanel: React.FC<Props> = ({ isOpen, onToggle }) => {
             app_name: env.APP_NAME || '',
             project_name: env.PROJECT_NAME || ''
           }).toString();
-      } catch {
-        /* ignore */
+      } catch (err) {
+        console.error('Failed to parse env from localStorage', err);
       }
+    } else {
+      console.log('📁 SavedDataFramesPanel looking in MinIO root');
     }
-    fetch(`${VALIDATE_API}/list_saved_dataframes${query}`)
+    fetch(`${VALIDATE_API}/list_saved_dataframes${query}`, { credentials: 'include' })
       .then(res => res.json())
       .then(data => setFiles(Array.isArray(data.files) ? data.files : []))
-      .catch(() => setFiles([]));
+      .catch(err => {
+        console.error('Failed to load saved dataframes', err);
+        setFiles([]);
+      });
   }, [isOpen]);
 
   const handleOpen = (obj: string) => {

--- a/TrinityFrontend/src/components/LaboratoryMode/components/SavedDataFramesPanel.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/components/SavedDataFramesPanel.tsx
@@ -26,28 +26,12 @@ const SavedDataFramesPanel: React.FC<Props> = ({ isOpen, onToggle }) => {
 
   useEffect(() => {
     if (!isOpen) return;
-    let query = '';
-    const envStr = localStorage.getItem('env');
-    if (envStr) {
-      try {
-        const env = JSON.parse(envStr);
-        query =
-          '?' +
-          new URLSearchParams({
-            client_name: env.CLIENT_NAME || '',
-            app_name: env.APP_NAME || '',
-            project_name: env.PROJECT_NAME || ''
-          }).toString();
-      } catch (err) {
-        console.error('Failed to parse env from localStorage', err);
-      }
-    }
-    fetch(`${VALIDATE_API}/list_saved_dataframes${query}`, { credentials: 'include' })
+    fetch(`${VALIDATE_API}/list_saved_dataframes`, { credentials: 'include' })
       .then(res => res.json())
       .then(data => {
         setPrefix(data.prefix || '');
         console.log(
-          `📁 SavedDataFramesPanel looking in MinIO bucket "${data.bucket}" folder "${data.prefix}"`
+          `📁 SavedDataFramesPanel looking in MinIO bucket "${data.bucket}" folder "${data.prefix}" (CLIENT_NAME=${data.environment?.CLIENT_NAME} APP_NAME=${data.environment?.APP_NAME} PROJECT_NAME=${data.environment?.PROJECT_NAME})`
         );
         setFiles(Array.isArray(data.files) ? data.files : []);
       })


### PR DESCRIPTION
## Summary
- list every object under a client's project prefix in `list_saved_dataframes`

## Testing
- `pytest tests/test_arrow_flight.py::test_list_saved_dataframes_env -q`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68905a1f716083218fe453ef51156e8b