### PR TITLE
fix: refresh env after project rename

### DIFF
--- a/TrinityBackendDjango/apps/registry/migrations/0010_registryenvironment.py
+++ b/TrinityBackendDjango/apps/registry/migrations/0010_registryenvironment.py
@@ -1,0 +1,29 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("registry", "0009_project_unique"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="RegistryEnvironment",
+            fields=[
+                ("id", models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("client_name", models.CharField(max_length=255)),
+                ("app_name", models.CharField(max_length=255)),
+                ("project_name", models.CharField(max_length=255)),
+                ("envvars", models.JSONField(blank=True, default=dict)),
+                ("identifiers", models.JSONField(blank=True, default=list)),
+                ("measures", models.JSONField(blank=True, default=list)),
+                ("dimensions", models.JSONField(blank=True, default=dict)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+            ],
+            options={
+                "db_table": "registry_environment",
+                "unique_together": {("client_name", "app_name", "project_name")},
+            },
+        ),
+    ]

--- a/TrinityBackendDjango/apps/registry/models.py
+++ b/TrinityBackendDjango/apps/registry/models.py
@@ -120,3 +120,29 @@ class ArrowDataset(models.Model):
 
     def __str__(self):
         return f"{self.atom_id}:{self.file_key}"
+
+
+class RegistryEnvironment(models.Model):
+    """Cached environment and schema configuration per project.
+
+    The table stores the resolved client/app/project names alongside any
+    additional environment variables or column classification data. It lives
+    in each tenant's schema so lookups remain local to the tenant database.
+    """
+
+    client_name = models.CharField(max_length=255)
+    app_name = models.CharField(max_length=255)
+    project_name = models.CharField(max_length=255)
+    envvars = models.JSONField(default=dict, blank=True)
+    identifiers = models.JSONField(default=list, blank=True)
+    measures = models.JSONField(default=list, blank=True)
+    dimensions = models.JSONField(default=dict, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        db_table = "registry_environment"
+        unique_together = ("client_name", "app_name", "project_name")
+
+    def __str__(self):
+        return f"{self.client_name}/{self.app_name}/{self.project_name}"

--- a/TrinityBackendDjango/apps/registry/signals.py
+++ b/TrinityBackendDjango/apps/registry/signals.py
@@ -20,11 +20,28 @@ def _current_tenant_name() -> str:
 @receiver(post_save, sender=Project)
 def create_project_folder(sender, instance, created, **kwargs):
     if created:
-        tenant = _current_tenant_name()
+        tenant = os.getenv("CLIENT_NAME", _current_tenant_name())
         app_slug = instance.app.slug
         project_name = instance.name
         prefix = f"{tenant}/{app_slug}/{project_name}"
         create_prefix(prefix)
+        envvars = {
+            "CLIENT_NAME": tenant,
+            "APP_NAME": app_slug,
+            "PROJECT_NAME": project_name,
+            "PROJECT_ID": f"{project_name}_{instance.pk}",
+        }
+        RegistryEnvironment.objects.update_or_create(
+            client_name=tenant,
+            app_name=app_slug,
+            project_name=project_name,
+            defaults={
+                "envvars": envvars,
+                "identifiers": [],
+                "measures": [],
+                "dimensions": {},
+            },
+        )
 
 
 @receiver(pre_save, sender=Project)
@@ -75,14 +92,41 @@ def update_env_vars_on_rename(sender, instance, **kwargs):
             print(
                 f"♻️ Redis env updated for user {entry['user_id']} to {instance.name}"
             )
-            RegistryEnvironment.objects.filter(
+            reg_obj = RegistryEnvironment.objects.filter(
                 client_name=entry["client_name"],
                 app_name=entry["app_name"],
                 project_name=entry["project_name"],
-            ).update(project_name=instance.name)
-            print(
-                f"🗃️ RegistryEnvironment updated for {entry['client_name']}/{entry['app_name']} -> {instance.name}"
-            )
+            ).first()
+            if reg_obj:
+                reg_obj.project_name = instance.name
+                env = reg_obj.envvars or {}
+                env.update(
+                    {
+                        "CLIENT_NAME": entry["client_name"],
+                        "APP_NAME": entry["app_name"],
+                        "PROJECT_NAME": instance.name,
+                        "PROJECT_ID": new_pid,
+                    }
+                )
+                reg_obj.envvars = env
+                reg_obj.save(update_fields=["project_name", "envvars"])
+                print(
+                    f"🗃️ RegistryEnvironment updated for {entry['client_name']}/{entry['app_name']} -> {instance.name}"
+                )
+            else:
+                RegistryEnvironment.objects.update_or_create(
+                    client_name=entry["client_name"],
+                    app_name=entry["app_name"],
+                    project_name=instance.name,
+                    defaults={
+                        "envvars": {
+                            "CLIENT_NAME": entry["client_name"],
+                            "APP_NAME": entry["app_name"],
+                            "PROJECT_NAME": instance.name,
+                            "PROJECT_ID": new_pid,
+                        }
+                    },
+                )
             try:
                 mc = MongoClient(
                     getattr(settings, "MONGO_URI", "mongodb://mongo:27017/trinity"),

--- a/TrinityBackendDjango/apps/registry/signals.py
+++ b/TrinityBackendDjango/apps/registry/signals.py
@@ -5,7 +5,7 @@ from django.utils.text import slugify
 from .models import Project
 from common.minio_utils import create_prefix, rename_project_folder
 from apps.accounts.models import UserEnvironmentVariable
-from redis_store.env_cache import invalidate_env
+from redis_store.env_cache import invalidate_env, set_current_env
 
 
 def _current_tenant_name() -> str:
@@ -58,6 +58,15 @@ def update_env_vars_on_rename(sender, instance, **kwargs):
                 client_name=entry["client_name"],
                 app_name=entry["app_name"],
                 project_name=entry["project_name"],
+            )
+            set_current_env(
+                str(entry["user_id"]),
+                client_id=entry["client_id"],
+                app_id=entry["app_id"],
+                project_id=new_pid,
+                client_name=entry["client_name"],
+                app_name=entry["app_name"],
+                project_name=instance.name,
             )
         tenant = _current_tenant_name()
         app_slug = instance.app.slug

--- a/TrinityBackendFastAPI/app/core/utils.py
+++ b/TrinityBackendFastAPI/app/core/utils.py
@@ -125,9 +125,13 @@ async def _query_registry_env(
         )
         if row:
             env = dict(row["envvars"] or {})
-            env.setdefault("CLIENT_NAME", client_name)
-            env.setdefault("APP_NAME", app_name)
-            env.setdefault("PROJECT_NAME", project_name)
+            env.update(
+                {
+                    "CLIENT_NAME": client_name,
+                    "APP_NAME": app_name,
+                    "PROJECT_NAME": project_name,
+                }
+            )
             if row.get("identifiers") is not None:
                 env["identifiers"] = row["identifiers"]
             if row.get("measures") is not None:

--- a/TrinityBackendFastAPI/app/core/utils.py
+++ b/TrinityBackendFastAPI/app/core/utils.py
@@ -222,11 +222,21 @@ async def get_env_vars(
                 client_db, app_db, project_db = await fetch_client_app_project(
                     None, numeric_pid
                 )
-                env = {
-                    "CLIENT_NAME": client_db,
-                    "APP_NAME": app_db,
-                    "PROJECT_NAME": project_db,
-                }
+                # Fetch the authoritative environment row using the resolved
+                # names so renames are reflected immediately.
+                reg_env = await _query_registry_env(
+                    client_db or "",
+                    app_db or "",
+                    project_db or "",
+                )
+                if reg_env:
+                    env = reg_env
+                else:
+                    env = {
+                        "CLIENT_NAME": client_db,
+                        "APP_NAME": app_db,
+                        "PROJECT_NAME": project_db,
+                    }
                 source = "postgres"
             except Exception:
                 env = {

--- a/TrinityFrontend/src/components/LaboratoryMode/components/SavedDataFramesPanel.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/components/SavedDataFramesPanel.tsx
@@ -31,7 +31,7 @@ const SavedDataFramesPanel: React.FC<Props> = ({ isOpen, onToggle }) => {
       .then(data => {
         setPrefix(data.prefix || '');
         console.log(
-          `📁 SavedDataFramesPanel looking in MinIO bucket "${data.bucket}" folder "${data.prefix}" (CLIENT_NAME=${data.environment?.CLIENT_NAME} APP_NAME=${data.environment?.APP_NAME} PROJECT_NAME=${data.environment?.PROJECT_NAME})`
+          `📁 SavedDataFramesPanel looking in MinIO bucket "${data.bucket}" folder "${data.prefix}" via ${data.env_source} (CLIENT_NAME=${data.environment?.CLIENT_NAME} APP_NAME=${data.environment?.APP_NAME} PROJECT_NAME=${data.environment?.PROJECT_NAME})`
         );
         setFiles(Array.isArray(data.files) ? data.files : []);
       })

--- a/TrinityFrontend/src/components/PrimaryMenu/AppIdentity/AppIdentity.tsx
+++ b/TrinityFrontend/src/components/PrimaryMenu/AppIdentity/AppIdentity.tsx
@@ -42,7 +42,7 @@ const AppIdentity: React.FC<AppIdentityProps> = ({ projectName, onGoBack, onRena
             if (envRes.ok) {
               const envData = await envRes.json();
               if (envData.environment) {
-                console.log('Environment after project rename', envData.environment);
+                console.log('Environment after project rename', envData.environment, 'source', envData.env_source);
                 localStorage.setItem('env', JSON.stringify(envData.environment));
               }
             }

--- a/TrinityFrontend/src/pages/Projects.tsx
+++ b/TrinityFrontend/src/pages/Projects.tsx
@@ -275,7 +275,7 @@ const Projects = () => {
           if (envRes.ok) {
             const envData = await envRes.json();
             if (envData.environment) {
-              console.log('Environment after project rename', envData.environment);
+              console.log('Environment after project rename', envData.environment, 'source', envData.env_source);
               localStorage.setItem('env', JSON.stringify(envData.environment));
             }
           }

--- a/TrinityFrontend/src/pages/Projects.tsx
+++ b/TrinityFrontend/src/pages/Projects.tsx
@@ -268,6 +268,20 @@ const Projects = () => {
               : p
           )
         );
+
+        // Update localStorage so other panels see the new project name
+        const stored = localStorage.getItem('current-project');
+        if (stored) {
+          try {
+            const obj = JSON.parse(stored);
+            if (obj && obj.id === updated.id) {
+              localStorage.setItem('current-project', JSON.stringify(updated));
+            }
+          } catch {
+            /* ignore */
+          }
+        }
+
         try {
           const envRes = await fetch(`${REGISTRY_API}/projects/${updated.id}/`, {
             credentials: 'include'


### PR DESCRIPTION
## Summary
- keep user env cache in sync when renaming projects
- resolve env vars by numeric project id if name-based lookups fail

## Testing
- `pytest TrinityBackendFastAPI/tests/test_arrow_flight.py::test_list_saved_dataframes_env -q`
- `pytest TrinityBackendFastAPI/tests/test_session_state.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6890c52de8f4832182aae50bb30b0ceb