### PR TITLE
Handle duplicate project names and refine user role display

### DIFF
--- a/TrinityBackendDjango/apps/registry/views.py
+++ b/TrinityBackendDjango/apps/registry/views.py
@@ -79,9 +79,16 @@ class ProjectViewSet(viewsets.ModelViewSet):
         user = self.request.user
         app = serializer.validated_data.get("app")
         base_name = serializer.validated_data.get("name")
+
+        # Ensure the project name is unique across the client/app combination.
+        # The RegistryEnvironment model enforces a unique constraint on
+        # ``client_name``, ``app_name`` and ``project_name``. When multiple
+        # users attempt to create projects with the same name under the same
+        # app, we need to automatically append a counter so the environment
+        # entry remains unique instead of raising an integrity error.
         name = base_name
         counter = 1
-        while Project.objects.filter(owner=user, app=app, name=name).exists():
+        while Project.objects.filter(app=app, name=name).exists():
             name = f"{base_name} {counter}"
             counter += 1
 

--- a/TrinityFrontend/src/pages/Users.tsx
+++ b/TrinityFrontend/src/pages/Users.tsx
@@ -39,6 +39,7 @@ interface User {
   // optional custom fields
   phone?: string;
   department?: string;
+  role?: string;
 }
 
 const API_BASE = ACCOUNTS_API;
@@ -183,17 +184,22 @@ const Users = () => {
     }
   };
 
-  const getRole = (u: User) => (u.is_staff ? 'Admin' : 'Analyst');
+  const getRole = (u: User) => {
+    const r = u.role?.toLowerCase();
+    if (u.is_staff || r === 'admin') return 'Admin';
+    if (r === 'editor') return 'Editor';
+    return 'Viewer';
+  };
   const getStatus = (_u: User) => 'Active';
 
   const getRoleColor = (role: string) => {
     switch (role) {
       case 'Admin':
         return 'bg-red-100 text-red-800 border-red-200';
-      case 'Analyst':
-        return 'bg-blue-100 text-blue-800 border-blue-200';
+      case 'Editor':
+        return 'bg-[#fec107]/20 text-[#fec107] border-[#fec107]/30';
       case 'Viewer':
-        return 'bg-gray-100 text-gray-800 border-gray-200';
+        return 'bg-green-100 text-green-800 border-green-200';
       default:
         return 'bg-gray-100 text-gray-800 border-gray-200';
     }
@@ -326,7 +332,7 @@ const Users = () => {
               >
                 <option value="All">All Roles</option>
                 <option value="Admin">Admin</option>
-                <option value="Analyst">Analyst</option>
+                <option value="Editor">Editor</option>
                 <option value="Viewer">Viewer</option>
               </select>
 


### PR DESCRIPTION
## Summary
- ensure project names are suffixed when a name collision occurs within the same app
- expose admin/editor/viewer roles in user management page with distinct colors

## Testing
- `pytest -q` *(fails: KeyboardInterrupt with warnings)*
- `cd TrinityFrontend && npm run lint` *(fails: 16 errors, 35 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68948965009c8321b40d717abe60063b