### PR TITLE
Integrate Explore atom

### DIFF
--- a/TrinityBackendFastAPI/app/api/router.py
+++ b/TrinityBackendFastAPI/app/api/router.py
@@ -16,6 +16,7 @@ from app.features.chart_maker.endpoint import router as chart_maker_router
 from app.features.build_model_feature_based.endpoint import router as build_model_router
 # from app.features.build_autoregressive.endpoint import router as autoregressive_router
 from app.features.select_models_feature_based.endpoint import router as select_router
+from app.features.explore.endpoint import router as explore_router
 api_router = APIRouter()
 text_router  = APIRouter()
 api_router.include_router(feature_overview_router)
@@ -36,6 +37,7 @@ api_router.include_router(project_state_router)
 api_router.include_router(scope_selector_router)
 api_router.include_router(user_apps_router)
 api_router.include_router(chart_maker_router)
+api_router.include_router(explore_router)
 
 api_router.include_router(build_model_router)
 # api_router.include_router(autoregressive_router)

--- a/TrinityBackendFastAPI/app/features/explore/endpoint.py
+++ b/TrinityBackendFastAPI/app/features/explore/endpoint.py
@@ -1,0 +1,43 @@
+from fastapi import APIRouter, HTTPException, Query
+from urllib.parse import unquote
+import os
+import redis
+from minio import Minio
+from minio.error import S3Error
+
+from .service import summarize_dataframe
+
+router = APIRouter(prefix="/explore", tags=["Explore"])
+
+MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT", "minio:9000")
+MINIO_ACCESS_KEY = os.getenv("MINIO_ACCESS_KEY", "admin_dev")
+MINIO_SECRET_KEY = os.getenv("MINIO_SECRET_KEY", "pass_dev")
+MINIO_BUCKET = os.getenv("MINIO_BUCKET", "trinity")
+REDIS_HOST = os.getenv("REDIS_HOST", "redis")
+REDIS_PORT = int(os.getenv("REDIS_PORT", 6379))
+REDIS_DB = int(os.getenv("REDIS_DB", 0))
+
+minio_client = Minio(
+    MINIO_ENDPOINT,
+    access_key=MINIO_ACCESS_KEY,
+    secret_key=MINIO_SECRET_KEY,
+    secure=False,
+)
+redis_client = redis.Redis(host=REDIS_HOST, port=REDIS_PORT, db=REDIS_DB)
+
+@router.get("/summary")
+async def explore_summary(object_name: str = Query(..., alias="object_name")):
+    """Return basic descriptive statistics for a stored dataframe."""
+    try:
+        key = unquote(object_name)
+        data = redis_client.get(key)
+        if data is None:
+            obj = minio_client.get_object(MINIO_BUCKET, key)
+            data = obj.read()
+        is_arrow = key.endswith(".arrow")
+        result = summarize_dataframe(data, is_arrow=is_arrow)
+        return result
+    except S3Error as e:
+        raise HTTPException(status_code=404, detail=f"Dataframe not found: {e}")
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))

--- a/TrinityBackendFastAPI/app/features/explore/schema.py
+++ b/TrinityBackendFastAPI/app/features/explore/schema.py
@@ -1,0 +1,7 @@
+from typing import Dict, Any, List
+from pydantic import BaseModel
+
+class ExploreResponse(BaseModel):
+    columns: List[str]
+    row_count: int
+    summary: Dict[str, Dict[str, Any]]

--- a/TrinityBackendFastAPI/app/features/explore/service.py
+++ b/TrinityBackendFastAPI/app/features/explore/service.py
@@ -1,0 +1,17 @@
+import io
+import pandas as pd
+import pyarrow as pa
+import pyarrow.ipc as ipc
+from .schema import ExploreResponse
+
+
+def summarize_dataframe(data: bytes, *, is_arrow: bool) -> ExploreResponse:
+    """Create summary statistics for the given dataframe bytes."""
+    if is_arrow:
+        reader = ipc.open_file(pa.BufferReader(data))
+        table = reader.read_all()
+        df = table.to_pandas()
+    else:
+        df = pd.read_csv(io.BytesIO(data))
+    summary = df.describe(include="all").to_dict()
+    return ExploreResponse(columns=list(df.columns), row_count=len(df), summary=summary)

--- a/TrinityFrontend/src/components/AtomCategory/data/atomCategories.ts
+++ b/TrinityFrontend/src/components/AtomCategory/data/atomCategories.ts
@@ -111,8 +111,8 @@ export const atomCategories: AtomCategory[] = [
     icon: BarChart3,
     color: 'bg-purple-500',
     atoms: [
-      correlation,
       explore,
+      correlation,
       descriptiveStats,
       trendAnalysis
     ]

--- a/TrinityFrontend/src/components/AtomList/atoms/explore/ExploreAtom.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/explore/ExploreAtom.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useState } from 'react';
+import { useLaboratoryStore } from '@/components/LaboratoryMode/store/laboratoryStore';
+import { EXPLORE_API } from '@/lib/api';
+
+interface ExploreAtomProps {
+  atomId: string;
+}
+
+const ExploreAtom: React.FC<ExploreAtomProps> = ({ atomId }) => {
+  const atom = useLaboratoryStore(state => state.getAtom(atomId));
+  const dataSource = atom?.settings?.dataSource as string | undefined;
+  const [result, setResult] = useState<any>();
+
+  useEffect(() => {
+    const load = async () => {
+      if (!dataSource) return;
+      try {
+        const res = await fetch(
+          `${EXPLORE_API}/summary?object_name=${encodeURIComponent(dataSource)}`,
+          { credentials: 'include' }
+        );
+        if (res.ok) {
+          const data = await res.json();
+          setResult(data);
+        }
+      } catch (err) {
+        console.error('Explore request failed', err);
+      }
+    };
+    load();
+  }, [dataSource]);
+
+  if (!dataSource) {
+    return <div className="text-sm text-gray-500">No data source selected.</div>;
+  }
+  if (!result) {
+    return <div className="text-sm text-gray-500">Loading...</div>;
+  }
+  return (
+    <pre className="text-xs max-h-64 overflow-auto bg-gray-50 p-2 rounded">
+      {JSON.stringify(result.summary, null, 2)}
+    </pre>
+  );
+};
+
+export default ExploreAtom;

--- a/TrinityFrontend/src/components/AtomList/atoms/explore/components/properties/ExploreProperties.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/explore/components/properties/ExploreProperties.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Input } from '@/components/ui/input';
+import { useLaboratoryStore } from '@/components/LaboratoryMode/store/laboratoryStore';
+
+interface Props {
+  atomId: string;
+}
+
+const ExploreProperties: React.FC<Props> = ({ atomId }) => {
+  const atom = useLaboratoryStore(state => state.getAtom(atomId));
+  const updateSettings = useLaboratoryStore(state => state.updateAtomSettings);
+  const dataSource = (atom?.settings as any)?.dataSource || '';
+
+  return (
+    <div className="p-4 space-y-4">
+      <div>
+        <label className="block text-sm text-gray-600 mb-1">Data Source</label>
+        <Input
+          value={dataSource}
+          onChange={e => updateSettings(atomId, { dataSource: e.target.value })}
+          placeholder="object_name.csv"
+          className="text-sm"
+        />
+      </div>
+    </div>
+  );
+};
+
+export default ExploreProperties;

--- a/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea/index.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea/index.tsx
@@ -20,6 +20,7 @@ import { AIChatBot, AtomAIChatBot } from '@/components/TrinityAI';
 import TextBoxEditor from '@/components/AtomList/atoms/text-box/TextBoxEditor';
 import DataUploadValidateAtom from '@/components/AtomList/atoms/data-upload-validate/DataUploadValidateAtom';
 import FeatureOverviewAtom from '@/components/AtomList/atoms/feature-overview/FeatureOverviewAtom';
+import ExploreAtom from '@/components/AtomList/atoms/explore/ExploreAtom';
 import ConcatAtom from '@/components/AtomList/atoms/concat/ConcatAtom';
 import MergeAtom from '@/components/AtomList/atoms/merge/MergeAtom';
 import ColumnClassifierAtom from '@/components/AtomList/atoms/column-classifier/ColumnClassifierAtom';
@@ -281,6 +282,19 @@ const CanvasArea: React.FC<CanvasAreaProps> = ({
       numericColumns: Array.isArray(prev.numeric) ? prev.numeric : [],
       dimensionMap: mapping,
       xAxis: prev.xField || 'date',
+    });
+  };
+
+  const prefillExplore = async (atomId: string) => {
+    const prev = await findLatestDataSource();
+    if (!prev || !prev.csv) {
+      console.warn('⚠️ no data source found for explore');
+      return;
+    }
+    await prefetchDataframe(prev.csv);
+    updateAtomSettings(atomId, {
+      dataSource: prev.csv,
+      csvDisplay: prev.display || prev.csv,
     });
   };
 
@@ -565,6 +579,8 @@ const CanvasArea: React.FC<CanvasAreaProps> = ({
 
       if (atom.id === 'feature-overview') {
         prefillFeatureOverview(cardId, newAtom.id);
+      } else if (atom.id === 'explore') {
+        prefillExplore(newAtom.id);
       } else if (atom.id === 'column-classifier') {
         prefillColumnClassifier(newAtom.id);
       }
@@ -638,6 +654,8 @@ const addNewCardWithAtom = (
 
   if (atomId === 'feature-overview') {
     prefillFeatureOverview(newCard.id, newAtom.id);
+  } else if (atomId === 'explore') {
+    prefillExplore(newAtom.id);
   } else if (atomId === 'column-classifier') {
     prefillColumnClassifier(newAtom.id);
   }
@@ -725,6 +743,8 @@ const handleAddDragLeave = (e: React.DragEvent) => {
 
     if (info.id === 'feature-overview') {
       prefillFeatureOverview(cardId, newAtom.id);
+    } else if (info.id === 'explore') {
+      prefillExplore(newAtom.id);
     } else if (info.id === 'column-classifier') {
       prefillColumnClassifier(newAtom.id);
     }
@@ -834,6 +854,8 @@ const handleAddDragLeave = (e: React.DragEvent) => {
     for (const atom of card.atoms) {
       if (atom.atomId === 'feature-overview') {
         await prefillFeatureOverview(cardId, atom.id);
+      } else if (atom.atomId === 'explore') {
+        await prefillExplore(atom.id);
       } else if (atom.atomId === 'column-classifier') {
         await prefillColumnClassifier(atom.id);
       }
@@ -1182,6 +1204,8 @@ const handleAddDragLeave = (e: React.DragEvent) => {
                         <DataUploadValidateAtom atomId={atom.id} />
                       ) : atom.atomId === 'feature-overview' ? (
                         <FeatureOverviewAtom atomId={atom.id} />
+                      ) : atom.atomId === 'explore' ? (
+                        <ExploreAtom atomId={atom.id} />
                       ) : atom.atomId === 'chart-maker' ? (
                         <ChartMakerAtom atomId={atom.id} />
                       ) : atom.atomId === 'concat' ? (

--- a/TrinityFrontend/src/components/LaboratoryMode/components/SettingsPanel.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/components/SettingsPanel.tsx
@@ -30,6 +30,7 @@ import GroupByProperties from '@/components/AtomList/atoms/groupby-wtg-avg/compo
 import BuildModelFeatureBasedProperties from '@/components/AtomList/atoms/build-model-feature-based/components/properties/BuildModelFeatureBasedProperties';
 import ScopeSelectorProperties from '@/components/AtomList/atoms/scope-selector/components/properties/ScopeSelectorProperties';
 import DataFrameOperationsProperties from '@/components/AtomList/atoms/dataframe-operations/components/properties/DataFrameOperationsProperties';
+import ExploreProperties from '@/components/AtomList/atoms/explore/components/properties/ExploreProperties';
 
 interface SettingsPanelProps {
   isCollapsed: boolean;
@@ -113,6 +114,8 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
             <DataUploadValidateProperties atomId={selectedAtomId} />
           ) : selectedAtomId && atom?.atomId === 'feature-overview' ? (
             <FeatureOverviewProperties atomId={selectedAtomId} />
+          ) : selectedAtomId && atom?.atomId === 'explore' ? (
+            <ExploreProperties atomId={selectedAtomId} />
           ) : selectedAtomId && atom?.atomId === 'chart-maker' ? (
             <ChartMakerProperties atomId={selectedAtomId} />
           ) : selectedAtomId && atom?.atomId === 'concat' ? (

--- a/TrinityFrontend/src/components/LaboratoryMode/components/SettingsPanel/index.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/components/SettingsPanel/index.tsx
@@ -30,6 +30,7 @@ import MergeProperties from '@/components/AtomList/atoms/merge/components/proper
 import ColumnClassifierProperties from '@/components/AtomList/atoms/column-classifier/components/properties/ColumnClassifierProperties';
 import DataFrameOperationsProperties from '@/components/AtomList/atoms/dataframe-operations/components/properties/DataFrameOperationsProperties';
 import ChartMakerProperties from '@/components/AtomList/atoms/chart-maker/components/properties/ChartMakerProperties';
+import ExploreProperties from '@/components/AtomList/atoms/explore/components/properties/ExploreProperties';
 import AtomSettingsTabs from "./AtomSettingsTabs";
 
 interface SettingsPanelProps {
@@ -114,6 +115,8 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
             <DataUploadValidateProperties atomId={selectedAtomId} />
           ) : selectedAtomId && atom?.atomId === 'feature-overview' ? (
             <FeatureOverviewProperties atomId={selectedAtomId} />
+          ) : selectedAtomId && atom?.atomId === 'explore' ? (
+            <ExploreProperties atomId={selectedAtomId} />
           ) : selectedAtomId && atom?.atomId === 'chart-maker' ? (
             <ChartMakerProperties atomId={selectedAtomId} />
           ) : selectedAtomId && atom?.atomId === 'build-model-feature-based' ? (

--- a/TrinityFrontend/src/lib/api.ts
+++ b/TrinityFrontend/src/lib/api.ts
@@ -96,6 +96,10 @@ export const FEATURE_OVERVIEW_API =
   normalizeUrl(import.meta.env.VITE_FEATURE_OVERVIEW_API) ||
   `${backendOrigin.replace(new RegExp(`:${djangoPort}$`), `:${fastapiPort}`)}/api/feature-overview`;
 
+export const EXPLORE_API =
+  normalizeUrl(import.meta.env.VITE_EXPLORE_API) ||
+  `${backendOrigin.replace(new RegExp(`:${djangoPort}$`), `:${fastapiPort}`)}/api/explore`;
+
 export const SCOPE_SELECTOR_API =
   normalizeUrl(import.meta.env.VITE_SCOPE_SELECTOR_API) ||
   `${backendOrigin.replace(new RegExp(`:${djangoPort}$`), `:${fastapiPort}`)}/api/scope-selector`;


### PR DESCRIPTION
## Summary
- add backend Explore endpoint for dataframe summaries
- wire Explore atom into laboratory canvas and settings
- expose EXPLORE_API and update atom categories

## Testing
- `npm test` (fails: Missing script "test")
- `pytest` (fails: ValidationError during collection)


------
https://chatgpt.com/codex/tasks/task_e_68a56bfed2f88321805a24afa364d729