### PR TITLE
Restore atom configurations on mode load

### DIFF
--- a/TrinityBackendDjango/apps/registry/views.py
+++ b/TrinityBackendDjango/apps/registry/views.py
@@ -5,7 +5,7 @@ import os
 from apps.accounts.views import CsrfExemptSessionAuthentication
 from apps.accounts.utils import save_env_var, get_env_dict, load_env_vars
 from .models import App, Project, Session, LaboratoryAction, ArrowDataset
-from .atom_config import save_atom_list_configuration
+from .atom_config import save_atom_list_configuration, load_atom_list_configuration
 from .serializers import (
     AppSerializer,
     ProjectSerializer,
@@ -116,6 +116,19 @@ class ProjectViewSet(viewsets.ModelViewSet):
         serializer = self.get_serializer(project_obj)
         data = serializer.data
         data["environment"] = get_env_dict(request.user)
+
+        state = data.get("state") or {}
+        for field, mode in [
+            ("laboratory_config", "lab"),
+            ("workflow_config", "workflow"),
+            ("exhibition_config", "exhibition"),
+        ]:
+            cfg = load_atom_list_configuration(project_obj, mode)
+            if cfg:
+                state[field] = cfg
+        if state:
+            data["state"] = state
+
         return Response(data)
 
     def perform_update(self, serializer):

--- a/TrinityBackendDjango/tests/test_atom_config.py
+++ b/TrinityBackendDjango/tests/test_atom_config.py
@@ -1,0 +1,135 @@
+import os
+import os
+import sys
+from pathlib import Path
+import django
+
+# Configure Django settings
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "TrinityBackendDjango.config.settings")
+django.setup()
+
+from apps.registry import atom_config
+from apps.registry.atom_config import load_atom_list_configuration
+
+
+class FakeCursor(list):
+    def sort(self, *args, **kwargs):
+        return sorted(self, key=lambda d: (d.get("canvas_position", 0), d.get("atom_positions", 0)))
+
+
+class FakeCollection:
+    def __init__(self, docs):
+        self.docs = docs
+
+    def find(self, query):  # pragma: no cover - simple stub
+        return FakeCursor(self.docs.copy())
+
+
+class FakeDB:
+    def __init__(self, docs):
+        self.docs = docs
+
+    def __getitem__(self, name):  # pragma: no cover - simple stub
+        if name == "atom_list_configuration":
+            return FakeCollection(self.docs)
+        return FakeCollection([])
+
+
+class FakeClient:
+    def __init__(self, docs):
+        self.docs = docs
+
+    def __getitem__(self, name):  # pragma: no cover - simple stub
+        return FakeDB(self.docs)
+
+
+def test_load_atom_list_configuration_rebuilds_cards(monkeypatch):
+    docs = [
+        {
+            "client_id": "c1",
+            "app_id": "a1",
+            "project_id": "p1",
+            "mode": "lab",
+            "atom_name": "AtomA",
+            "canvas_position": 0,
+            "atom_positions": 0,
+            "atom_configs": {"x": 1},
+            "open_cards": "yes",
+            "scroll_position": 10,
+            "exhibition_previews": "no",
+            "mode_meta": {"card_id": "card1", "atom_id": "atomA"},
+        },
+        {
+            "client_id": "c1",
+            "app_id": "a1",
+            "project_id": "p1",
+            "mode": "lab",
+            "atom_name": "AtomB",
+            "canvas_position": 0,
+            "atom_positions": 1,
+            "atom_configs": {"y": 2},
+            "open_cards": "yes",
+            "scroll_position": 10,
+            "exhibition_previews": "no",
+            "mode_meta": {"card_id": "card1", "atom_id": "atomB"},
+        },
+        {
+            "client_id": "c1",
+            "app_id": "a1",
+            "project_id": "p1",
+            "mode": "lab",
+            "atom_name": "AtomC",
+            "canvas_position": 1,
+            "atom_positions": 0,
+            "atom_configs": {"z": 3},
+            "open_cards": "no",
+            "scroll_position": 0,
+            "exhibition_previews": "yes",
+            "mode_meta": {"card_id": "card2", "atom_id": "atomC"},
+        },
+    ]
+
+    monkeypatch.setattr(atom_config, "MongoClient", lambda uri: FakeClient(docs))
+    monkeypatch.setattr(atom_config, "_get_env_ids", lambda project: ("c1", "a1", "p1"))
+
+    result = load_atom_list_configuration(object(), "lab")
+    assert result == {
+        "cards": [
+            {
+                "id": "card1",
+                "collapsed": False,
+                "isExhibited": False,
+                "scroll_position": 10,
+                "atoms": [
+                    {
+                        "id": "atomA",
+                        "atomId": "AtomA",
+                        "title": "AtomA",
+                        "settings": {"x": 1},
+                    },
+                    {
+                        "id": "atomB",
+                        "atomId": "AtomB",
+                        "title": "AtomB",
+                        "settings": {"y": 2},
+                    },
+                ],
+            },
+            {
+                "id": "card2",
+                "collapsed": True,
+                "isExhibited": True,
+                "scroll_position": 0,
+                "atoms": [
+                    {
+                        "id": "atomC",
+                        "atomId": "AtomC",
+                        "title": "AtomC",
+                        "settings": {"z": 3},
+                    }
+                ],
+            },
+        ]
+    }

--- a/TrinityFrontend/src/components/ExhibitionMode/ExhibitionMode.tsx
+++ b/TrinityFrontend/src/components/ExhibitionMode/ExhibitionMode.tsx
@@ -4,9 +4,18 @@ import { Presentation } from 'lucide-react';
 import Header from '@/components/Header';
 import { useExhibitionStore } from './store/exhibitionStore';
 import TextBoxDisplay from '@/components/AtomList/atoms/text-box/TextBoxDisplay';
+import { useToast } from '@/hooks/use-toast';
 
 const ExhibitionMode = () => {
   const { exhibitedCards, cards, loadSavedConfiguration } = useExhibitionStore();
+  const { toast } = useToast();
+
+  useEffect(() => {
+    if (localStorage.getItem('laboratory-config')) {
+      console.log('Successfully Loaded Existing Project State');
+      toast({ title: 'Successfully Loaded Existing Project State' });
+    }
+  }, [toast]);
 
   useEffect(() => {
     if (cards.length === 0) {

--- a/TrinityFrontend/src/components/LaboratoryMode/LaboratoryMode.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/LaboratoryMode.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Play, Save, Share2, Undo2, AlertTriangle, List } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
@@ -27,6 +27,13 @@ const LaboratoryMode = () => {
   const setLabCards = useLaboratoryStore(state => state.setCards);
   const { user } = useAuth();
   const isViewer = user?.role === 'viewer';
+
+  useEffect(() => {
+    if (localStorage.getItem('laboratory-config')) {
+      console.log('Successfully Loaded Existing Project State');
+      toast({ title: 'Successfully Loaded Existing Project State' });
+    }
+  }, [toast]);
 
   const handleUndo = async () => {
     const current = localStorage.getItem('current-project');

--- a/TrinityFrontend/src/components/WorkflowMode/WorkflowMode.tsx
+++ b/TrinityFrontend/src/components/WorkflowMode/WorkflowMode.tsx
@@ -24,6 +24,13 @@ const WorkflowMode = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
+    if (localStorage.getItem('workflow-canvas-molecules')) {
+      console.log('Successfully Loaded Existing Project State');
+      toast({ title: 'Successfully Loaded Existing Project State' });
+    }
+  }, [toast]);
+
+  useEffect(() => {
     const envStr = localStorage.getItem('env');
     if (envStr) {
       try {

--- a/TrinityFrontend/src/components/WorkflowMode/components/WorkflowCanvas.tsx
+++ b/TrinityFrontend/src/components/WorkflowMode/components/WorkflowCanvas.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { safeStringify } from '@/utils/safeStringify';
+import { useToast } from '@/hooks/use-toast';
 import ReactFlow, {
   Background,
   Controls,
@@ -35,6 +36,7 @@ const WorkflowCanvas: React.FC<WorkflowCanvasProps> = ({
   const [edges, setEdges] = useState<Edge[]>([]);
   const reactFlowWrapper = useRef<HTMLDivElement | null>(null);
   const [reactFlowInstance, setReactFlowInstance] = useState<any>(null);
+  const { toast } = useToast();
 
   const onNodesChange = useCallback(
     (changes: NodeChange[]) => setNodes(ns => applyNodeChanges(changes, ns)),
@@ -165,6 +167,8 @@ const WorkflowCanvas: React.FC<WorkflowCanvasProps> = ({
 
         setNodes(loadedNodes);
         setEdges(loadedEdges);
+        console.log('Successfully Loaded Existing Project State');
+        toast({ title: 'Successfully Loaded Existing Project State' });
       } catch (e) {
         console.error('Failed to parse workflow layout', e);
       }
@@ -193,7 +197,7 @@ const WorkflowCanvas: React.FC<WorkflowCanvasProps> = ({
           .catch(() => {});
       }
     }
-  }, []);
+  }, [onAtomToggle, onAtomReorder, onMoleculeSelect, removeNode, toast]);
 
   useEffect(() => {
     if (!onCanvasMoleculesUpdate) return;


### PR DESCRIPTION
## Summary
- fetch atom layout from Mongo using environment-derived identifiers
- inject restored configuration into project retrieval for lab/workflow/exhibition modes
- add unit test covering reconstruction logic

## Testing
- `pytest TrinityBackendDjango/tests/test_atom_config.py -q`
- `pytest -q` *(fails: HTTPConnectionPool(host='minio', port=9000): Max retries exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_689217a36b70832181da8c300eabba20