### PR TITLE
fix: include classifier MongoDB credentials in dev compose

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -134,7 +134,7 @@ services:
       HOST_IP: ${HOST_IP:-10.2.1.242}
       FASTAPI_CORS_ORIGINS: "http://127.0.0.1:8081,http://${HOST_IP:-10.2.1.242}:8081,http://172.17.48.1:8081,http://10.2.1.65:8081,https://trinity-dev.quantmatrixai.com"
       MONGO_URI: "mongodb://mongo:27017/trinity_dev"
-      CLASSIFY_MONGO_URI: "mongodb://mongo:27017"
+      CLASSIFY_MONGO_URI: "mongodb://admin_dev:pass_dev@mongo:27017/?authSource=admin"
     ports:
       - "8004:8001"
     depends_on:


### PR DESCRIPTION
## Summary
- supply MongoDB username/password in CLASSIFY_MONGO_URI to avoid auth errors during file upload

## Testing
- `docker compose -f docker-compose-dev.yml config` *(fails: command not found)*
- `python - <<'PY'\nimport yaml, sys\nwith open('docker-compose-dev.yml') as f:\n    yaml.safe_load(f)\nprint('YAML OK')\nPY`

------
https://chatgpt.com/codex/tasks/task_e_68937960c3ac832186d1b47acffb2fa3