### PR TITLE
feat: expand tenant and role management

### DIFF
--- a/TrinityBackendDjango/apps/accounts/apps.py
+++ b/TrinityBackendDjango/apps/accounts/apps.py
@@ -5,3 +5,6 @@ class AccountsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "apps.accounts"
     verbose_name = "User Accounts"
+
+    def ready(self):
+        from . import signals  # noqa: F401

--- a/TrinityBackendDjango/apps/accounts/serializers.py
+++ b/TrinityBackendDjango/apps/accounts/serializers.py
@@ -6,6 +6,9 @@ class UserSerializer(serializers.ModelSerializer):
     """Serializer for the custom User model with password handling."""
 
     password = serializers.CharField(write_only=True, required=False)
+    allowed_apps = serializers.ListField(
+        child=serializers.IntegerField(), write_only=True, required=False, default=list
+    )
 
     class Meta:
         model = User
@@ -19,12 +22,16 @@ class UserSerializer(serializers.ModelSerializer):
             "mfa_enabled",
             "preferences",
             "is_staff",
+            "allowed_apps",
         ]
         read_only_fields = ["id", "is_staff"]
 
     def create(self, validated_data):
         password = validated_data.pop("password", None)
+        allowed_apps = validated_data.pop("allowed_apps", None)
         user = User(**validated_data)
+        if allowed_apps is not None:
+            user._allowed_apps = allowed_apps
         if password:
             user.set_password(password)
         else:

--- a/TrinityBackendDjango/apps/accounts/signals.py
+++ b/TrinityBackendDjango/apps/accounts/signals.py
@@ -26,10 +26,11 @@ def create_userrole_and_increment(sender, instance, created, **kwargs):
             UserRole.objects.create(
                 user=instance,
                 client_id=uuid.uuid4(),
+                client_name=tenant.name,
+                email=instance.email,
                 app_id=uuid.uuid4(),
-                project_id=uuid.uuid4(),
                 role=UserRole.ROLE_VIEWER,
-                allowed_apps=tenant.allowed_apps,
+                allowed_apps=getattr(instance, "_allowed_apps", tenant.allowed_apps),
             )
     except Exception:
         pass

--- a/TrinityBackendDjango/apps/accounts/signals.py
+++ b/TrinityBackendDjango/apps/accounts/signals.py
@@ -1,0 +1,48 @@
+from django.db.models.signals import post_save, post_delete
+from django.dispatch import receiver
+from django.conf import settings
+from django.db import connection, models
+from django_tenants.utils import get_tenant_model
+import uuid
+
+from apps.roles.models import UserRole
+
+
+@receiver(post_save, sender=settings.AUTH_USER_MODEL)
+def create_userrole_and_increment(sender, instance, created, **kwargs):
+    if not created:
+        return
+    schema = connection.schema_name
+    if schema == "public":
+        return
+    Tenant = get_tenant_model()
+    try:
+        tenant = Tenant.objects.get(schema_name=schema)
+    except Tenant.DoesNotExist:
+        return
+    Tenant.objects.filter(id=tenant.id).update(users_in_use=models.F("users_in_use") + 1)
+    try:
+        if not UserRole.objects.filter(user=instance).exists():
+            UserRole.objects.create(
+                user=instance,
+                client_id=uuid.uuid4(),
+                app_id=uuid.uuid4(),
+                project_id=uuid.uuid4(),
+                role=UserRole.ROLE_VIEWER,
+                allowed_apps=tenant.allowed_apps,
+            )
+    except Exception:
+        pass
+
+
+@receiver(post_delete, sender=settings.AUTH_USER_MODEL)
+def decrement_user_count(sender, instance, **kwargs):
+    schema = connection.schema_name
+    if schema == "public":
+        return
+    Tenant = get_tenant_model()
+    try:
+        tenant = Tenant.objects.get(schema_name=schema)
+    except Tenant.DoesNotExist:
+        return
+    Tenant.objects.filter(id=tenant.id).update(users_in_use=models.F("users_in_use") - 1)

--- a/TrinityBackendDjango/apps/roles/admin.py
+++ b/TrinityBackendDjango/apps/roles/admin.py
@@ -11,6 +11,12 @@ class RoleDefinitionAdmin(admin.ModelAdmin):
 
 @admin.register(UserRole)
 class UserRoleAdmin(admin.ModelAdmin):
-    list_display = ("user", "role", "client_id", "app_id", "project_id")
+    list_display = ("user", "email", "client_name", "role", "client_id", "app_id")
     list_filter = ("role",)
-    search_fields = ("user__username", "client_id", "app_id", "project_id")
+    search_fields = (
+        "user__username",
+        "email",
+        "client_name",
+        "client_id",
+        "app_id",
+    )

--- a/TrinityBackendDjango/apps/roles/migrations/0003_userrole_allowed_apps.py
+++ b/TrinityBackendDjango/apps/roles/migrations/0003_userrole_allowed_apps.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("roles", "0002_userrole"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="userrole",
+            name="allowed_apps",
+            field=models.JSONField(default=list, blank=True),
+        ),
+    ]

--- a/TrinityBackendDjango/apps/roles/migrations/0004_seed_role_definitions.py
+++ b/TrinityBackendDjango/apps/roles/migrations/0004_seed_role_definitions.py
@@ -1,0 +1,40 @@
+from django.db import migrations
+from django.contrib.auth.models import Group, Permission
+
+
+def seed_roles(apps, schema_editor):
+    RoleDefinition = apps.get_model('roles', 'RoleDefinition')
+    # Create groups
+    admin_group, _ = Group.objects.get_or_create(name='admin')
+    editor_group, _ = Group.objects.get_or_create(name='editor')
+    viewer_group, _ = Group.objects.get_or_create(name='viewer')
+
+    # Assign basic permissions
+    all_perms = Permission.objects.all()
+    view_perms = Permission.objects.filter(codename__startswith='view_')
+    edit_perms = Permission.objects.filter(codename__startswith=('view_', 'add_', 'change_'))
+
+    admin_group.permissions.set(all_perms)
+    editor_group.permissions.set(edit_perms)
+    viewer_group.permissions.set(view_perms)
+
+    RoleDefinition.objects.get_or_create(name='admin', defaults={'group': admin_group})
+    RoleDefinition.objects.get_or_create(name='editor', defaults={'group': editor_group})
+    RoleDefinition.objects.get_or_create(name='viewer', defaults={'group': viewer_group})
+
+
+def unseed_roles(apps, schema_editor):
+    RoleDefinition = apps.get_model('roles', 'RoleDefinition')
+    RoleDefinition.objects.filter(name__in=['admin','editor','viewer']).delete()
+    Group = apps.get_model('auth', 'Group')
+    Group.objects.filter(name__in=['admin','editor','viewer']).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("roles", "0003_userrole_allowed_apps"),
+    ]
+
+    operations = [
+        migrations.RunPython(seed_roles, reverse_code=unseed_roles),
+    ]

--- a/TrinityBackendDjango/apps/roles/migrations/0004_seed_role_definitions.py
+++ b/TrinityBackendDjango/apps/roles/migrations/0004_seed_role_definitions.py
@@ -1,33 +1,40 @@
 from django.db import migrations
-from django.contrib.auth.models import Group, Permission
 
 
 def seed_roles(apps, schema_editor):
-    RoleDefinition = apps.get_model('roles', 'RoleDefinition')
+    RoleDefinition = apps.get_model("roles", "RoleDefinition")
+    Group = apps.get_model("auth", "Group")
+    Permission = apps.get_model("auth", "Permission")
+    from django.db.models import Q
+
     # Create groups
-    admin_group, _ = Group.objects.get_or_create(name='admin')
-    editor_group, _ = Group.objects.get_or_create(name='editor')
-    viewer_group, _ = Group.objects.get_or_create(name='viewer')
+    admin_group, _ = Group.objects.get_or_create(name="admin")
+    editor_group, _ = Group.objects.get_or_create(name="editor")
+    viewer_group, _ = Group.objects.get_or_create(name="viewer")
 
     # Assign basic permissions
     all_perms = Permission.objects.all()
-    view_perms = Permission.objects.filter(codename__startswith='view_')
-    edit_perms = Permission.objects.filter(codename__startswith=('view_', 'add_', 'change_'))
+    view_perms = Permission.objects.filter(codename__startswith="view_")
+    edit_perms = Permission.objects.filter(
+        Q(codename__startswith="view_")
+        | Q(codename__startswith="add_")
+        | Q(codename__startswith="change_")
+    )
 
     admin_group.permissions.set(all_perms)
     editor_group.permissions.set(edit_perms)
     viewer_group.permissions.set(view_perms)
 
-    RoleDefinition.objects.get_or_create(name='admin', defaults={'group': admin_group})
-    RoleDefinition.objects.get_or_create(name='editor', defaults={'group': editor_group})
-    RoleDefinition.objects.get_or_create(name='viewer', defaults={'group': viewer_group})
+    RoleDefinition.objects.get_or_create(name="admin", defaults={"group": admin_group})
+    RoleDefinition.objects.get_or_create(name="editor", defaults={"group": editor_group})
+    RoleDefinition.objects.get_or_create(name="viewer", defaults={"group": viewer_group})
 
 
 def unseed_roles(apps, schema_editor):
-    RoleDefinition = apps.get_model('roles', 'RoleDefinition')
-    RoleDefinition.objects.filter(name__in=['admin','editor','viewer']).delete()
-    Group = apps.get_model('auth', 'Group')
-    Group.objects.filter(name__in=['admin','editor','viewer']).delete()
+    RoleDefinition = apps.get_model("roles", "RoleDefinition")
+    RoleDefinition.objects.filter(name__in=["admin", "editor", "viewer"]).delete()
+    Group = apps.get_model("auth", "Group")
+    Group.objects.filter(name__in=["admin", "editor", "viewer"]).delete()
 
 
 class Migration(migrations.Migration):

--- a/TrinityBackendDjango/apps/roles/migrations/0005_userrole_client_fields.py
+++ b/TrinityBackendDjango/apps/roles/migrations/0005_userrole_client_fields.py
@@ -1,0 +1,28 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("roles", "0004_seed_role_definitions"),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name="userrole",
+            name="project_id",
+        ),
+        migrations.AddField(
+            model_name="userrole",
+            name="client_name",
+            field=models.CharField(max_length=255, blank=True),
+        ),
+        migrations.AddField(
+            model_name="userrole",
+            name="email",
+            field=models.EmailField(max_length=254, blank=True),
+        ),
+        migrations.AlterUniqueTogether(
+            name="userrole",
+            unique_together={("user", "client_id", "app_id")},
+        ),
+    ]

--- a/TrinityBackendDjango/apps/roles/models.py
+++ b/TrinityBackendDjango/apps/roles/models.py
@@ -32,7 +32,7 @@ class RoleDefinition(models.Model):
 
 
 class UserRole(models.Model):
-    """Assign a role to a user for a specific client/app/project."""
+    """Assign a role to a user for a specific client and app."""
 
     ROLE_ADMIN = "admin"
     ROLE_EDITOR = "editor"
@@ -52,8 +52,9 @@ class UserRole(models.Model):
         related_name="role_assignments",
     )
     client_id = models.UUIDField()
+    client_name = models.CharField(max_length=255, blank=True)
+    email = models.EmailField(blank=True)
     app_id = models.UUIDField()
-    project_id = models.UUIDField()
     role = models.CharField(max_length=20, choices=ROLE_CHOICES)
     allowed_apps = models.JSONField(
         default=list,
@@ -64,7 +65,7 @@ class UserRole(models.Model):
     updated_at = models.DateTimeField(auto_now=True)
 
     class Meta:
-        unique_together = ("user", "client_id", "app_id", "project_id")
+        unique_together = ("user", "client_id", "app_id")
         verbose_name = "User Role"
         verbose_name_plural = "User Roles"
 

--- a/TrinityBackendDjango/apps/roles/models.py
+++ b/TrinityBackendDjango/apps/roles/models.py
@@ -55,6 +55,11 @@ class UserRole(models.Model):
     app_id = models.UUIDField()
     project_id = models.UUIDField()
     role = models.CharField(max_length=20, choices=ROLE_CHOICES)
+    allowed_apps = models.JSONField(
+        default=list,
+        blank=True,
+        help_text="Apps the user is permitted to access",
+    )
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 

--- a/TrinityBackendDjango/apps/tenants/migrations/0003_add_management_fields.py
+++ b/TrinityBackendDjango/apps/tenants/migrations/0003_add_management_fields.py
@@ -1,0 +1,40 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("tenants", "0002_alter_domain_domain_alter_domain_is_primary_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="tenant",
+            name="primary_domain",
+            field=models.CharField(max_length=253, blank=True),
+        ),
+        migrations.AddField(
+            model_name="tenant",
+            name="allowed_apps",
+            field=models.JSONField(default=list, blank=True),
+        ),
+        migrations.AddField(
+            model_name="tenant",
+            name="seats_allowed",
+            field=models.PositiveIntegerField(default=0),
+        ),
+        migrations.AddField(
+            model_name="tenant",
+            name="users_in_use",
+            field=models.PositiveIntegerField(default=0),
+        ),
+        migrations.AddField(
+            model_name="tenant",
+            name="project_cap",
+            field=models.PositiveIntegerField(default=0),
+        ),
+        migrations.AddField(
+            model_name="tenant",
+            name="projects_allowed",
+            field=models.JSONField(default=list, blank=True),
+        ),
+    ]

--- a/TrinityBackendDjango/apps/tenants/migrations/0004_add_admin_contact.py
+++ b/TrinityBackendDjango/apps/tenants/migrations/0004_add_admin_contact.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("tenants", "0003_add_management_fields"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="tenant",
+            name="admin_name",
+            field=models.CharField(max_length=255, blank=True),
+        ),
+        migrations.AddField(
+            model_name="tenant",
+            name="admin_email",
+            field=models.EmailField(max_length=254, blank=True),
+        ),
+    ]

--- a/TrinityBackendDjango/apps/tenants/models.py
+++ b/TrinityBackendDjango/apps/tenants/models.py
@@ -7,6 +7,14 @@ class Tenant(TenantMixin):
 
     name = models.CharField(max_length=255, unique=True)
     created_on = models.DateField(auto_now_add=True)
+    primary_domain = models.CharField(max_length=253, blank=True)
+    allowed_apps = models.JSONField(default=list, blank=True)
+    seats_allowed = models.PositiveIntegerField(default=0)
+    users_in_use = models.PositiveIntegerField(default=0)
+    project_cap = models.PositiveIntegerField(default=0)
+    projects_allowed = models.JSONField(default=list, blank=True)
+    admin_name = models.CharField(max_length=255, blank=True)
+    admin_email = models.EmailField(blank=True)
 
     auto_create_schema = True
 

--- a/TrinityBackendDjango/apps/tenants/serializers.py
+++ b/TrinityBackendDjango/apps/tenants/serializers.py
@@ -126,7 +126,10 @@ class TenantSerializer(serializers.ModelSerializer):
                 password=admin_password,
             )
             UserRole.objects.filter(user=admin_user).update(
-                role=UserRole.ROLE_ADMIN, allowed_apps=tenant.allowed_apps
+                role=UserRole.ROLE_ADMIN,
+                allowed_apps=tenant.allowed_apps,
+                client_name=tenant.name,
+                email=validated_data["admin_email"],
             )
 
         print("Tenant creation complete")

--- a/TrinityBackendDjango/apps/tenants/serializers.py
+++ b/TrinityBackendDjango/apps/tenants/serializers.py
@@ -1,24 +1,25 @@
 from rest_framework import serializers
-from django.utils import timezone
 from django_tenants.utils import schema_context
 from django.core.management import call_command
 from django.db import transaction, connection
-from common.minio_utils import create_prefix
 import os
 import re
 from .models import Tenant, Domain
-from apps.subscriptions.models import Company, SubscriptionPlan
-from apps.config_store.models import TenantConfig
 from apps.registry.models import App
 
 
 class TenantSerializer(serializers.ModelSerializer):
-    domain = serializers.CharField(write_only=True, required=False)
-    seats_allowed = serializers.IntegerField(write_only=True, required=False)
-    project_cap = serializers.IntegerField(write_only=True, required=False)
-    apps_allowed = serializers.ListField(
-        child=serializers.IntegerField(), write_only=True, required=False
+    primary_domain = serializers.CharField(required=False, allow_blank=True)
+    allowed_apps = serializers.ListField(
+        child=serializers.IntegerField(), required=False
     )
+    projects_allowed = serializers.ListField(
+        child=serializers.CharField(), required=False
+    )
+    users_in_use = serializers.IntegerField(read_only=True)
+    admin_name = serializers.CharField()
+    admin_email = serializers.EmailField()
+    admin_password = serializers.CharField(write_only=True)
 
     class Meta:
         model = Tenant
@@ -27,12 +28,17 @@ class TenantSerializer(serializers.ModelSerializer):
             "name",
             "schema_name",
             "created_on",
-            "domain",
+            "primary_domain",
             "seats_allowed",
             "project_cap",
-            "apps_allowed",
+            "allowed_apps",
+            "projects_allowed",
+            "users_in_use",
+            "admin_name",
+            "admin_email",
+            "admin_password",
         ]
-        read_only_fields = ["id", "created_on"]
+        read_only_fields = ["id", "created_on", "users_in_use"]
 
     def create(self, validated_data):
         """Create a new tenant using the same steps as create_tenant.py."""
@@ -46,10 +52,10 @@ class TenantSerializer(serializers.ModelSerializer):
         except Exception:
             pass
 
-        domain = validated_data.pop("domain", None)
-        seats = validated_data.pop("seats_allowed", None)
-        project_cap = validated_data.pop("project_cap", None)
-        apps_allowed = validated_data.pop("apps_allowed", None)
+        domain = validated_data.pop("primary_domain", "")
+        allowed_apps = validated_data.pop("allowed_apps", [])
+        projects_allowed = validated_data.pop("projects_allowed", [])
+        admin_password = validated_data.pop("admin_password")
 
         schema = (
             validated_data.get("schema_name", "")
@@ -62,21 +68,22 @@ class TenantSerializer(serializers.ModelSerializer):
         validated_data["schema_name"] = schema
 
         with transaction.atomic():
-            tenant = Tenant.objects.create(**validated_data)
+            tenant = Tenant.objects.create(
+                **validated_data,
+                primary_domain=domain,
+                allowed_apps=allowed_apps,
+                projects_allowed=projects_allowed,
+            )
             print("→ Created tenant", tenant)
             if domain:
                 if Domain.objects.filter(domain=domain).exists():
-                    raise serializers.ValidationError({"domain": "Domain already exists"})
-                Domain.objects.create(
-                    domain=domain,
-                    tenant=tenant,
-                    is_primary=True,
-                )
+                    raise serializers.ValidationError({"primary_domain": "Domain already exists"})
+                Domain.objects.create(domain=domain, tenant=tenant, is_primary=True)
                 print("→ Created primary domain", domain)
 
-            primary_domain = os.getenv("PRIMARY_DOMAIN", "localhost")
+            primary = os.getenv("PRIMARY_DOMAIN", "localhost")
             for alias in ("localhost", "127.0.0.1"):
-                if alias != primary_domain and alias != domain and not Domain.objects.filter(domain=alias).exists():
+                if alias != primary and alias != domain and not Domain.objects.filter(domain=alias).exists():
                     Domain.objects.create(domain=alias, tenant=tenant, is_primary=False)
 
         # Allow skipping heavy migration logic when running in simple mode
@@ -109,18 +116,18 @@ class TenantSerializer(serializers.ModelSerializer):
                 for name, slug, desc in default_apps:
                     App.objects.get_or_create(slug=slug, defaults={"name": name, "description": desc})
 
-                if seats is not None or project_cap is not None:
-                    company = Company.objects.create(tenant=tenant)
-                    SubscriptionPlan.objects.create(
-                        company=company,
-                        plan_name="Default",
-                        seats_allowed=seats or 0,
-                        project_cap=project_cap or 0,
-                        renewal_date=timezone.now().date(),
-                    )
+        with schema_context(tenant.schema_name):
+            from apps.accounts.models import User
+            from apps.roles.models import UserRole
 
-                if apps_allowed:
-                    TenantConfig.objects.create(tenant=tenant, key="apps_allowed", value=apps_allowed)
+            admin_user = User.objects.create_user(
+                username=validated_data["admin_name"],
+                email=validated_data["admin_email"],
+                password=admin_password,
+            )
+            UserRole.objects.filter(user=admin_user).update(
+                role=UserRole.ROLE_ADMIN, allowed_apps=tenant.allowed_apps
+            )
 
         print("Tenant creation complete")
         return tenant

--- a/TrinityBackendDjango/create_tenant.py
+++ b/TrinityBackendDjango/create_tenant.py
@@ -219,8 +219,9 @@ def main():
             UserRole.objects.update_or_create(
                 user=user,
                 client_id=tenant_client_id,
+                client_name=tenant_obj.name,
+                email=user.email,
                 app_id=uuid.uuid4(),
-                project_id=uuid.uuid4(),
                 defaults={"role": role, "allowed_apps": allowed_app_ids},
             )
 

--- a/TrinityBackendDjango/create_tenant.py
+++ b/TrinityBackendDjango/create_tenant.py
@@ -13,10 +13,14 @@ from apps.tenants.models import Tenant, Domain
 
 
 def main():
-    tenant_name = "Quant_Matrix_AI"
+    tenant_name = "Quant Matrix AI"
     tenant_schema = "Quant_Matrix_AI_Schema"
-    # Map localhost requests to the default tenant unless overridden
     primary_domain = os.getenv("PRIMARY_DOMAIN", "quantmatrix.ai")
+    seats_allowed = int(os.getenv("TENANT_SEATS", 20))
+    project_cap = int(os.getenv("TENANT_PROJECT_CAP", 5))
+    projects_allowed = ["Demo Project"]
+    admin_username = "neo"
+    admin_email = f"{admin_username}@{primary_domain}"
 
     print("\n→ 1) Applying SHARED (public) migrations…")
     # Run only shared apps into the public schema
@@ -32,10 +36,20 @@ def main():
     from django.contrib.auth import get_user_model
 
     User = get_user_model()
-    if not User.objects.filter(username="neo").exists():
-        User.objects.create_superuser(username="neo", password="neo_the_one", email="")
-        print("→ 1b) Created default super admin 'neo' with password 'neo_the_one'")
+    if not User.objects.filter(username=admin_username).exists():
+        User.objects.create_superuser(
+            username=admin_username,
+            password="neo_the_one",
+            email=admin_email,
+        )
+        print(
+            "→ 1b) Created default super admin 'neo' with password 'neo_the_one'"
+        )
     else:
+        user = User.objects.get(username=admin_username)
+        if user.email != admin_email:
+            user.email = admin_email
+            user.save()
         print("→ 1b) Default super admin 'neo' already exists")
 
     # Create additional users for each role. The admin, editor and viewer
@@ -45,8 +59,7 @@ def main():
     # Username for staff members uses their Quant Matrix email address
     email_domain = "quantmatrix.ai"
     role_users = [
-        ("neo", "neo_the_one", "super_admin", "", ""),
-        ("admin_user", "admin", "admin", "", ""),
+        (admin_username, "neo_the_one", "admin", "", ""),
         ("editor_user", "editor", "editor", "", ""),
         ("viewer_user", "viewer", "viewer", "", ""),
         (f"gautami.sharma@{email_domain}", "QM250111", "editor", "Gautami", "Sharma"),
@@ -59,12 +72,12 @@ def main():
         (f"rutuja.wagh@{email_domain}", "QM240104", "viewer", "Rutuja", "Wagh"),
         (f"saahil.kejriwal@{email_domain}", "QM240103", "viewer", "Saahil", "Kejriwal"),
         (f"harshadip.das@{email_domain}", "QM240102", "admin", "Harshadip", "Das"),
-        (f"venu.gorti@{email_domain}", "QM240110", "admin", "Venu", "Gorti"),
+        (f"venu.gorti@{email_domain}", "QM240101", "admin", "Venu", "Gorti"),
     ]
 
     for username, password, role, first, last in role_users:
+        is_staff = role == "admin"
         if not User.objects.filter(username=username).exists():
-            is_staff = role in ("admin", "super_admin")
             User.objects.create_user(
                 username=username,
                 password=password,
@@ -77,7 +90,7 @@ def main():
         else:
             user = User.objects.get(username=username)
             update_needed = False
-            if role in ("admin", "super_admin") and not user.is_staff:
+            if is_staff and not user.is_staff:
                 user.is_staff = True
                 update_needed = True
             if first and user.first_name != first:
@@ -89,22 +102,34 @@ def main():
             if "@" in username and user.email != username:
                 user.email = username
                 update_needed = True
+            if not user.check_password(password):
+                user.set_password(password)
+                update_needed = True
             if update_needed:
                 user.save()
             print(f"→ 1c) User '{username}' already exists")
 
     with transaction.atomic():
-        # 2a) Create (or get) the Tenant row in public
+        tenant_defaults = {
+            "name": tenant_name,
+            "primary_domain": primary_domain,
+            "seats_allowed": seats_allowed,
+            "project_cap": project_cap,
+            "projects_allowed": projects_allowed,
+            "admin_name": admin_username,
+            "admin_email": admin_email,
+        }
         tenant_obj, created = Tenant.objects.get_or_create(
-            schema_name=tenant_schema,
-            defaults={"name": tenant_name},
+            schema_name=tenant_schema, defaults={**tenant_defaults, "allowed_apps": []}
         )
         if created:
             print(f"→ 2) Created Tenant: {tenant_obj}")
         else:
-            print(f"→ 2) Tenant already existed: {tenant_obj}")
+            for field, value in tenant_defaults.items():
+                setattr(tenant_obj, field, value)
+            tenant_obj.save()
+            print(f"→ 2) Updated Tenant: {tenant_obj}")
 
-        # 2b) Create its primary Domain in public
         domain_obj, domain_created = Domain.objects.get_or_create(
             domain=primary_domain,
             tenant=tenant_obj,
@@ -173,6 +198,7 @@ def main():
         ("Blank App", "blank", "Start from an empty canvas"),
     ]
 
+    allowed_app_ids = []
     # Ensure we're operating within the tenant schema when seeding data
     with schema_context(tenant_schema):
         for name, slug, desc in default_apps:
@@ -180,29 +206,27 @@ def main():
                 slug=slug,
                 defaults={"name": name, "description": desc},
             )
+            allowed_app_ids.append(obj.id)
             if created:
                 print(f"   → Created App template '{name}'")
             else:
                 print(f"   → App template '{name}' already exists")
 
-        # Assign roles to the default users within this tenant
         from apps.roles.models import UserRole
 
         for username, _, role, *_ in role_users:
             user = User.objects.get(username=username)
-            # Admin, editor and viewer roles are tied to the Quant Matrix AI tenant
-            # so they share the same client UUID. Only the super admin user is not
-            # bound to a specific client.
-            client_uuid = (
-                tenant_client_id if username != "neo" else uuid.uuid4()
-            )
-            UserRole.objects.get_or_create(
+            UserRole.objects.update_or_create(
                 user=user,
-                client_id=client_uuid,
+                client_id=tenant_client_id,
                 app_id=uuid.uuid4(),
                 project_id=uuid.uuid4(),
-                role=role,
+                defaults={"role": role, "allowed_apps": allowed_app_ids},
             )
+
+    Tenant.objects.filter(id=tenant_obj.id).update(
+        allowed_apps=allowed_app_ids, users_in_use=len(role_users)
+    )
 
     print("All done! Tenant and all tables created.\n")
 

--- a/TrinityFrontend/src/pages/Clients.tsx
+++ b/TrinityFrontend/src/pages/Clients.tsx
@@ -38,7 +38,14 @@ interface Tenant {
   name: string;
   schema_name: string;
   created_on: string;
-  domain: string;
+  primary_domain: string;
+  seats_allowed: number;
+  project_cap: number;
+  allowed_apps: number[];
+  projects_allowed: string[];
+  users_in_use: number;
+  admin_name?: string;
+  admin_email?: string;
 }
 
 interface App {
@@ -65,10 +72,14 @@ const Clients = () => {
   const [form, setForm] = useState({
     name: '',
     schema_name: '',
-    domain: '',
+    primary_domain: '',
     seats_allowed: '',
     project_cap: '',
     apps_allowed: [] as number[],
+    projects_allowed: '',
+    admin_name: '',
+    admin_email: '',
+    admin_password: '',
   });
 
   const navigate = useNavigate();
@@ -82,25 +93,7 @@ const Clients = () => {
       if (res.ok) {
         const data = await res.json();
         console.log('Tenants data', data);
-        // fetch first domain for each tenant
-        const domainsRes = await fetch(`${TENANTS_API}/domains/`, {
-          credentials: 'include',
-        });
-        let domains: any[] = [];
-        console.log('Domains fetch status', domainsRes.status);
-        if (domainsRes.ok) {
-          domains = await domainsRes.json();
-          console.log('Domains data', domains);
-        } else {
-          console.log('Domains fetch error', await domainsRes.text());
-        }
-        setTenants(
-          data.map((t: any) => ({
-            ...t,
-            domain:
-              domains.find((d) => d.tenant === t.id && d.is_primary)?.domain || '',
-          }))
-        );
+        setTenants(data);
       }
     } catch {
       console.log('Load tenants error');
@@ -144,10 +137,17 @@ const Clients = () => {
     const payload = {
       name: form.name,
       schema_name: form.schema_name,
-      domain: form.domain,
+      primary_domain: form.primary_domain,
       seats_allowed: Number(form.seats_allowed),
       project_cap: Number(form.project_cap),
-      apps_allowed: form.apps_allowed,
+      allowed_apps: form.apps_allowed,
+      projects_allowed: form.projects_allowed
+        .split(',')
+        .map((p) => p.trim())
+        .filter((p) => p.length > 0),
+      admin_name: form.admin_name,
+      admin_email: form.admin_email,
+      admin_password: form.admin_password,
     };
     console.log('Submitting tenant payload', payload);
     try {
@@ -160,17 +160,21 @@ const Clients = () => {
       console.log('Create tenant status', res.status);
       const body = await res.text();
       console.log('Create tenant body', body);
-      if (res.ok) {
-        setForm({
-          name: '',
-          schema_name: '',
-          domain: '',
-          seats_allowed: '',
-          project_cap: '',
-          apps_allowed: [],
-        });
-        loadTenants();
-      }
+        if (res.ok) {
+          setForm({
+            name: '',
+            schema_name: '',
+            primary_domain: '',
+            seats_allowed: '',
+            project_cap: '',
+            apps_allowed: [],
+            projects_allowed: '',
+            admin_name: '',
+            admin_email: '',
+            admin_password: '',
+          });
+          loadTenants();
+        }
     } catch (err) {
       console.log('Tenant creation error', err);
     }
@@ -194,7 +198,7 @@ const Clients = () => {
 
   const filteredTenants = tenants.filter((t) =>
     t.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    t.domain.toLowerCase().includes(searchTerm.toLowerCase())
+    t.primary_domain.toLowerCase().includes(searchTerm.toLowerCase())
   );
 
   return (
@@ -263,11 +267,11 @@ const Clients = () => {
                   />
                 </div>
                 <div className="space-y-2">
-                  <Label htmlFor="domain" className="text-sm font-medium text-gray-700">Primary Domain</Label>
+                  <Label htmlFor="primary_domain" className="text-sm font-medium text-gray-700">Primary Domain</Label>
                   <Input
-                    id="domain"
-                    name="domain"
-                    value={form.domain}
+                    id="primary_domain"
+                    name="primary_domain"
+                    value={form.primary_domain}
                     onChange={handleChange}
                     placeholder="client.example.com"
                     className="border-gray-200 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
@@ -313,6 +317,56 @@ const Clients = () => {
                       </option>
                     ))}
                   </select>
+                </div>
+                <div className="space-y-2 md:col-span-2 lg:col-span-3">
+                  <Label htmlFor="projects_allowed" className="text-sm font-medium text-gray-700">Allowed Projects (comma separated)</Label>
+                  <Input
+                    id="projects_allowed"
+                    name="projects_allowed"
+                    value={form.projects_allowed}
+                    onChange={handleChange}
+                    placeholder="project1, project2"
+                    className="border-gray-200 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  />
+                </div>
+
+                <div className="space-y-2 md:col-span-2 lg:col-span-3">
+                  <h3 className="text-lg font-semibold text-gray-800">Admin User</h3>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="admin_name" className="text-sm font-medium text-gray-700">Admin Name *</Label>
+                  <Input
+                    id="admin_name"
+                    name="admin_name"
+                    value={form.admin_name}
+                    onChange={handleChange}
+                    placeholder="admin"
+                    className="border-gray-200 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="admin_email" className="text-sm font-medium text-gray-700">Admin Email *</Label>
+                  <Input
+                    id="admin_email"
+                    name="admin_email"
+                    type="email"
+                    value={form.admin_email}
+                    onChange={handleChange}
+                    placeholder="admin@example.com"
+                    className="border-gray-200 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="admin_password" className="text-sm font-medium text-gray-700">Admin Password *</Label>
+                  <Input
+                    id="admin_password"
+                    name="admin_password"
+                    type="password"
+                    value={form.admin_password}
+                    onChange={handleChange}
+                    placeholder="********"
+                    className="border-gray-200 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  />
                 </div>
 
                 <div className="md:col-span-2 lg:col-span-3 flex justify-end">
@@ -405,7 +459,7 @@ const Clients = () => {
                       <h3 className="font-semibold text-gray-900 group-hover:text-blue-600 transition-colors">
                         {client.name}
                       </h3>
-                      <p className="text-sm text-gray-500">{client.domain}</p>
+                      <p className="text-sm text-gray-500">{client.primary_domain}</p>
                     </div>
                   </div>
 
@@ -437,11 +491,21 @@ const Clients = () => {
                 <div className="space-y-3 mb-4">
                   <div className="flex items-center text-sm text-gray-600">
                     <Mail className="w-4 h-4 mr-2" />
-                    <span>{client.domain}</span>
+                    <span>{client.primary_domain}</span>
                   </div>
                   <div className="flex items-center text-sm text-gray-600">
                     <MapPin className="w-4 h-4 mr-2" />
                     <span>Schema: {client.schema_name}</span>
+                  </div>
+                  <div className="flex items-center text-sm text-gray-600">
+                    <Users className="w-4 h-4 mr-2" />
+                    <span>
+                      Users: {client.users_in_use}/{client.seats_allowed}
+                    </span>
+                  </div>
+                  <div className="flex items-center text-sm text-gray-600">
+                    <Calendar className="w-4 h-4 mr-2" />
+                    <span>Projects allowed: {client.project_cap}</span>
                   </div>
                 </div>
 

--- a/TrinityFrontend/src/pages/Clients.tsx
+++ b/TrinityFrontend/src/pages/Clients.tsx
@@ -331,10 +331,10 @@ const Clients = () => {
                 </div>
 
                 <div className="space-y-2 md:col-span-2 lg:col-span-3">
-                  <h3 className="text-lg font-semibold text-gray-800">Admin User</h3>
+                  <h3 className="text-lg font-semibold text-gray-800">Admin Details</h3>
                 </div>
                 <div className="space-y-2">
-                  <Label htmlFor="admin_name" className="text-sm font-medium text-gray-700">Admin Name *</Label>
+                  <Label htmlFor="admin_name" className="text-sm font-medium text-gray-700">Admin Username *</Label>
                   <Input
                     id="admin_name"
                     name="admin_name"

--- a/sessionStateManagement.txt
+++ b/sessionStateManagement.txt
@@ -1,0 +1,25 @@
+Session State Management Overview
+=================================
+
+User Sessions (Django backend)
+-----------------------------
+- Users authenticate via the Django API, which establishes a `sessionid` cookie.
+- Session-related endpoints live under `/api/session/` and are handled by `apps.session_state`.
+- `SessionInitView` builds a session ID in the form `session:<client_id>:<user_id>:<app_id>:<project_id>`. It loads any existing state from Redis or MongoDB, or constructs a default state with environment variables and classifier config. The result is cached in Redis for 2 hours and the namespace key is stored for lookup.
+- `SessionStateView` retrieves session state, falling back to MongoDB or reconstructing defaults if Redis is empty. It refreshes the Redis cache when state is rebuilt.
+- `SessionUpdateView` updates individual keys or navigation entries in the session state. Updates are written to Redis and persisted to MongoDB.
+- `SessionEndView` deletes the session from Redis and MongoDB.
+
+Frontend Integration
+--------------------
+- After login, the frontend saves environment data to `localStorage` and verifies a session cookie is set before considering the user authenticated.
+- Helper functions in `src/lib/session.ts` assemble the session ID and namespace from stored environment variables and the user ID.
+- `updateSessionState` sends PATCH requests to the Django session API to update keys; `addNavigationItem` specializes this for navigation; `logSessionState` fetches the full state for debugging.
+
+Project State (FastAPI backend)
+------------------------------
+- A separate project-state module in the FastAPI app manages state per client/app/project.
+- `save_state` writes the project state to Redis (TTL 1 hour), persists it via `upsert_project_state`, and stores a timestamped snapshot in MinIO.
+- `load_state` first checks Redis, then the database, and finally the latest MinIO snapshot to rebuild the state if needed.
+
+This setup provides quick session access via Redis, durability through MongoDB (for user sessions) or the application database/MinIO (for project state), and coordination with the frontend through a consistent session identifier.


### PR DESCRIPTION
## Summary
- add tenant fields for app, project, and user limits
- seed admin, editor, and viewer role definitions and track per-user app permissions
- update client management UI for new tenant attributes
- require admin user details when creating tenants and auto-provision admin roles

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891af14fb588321b26426ec36024530