### PR TITLE
Preserve atom title case across sessions

### DIFF
--- a/TrinityBackendDjango/apps/registry/atom_config.py
+++ b/TrinityBackendDjango/apps/registry/atom_config.py
@@ -76,7 +76,8 @@ def save_atom_list_configuration(
             exhibition_preview = "yes" if card.get("isExhibited") else "no"
             scroll_pos = card.get("scroll_position", 0)
             for atom_pos, atom in enumerate(card.get("atoms", [])):
-                atom_name = atom.get("atomId") or atom.get("title") or "unknown"
+                atom_id = atom.get("atomId") or atom.get("title") or "unknown"
+                atom_title = atom.get("title") or atom_id
                 atom_settings = atom.get("settings", {})
                 version_hash = hashlib.sha256(
                     json.dumps(atom_settings, sort_keys=True).encode()
@@ -87,7 +88,8 @@ def save_atom_list_configuration(
                         "app_id": app_id,
                         "project_id": project_id,
                         "mode": mode,
-                        "atom_name": atom_name,
+                        "atom_name": atom_id,
+                        "atom_title": atom_title,
                         "canvas_position": canvas_pos,
                         "atom_positions": atom_pos,
                         "atom_configs": atom_settings,
@@ -145,11 +147,13 @@ def load_atom_list_configuration(
                     "atoms": [],
                 },
             )
+            atom_slug = doc.get("atom_name")
+            atom_title = doc.get("atom_title") or atom_slug
             card["atoms"].append(
                 {
                     "id": (doc.get("mode_meta") or {}).get("atom_id"),
-                    "atomId": doc.get("atom_name"),
-                    "title": doc.get("atom_name"),
+                    "atomId": atom_slug,
+                    "title": atom_title,
                     "settings": doc.get("atom_configs", {}),
                 }
             )

--- a/TrinityBackendDjango/tests/test_atom_config.py
+++ b/TrinityBackendDjango/tests/test_atom_config.py
@@ -133,3 +133,46 @@ def test_load_atom_list_configuration_rebuilds_cards(monkeypatch):
             },
         ]
     }
+
+
+def test_load_atom_list_configuration_uses_atom_title(monkeypatch):
+    docs = [
+        {
+            "client_id": "c1",
+            "app_id": "a1",
+            "project_id": "p1",
+            "mode": "lab",
+            "atom_name": "atom-a",
+            "atom_title": "Atom A",
+            "canvas_position": 0,
+            "atom_positions": 0,
+            "atom_configs": {},
+            "open_cards": "yes",
+            "scroll_position": 0,
+            "exhibition_previews": "no",
+            "mode_meta": {"card_id": "card1", "atom_id": "atomA"},
+        }
+    ]
+
+    monkeypatch.setattr(atom_config, "MongoClient", lambda uri: FakeClient(docs))
+    monkeypatch.setattr(atom_config, "_get_env_ids", lambda project: ("c1", "a1", "p1"))
+
+    result = load_atom_list_configuration(object(), "lab")
+    assert result == {
+        "cards": [
+            {
+                "id": "card1",
+                "collapsed": False,
+                "isExhibited": False,
+                "scroll_position": 0,
+                "atoms": [
+                    {
+                        "id": "atomA",
+                        "atomId": "atom-a",
+                        "title": "Atom A",
+                        "settings": {},
+                    }
+                ],
+            }
+        ]
+    }


### PR DESCRIPTION
## Summary
- store both slug and display title when persisting atom list configuration
- restore atom titles from Mongo using saved display title
- test atom configuration loading with preserved titles

## Testing
- `pytest` *(fails: NameResolutionError: Failed to resolve 'minio')*
- `pytest TrinityBackendDjango/tests/test_atom_config.py`

------
https://chatgpt.com/codex/tasks/task_e_689594999d0083219debac1b84d15f43