### PR TITLE
fix: refresh project env for saved dataframes

### DIFF
--- a/TrinityFrontend/src/components/LaboratoryMode/components/SavedDataFramesPanel.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/components/SavedDataFramesPanel.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Database, ChevronRight, ChevronDown, Trash2, Pencil } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { VALIDATE_API } from '@/lib/api';
+import { VALIDATE_API, REGISTRY_API } from '@/lib/api';
 
 interface Props {
   isOpen: boolean;
@@ -26,19 +26,66 @@ const SavedDataFramesPanel: React.FC<Props> = ({ isOpen, onToggle }) => {
 
   useEffect(() => {
     if (!isOpen) return;
-    fetch(`${VALIDATE_API}/list_saved_dataframes`, { credentials: 'include' })
-      .then(res => res.json())
-      .then(data => {
+    const load = async () => {
+      let env: any = null;
+      let query = '';
+      const envStr = localStorage.getItem('env');
+      if (envStr) {
+        try {
+          env = JSON.parse(envStr);
+        } catch {
+          /* ignore */
+        }
+      }
+      if (!env) {
+        try {
+          const projStr = localStorage.getItem('current-project');
+          if (projStr) {
+            const proj = JSON.parse(projStr);
+            const res = await fetch(`${REGISTRY_API}/projects/${proj.id}/`, {
+              credentials: 'include'
+            });
+            if (res.ok) {
+              const envData = await res.json();
+              if (envData.environment) {
+                env = envData.environment;
+                localStorage.setItem('env', JSON.stringify(env));
+              }
+            }
+          }
+        } catch (err) {
+          console.log('env fetch error', err);
+        }
+      }
+      if (env) {
+        query =
+          '?' +
+          new URLSearchParams({
+            client_id: env.CLIENT_ID || '',
+            app_id: env.APP_ID || '',
+            project_id: env.PROJECT_ID || '',
+            client_name: env.CLIENT_NAME || '',
+            app_name: env.APP_NAME || '',
+            project_name: env.PROJECT_NAME || ''
+          }).toString();
+      }
+
+      try {
+        const res = await fetch(`${VALIDATE_API}/list_saved_dataframes${query}`, {
+          credentials: 'include'
+        });
+        const data = await res.json();
         setPrefix(data.prefix || '');
         console.log(
           `📁 SavedDataFramesPanel looking in MinIO bucket "${data.bucket}" folder "${data.prefix}" via ${data.env_source} (CLIENT_NAME=${data.environment?.CLIENT_NAME} APP_NAME=${data.environment?.APP_NAME} PROJECT_NAME=${data.environment?.PROJECT_NAME})`
         );
         setFiles(Array.isArray(data.files) ? data.files : []);
-      })
-      .catch(err => {
+      } catch (err) {
         console.error('Failed to load saved dataframes', err);
         setFiles([]);
-      });
+      }
+    };
+    load();
   }, [isOpen]);
 
   const handleOpen = (obj: string) => {


### PR DESCRIPTION
## Summary
- ensure SavedDataFramesPanel pulls current project info before listing dataframes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render)*

------
https://chatgpt.com/codex/tasks/task_e_6891a1186f5883219047d9ad31f24e1b