### PR TITLE
Add admin details and app access controls

### DIFF
--- a/TrinityFrontend/src/pages/Clients.tsx
+++ b/TrinityFrontend/src/pages/Clients.tsx
@@ -61,10 +61,6 @@ const Clients = () => {
     role === 'super_admin' ||
     user?.is_staff ||
     user?.is_superuser;
-
-  if (!hasAccess) {
-    return <NotFound />;
-  }
   const [tenants, setTenants] = useState<Tenant[]>([]);
   const [apps, setApps] = useState<App[]>([]);
   const [searchTerm, setSearchTerm] = useState('');
@@ -116,9 +112,10 @@ const Clients = () => {
 
   useEffect(() => {
     console.log('Clients page mounted');
+    if (!hasAccess) return;
     loadTenants();
     loadApps();
-  }, []);
+  }, [hasAccess]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
     const { name, value, options } = e.target as HTMLSelectElement;
@@ -200,6 +197,10 @@ const Clients = () => {
     t.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
     t.primary_domain.toLowerCase().includes(searchTerm.toLowerCase())
   );
+
+  if (!hasAccess) {
+    return <NotFound />;
+  }
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-gray-50">
@@ -342,6 +343,7 @@ const Clients = () => {
                     onChange={handleChange}
                     placeholder="admin"
                     className="border-gray-200 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                    required
                   />
                 </div>
                 <div className="space-y-2">
@@ -354,6 +356,7 @@ const Clients = () => {
                     onChange={handleChange}
                     placeholder="admin@example.com"
                     className="border-gray-200 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                    required
                   />
                 </div>
                 <div className="space-y-2">
@@ -366,6 +369,7 @@ const Clients = () => {
                     onChange={handleChange}
                     placeholder="********"
                     className="border-gray-200 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                    required
                   />
                 </div>
 

--- a/TrinityFrontend/src/pages/Users.tsx
+++ b/TrinityFrontend/src/pages/Users.tsx
@@ -56,10 +56,6 @@ const Users = () => {
     role === 'super_admin' ||
     user?.is_staff ||
     user?.is_superuser;
-
-  if (!hasAccess) {
-    return <NotFound />;
-  }
   const [users, setUsers] = useState<User[]>([]);
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedRole, setSelectedRole] = useState<string>('All');
@@ -127,11 +123,12 @@ const Users = () => {
   };
 
   useEffect(() => {
+    if (!hasAccess) return;
     loadUsers();
     loadDomains();
     loadApps();
     loadTenantApps();
-  }, []);
+  }, [hasAccess]);
 
   const handleFormChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
@@ -162,7 +159,7 @@ const Users = () => {
         body: JSON.stringify(form),
       });
       if (res.ok) {
-        setForm({ username: '', password: '', email: '' });
+        setForm({ username: '', password: '', email: '', allowed_apps: [] });
         setShowAddForm(false);
         await loadUsers();
       }
@@ -218,6 +215,10 @@ const Users = () => {
     const matchesStatus = selectedStatus === 'All' || status === selectedStatus;
     return matchesSearch && matchesRole && matchesStatus;
   });
+
+  if (!hasAccess) {
+    return <NotFound />;
+  }
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-gray-50">


### PR DESCRIPTION
## Summary
- require admin username, email, and password when creating a new client
- allow user creation to assign only selected client apps
- cleanly reset user form after creation

## Testing
- `npm run lint` *(fails: Fast refresh only works when a file only exports components)*
- `npx eslint src/pages/Clients.tsx src/pages/Users.tsx`
- `python manage.py makemigrations` *(fails: NameResolutionError: Failed to resolve 'minio')*

------
https://chatgpt.com/codex/tasks/task_e_6891d87997608321a19370e77ed0323a