### PR TITLE
Integrate Explore atom

### DIFF
--- a/TrinityBackendFastAPI/app/api/router.py
+++ b/TrinityBackendFastAPI/app/api/router.py
@@ -16,6 +16,7 @@ from app.features.chart_maker.endpoint import router as chart_maker_router
 from app.features.build_model_feature_based.endpoint import router as build_model_router
 # from app.features.build_autoregressive.endpoint import router as autoregressive_router
 from app.features.select_models_feature_based.endpoint import router as select_router
+from app.features.explore.endpoint import router as explore_router
 api_router = APIRouter()
 text_router  = APIRouter()
 api_router.include_router(feature_overview_router)
@@ -36,6 +37,7 @@ api_router.include_router(project_state_router)
 api_router.include_router(scope_selector_router)
 api_router.include_router(user_apps_router)
 api_router.include_router(chart_maker_router)
+api_router.include_router(explore_router)
 
 api_router.include_router(build_model_router)
 # api_router.include_router(autoregressive_router)

--- a/TrinityFrontend/src/components/AtomCategory/data/atomCategories.ts
+++ b/TrinityFrontend/src/components/AtomCategory/data/atomCategories.ts
@@ -39,7 +39,7 @@ import rowOperations from '@/components/AtomList/atoms/row-operations';
 import columnClassifier from '@/components/AtomList/atoms/column-classifier';
 import createColumn from '@/components/AtomList/atoms/createcolumn';
 import correlation from '@/components/AtomList/atoms/correlation';
-import explore from '@/components/AtomList/atoms/explore';
+import explore from '@/components/AtomList/atoms/explore'; // Explore atom for interactive data exploration
 import descriptiveStats from '@/components/AtomList/atoms/descriptive-stats';
 import trendAnalysis from '@/components/AtomList/atoms/trend-analysis';
 import regressionFeatureBased from '@/components/AtomList/atoms/regression-feature-based';

--- a/TrinityFrontend/src/components/AtomList/atoms/explore/ExploreAtom.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/explore/ExploreAtom.tsx
@@ -90,12 +90,9 @@ const ExploreAtom: React.FC<ExploreAtomProps> = ({ atomId }) => {
   }), [atom?.settings?.data]);
 
   const isApplied = useMemo(() => {
-    // Check if settings have been explicitly applied (this is the primary indicator)
-    const hasAppliedSettings = atom?.settings?.applied === true;
-    
-    // Only consider it applied if settings have been explicitly applied
-    return hasAppliedSettings;
-  }, [atom?.settings?.applied]);
+    // Check if settings have been explicitly applied within the atom's data
+    return atom?.settings?.data?.applied === true;
+  }, [atom?.settings?.data?.applied]);
 
   const appliedConfig = data;
 

--- a/TrinityFrontend/src/components/AtomList/atoms/explore/ExploreAtom.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/explore/ExploreAtom.tsx
@@ -2,67 +2,7 @@ import React, { useMemo } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { BarChart3, Grid, TrendingUp, Clock, Database } from 'lucide-react';
 import ExploreCanvas from './components/ExploreCanvas';
-
-export interface ExploreData {
-  dataframe?: string;
-  dimensions: string[];
-  measures: string[];
-  graphLayout: {
-    numberOfGraphsInRow: number;
-    rows: number;
-  };
-  allColumns?: string[];
-  numericalColumns?: string[];
-  columnSummary?: any[];
-  showDataSummary?: boolean;
-  filterUnique?: boolean;
-  // Chart configuration properties
-  chartType?: string;
-  xAxis?: string;
-  yAxis?: string;
-  xAxisLabel?: string;
-  yAxisLabel?: string;
-  title?: string;
-  legendField?: string; // Field to use for creating multiple lines/series
-  aggregation?: string;
-  weightColumn?: string;
-  // Date filtering properties
-  dateFilters?: Array<{
-    column: string;
-    values: string[];
-  }>;
-  // Column classifier integration properties
-  columnClassifierConfig?: {
-    identifiers: string[];
-    measures: string[];
-    dimensions: { [key: string]: string[] };
-    client_name?: string;
-    app_name?: string;
-    project_name?: string;
-  };
-  availableDimensions?: string[];
-  availableMeasures?: string[];
-  availableIdentifiers?: string[];
-  chartReadyData?: any;
-  // Fallback properties for when column classifier config is not available
-  fallbackDimensions?: string[];
-  fallbackMeasures?: string[];
-  // Applied flag to track if settings have been applied
-  applied?: boolean;
-  // Additional optional properties
-  [key: string]: any;
-}
-
-export interface ExploreSettings {
-  dataSource: string;
-  enableFiltering?: boolean;
-  enableExport?: boolean;
-  autoRefresh?: boolean;
-  // Additional optional settings
-  [key: string]: any;
-}
-
-import { useLaboratoryStore } from '@/components/LaboratoryMode/store/laboratoryStore';
+import { useLaboratoryStore, ExploreData } from '@/components/LaboratoryMode/store/laboratoryStore';
 
 const chartTypes = [
   'Line', 'Bar', 'Pie', 'Scatter', 'Area', 'Column', 'Table', 'Custom'

--- a/TrinityFrontend/src/components/AtomList/atoms/explore/components/ExploreProperties.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/explore/components/ExploreProperties.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from 'react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Upload, Settings, Eye } from 'lucide-react';

--- a/TrinityFrontend/src/components/AtomList/atoms/explore/components/properties/ExploreProperties.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/explore/components/properties/ExploreProperties.tsx
@@ -3,31 +3,43 @@
 import React from 'react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Upload, Settings, Eye } from 'lucide-react';
-import ExploreInput from './ExploreInput';
-import ExploreSettings from './ExploreSettings';
-import ExploreExhibition from './ExploreExhibition';
+import ExploreInput from '../ExploreInput';
+import ExploreSettings from '../ExploreSettings';
+import ExploreExhibition from '../ExploreExhibition';
 import ErrorBoundary from '@/components/ErrorBoundary';
-import { ExploreData, ExploreSettings as ExploreSettingsType } from '../ExploreAtom';
+import { useLaboratoryStore } from '@/components/LaboratoryMode/store/laboratoryStore';
+import type { ExploreData, ExploreSettings as ExploreSettingsType } from '../ExploreAtom';
 
-interface ExplorePropertiesProps {
-  data: ExploreData;
-  settings: ExploreSettingsType;
-  onDataChange: (data: Partial<ExploreData>) => void;
-  onSettingsChange: (settings: Partial<ExploreSettingsType>) => void;
-  onDataUpload: (data: any, fileId: string) => void;
-  onApply?: (config: any) => void;
-  chartData?: any; // Add chart data prop
+interface Props {
+  atomId: string;
 }
 
-const ExploreProperties: React.FC<ExplorePropertiesProps> = ({
-  data,
-  settings,
-  onDataChange,
-  onSettingsChange,
-  onDataUpload,
-  onApply,
-  chartData
-}) => {
+const ExploreProperties: React.FC<Props> = ({ atomId }) => {
+  const atom = useLaboratoryStore(state => state.getAtom(atomId));
+  const updateSettings = useLaboratoryStore(state => state.updateAtomSettings);
+
+  const data = (atom?.settings?.data || {}) as ExploreData;
+  const settings = (atom?.settings?.settings || {}) as ExploreSettingsType;
+  const chartData = atom?.settings?.chartData;
+
+  const handleDataChange = (newData: Partial<ExploreData>) => {
+    updateSettings(atomId, {
+      data: { ...data, ...newData },
+    });
+  };
+
+  const handleDataUpload = (summary: any, fileId: string) => {
+    updateSettings(atomId, {
+      data: { ...data, columnSummary: summary, dataframe: fileId },
+    });
+  };
+
+  const handleApply = (config?: any) => {
+    updateSettings(atomId, {
+      data: { ...data, ...(config || {}), applied: true },
+    });
+  };
+
   return (
     <div className="w-80 h-full bg-background border-l border-border flex flex-col">
       <div className="flex-1 overflow-hidden">
@@ -45,20 +57,20 @@ const ExploreProperties: React.FC<ExplorePropertiesProps> = ({
           </TabsList>
           <div className="h-[calc(100%-60px)] overflow-y-auto">
             <TabsContent value="input" className="h-full m-0 p-2" forceMount>
-              <ExploreInput 
+              <ExploreInput
                 data={data}
                 settings={settings}
-                onDataChange={onDataChange}
-                onDataUpload={onDataUpload}
+                onDataChange={handleDataChange}
+                onDataUpload={handleDataUpload}
               />
             </TabsContent>
             <TabsContent value="settings" className="h-full m-0 p-2" forceMount>
               <ErrorBoundary>
-                <ExploreSettings 
+                <ExploreSettings
                   data={data}
                   settings={settings}
-                  onDataChange={onDataChange}
-                  onApply={onApply}
+                  onDataChange={handleDataChange}
+                  onApply={() => handleApply()}
                 />
               </ErrorBoundary>
             </TabsContent>
@@ -73,3 +85,4 @@ const ExploreProperties: React.FC<ExplorePropertiesProps> = ({
 };
 
 export default ExploreProperties;
+

--- a/TrinityFrontend/src/components/AtomList/atoms/explore/components/properties/ExploreProperties.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/explore/components/properties/ExploreProperties.tsx
@@ -7,8 +7,13 @@ import ExploreInput from '../ExploreInput';
 import ExploreSettings from '../ExploreSettings';
 import ExploreExhibition from '../ExploreExhibition';
 import ErrorBoundary from '@/components/ErrorBoundary';
-import { useLaboratoryStore } from '@/components/LaboratoryMode/store/laboratoryStore';
-import type { ExploreData, ExploreSettings as ExploreSettingsType } from '../ExploreAtom';
+import {
+  useLaboratoryStore,
+  DEFAULT_EXPLORE_SETTINGS,
+  DEFAULT_EXPLORE_DATA,
+  ExploreSettings as ExploreSettingsType,
+  ExploreData,
+} from '@/components/LaboratoryMode/store/laboratoryStore';
 
 interface Props {
   atomId: string;
@@ -18,8 +23,10 @@ const ExploreProperties: React.FC<Props> = ({ atomId }) => {
   const atom = useLaboratoryStore(state => state.getAtom(atomId));
   const updateSettings = useLaboratoryStore(state => state.updateAtomSettings);
 
-  const data = (atom?.settings?.data || {}) as ExploreData;
-  const settings = (atom?.settings?.settings || {}) as ExploreSettingsType;
+  const data = (atom?.settings?.data as ExploreData) || { ...DEFAULT_EXPLORE_DATA };
+  const settings = (atom?.settings?.settings as ExploreSettingsType) || {
+    ...DEFAULT_EXPLORE_SETTINGS,
+  };
   const chartData = atom?.settings?.chartData;
 
   const handleDataChange = (newData: Partial<ExploreData>) => {

--- a/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea/index.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea/index.tsx
@@ -29,6 +29,7 @@ import CreateColumnAtom from '@/components/AtomList/atoms/createcolumn/CreateCol
 import GroupByAtom from '@/components/AtomList/atoms/groupby-wtg-avg/GroupByAtom';
 import ChartMakerAtom from '@/components/AtomList/atoms/chart-maker/ChartMakerAtom';
 import BuildModelFeatureBasedAtom from '@/components/AtomList/atoms/build-model-feature-based/BuildModelFeatureBasedAtom';
+import ExploreAtom from '@/components/AtomList/atoms/explore/ExploreAtom';
 import { fetchDimensionMapping } from '@/lib/dimensions';
 
 import {
@@ -1182,6 +1183,8 @@ const handleAddDragLeave = (e: React.DragEvent) => {
                         <DataUploadValidateAtom atomId={atom.id} />
                       ) : atom.atomId === 'feature-overview' ? (
                         <FeatureOverviewAtom atomId={atom.id} />
+                      ) : atom.atomId === 'explore' ? (
+                        <ExploreAtom atomId={atom.id} />
                       ) : atom.atomId === 'chart-maker' ? (
                         <ChartMakerAtom atomId={atom.id} />
                       ) : atom.atomId === 'concat' ? (

--- a/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea/index.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea/index.tsx
@@ -718,6 +718,10 @@ const handleAddDragLeave = (e: React.DragEvent) => {
           ? { ...DEFAULT_FEATURE_OVERVIEW_SETTINGS }
           : info.id === 'dataframe-operations'
           ? { ...DEFAULT_DATAFRAME_OPERATIONS_SETTINGS }
+          : info.id === 'chart-maker'
+          ? { ...DEFAULT_CHART_MAKER_SETTINGS }
+          : info.id === 'explore'
+          ? { data: {}, settings: {} }
           : undefined,
     };
     setLayoutCards(

--- a/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea/index.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea/index.tsx
@@ -43,6 +43,8 @@ import {
   DEFAULT_CHART_MAKER_SETTINGS,
   DataUploadSettings,
   ColumnClassifierColumn,
+  DEFAULT_EXPLORE_SETTINGS,
+  DEFAULT_EXPLORE_DATA,
 } from '../../store/laboratoryStore';
 import { deriveWorkflowMolecules, WorkflowMolecule } from './helpers';
 
@@ -721,7 +723,7 @@ const handleAddDragLeave = (e: React.DragEvent) => {
           : info.id === 'chart-maker'
           ? { ...DEFAULT_CHART_MAKER_SETTINGS }
           : info.id === 'explore'
-          ? { data: {}, settings: {} }
+          ? { data: { ...DEFAULT_EXPLORE_DATA }, settings: { ...DEFAULT_EXPLORE_SETTINGS } }
           : undefined,
     };
     setLayoutCards(

--- a/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea/index.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea/index.tsx
@@ -551,6 +551,8 @@ const CanvasArea: React.FC<CanvasAreaProps> = ({
             ? { ...DEFAULT_DATAUPLOAD_SETTINGS }
             : atom.id === 'feature-overview'
             ? { ...DEFAULT_FEATURE_OVERVIEW_SETTINGS }
+            : atom.id === 'explore'
+            ? { data: {}, settings: {} }
             : atom.id === 'chart-maker'
             ? { ...DEFAULT_CHART_MAKER_SETTINGS }
             : undefined,

--- a/TrinityFrontend/src/components/LaboratoryMode/components/SettingsPanel/index.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/components/SettingsPanel/index.tsx
@@ -30,6 +30,7 @@ import MergeProperties from '@/components/AtomList/atoms/merge/components/proper
 import ColumnClassifierProperties from '@/components/AtomList/atoms/column-classifier/components/properties/ColumnClassifierProperties';
 import DataFrameOperationsProperties from '@/components/AtomList/atoms/dataframe-operations/components/properties/DataFrameOperationsProperties';
 import ChartMakerProperties from '@/components/AtomList/atoms/chart-maker/components/properties/ChartMakerProperties';
+import ExploreProperties from '@/components/AtomList/atoms/explore/components/ExploreProperties';
 import AtomSettingsTabs from "./AtomSettingsTabs";
 
 interface SettingsPanelProps {
@@ -114,6 +115,36 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
             <DataUploadValidateProperties atomId={selectedAtomId} />
           ) : selectedAtomId && atom?.atomId === 'feature-overview' ? (
             <FeatureOverviewProperties atomId={selectedAtomId} />
+          ) : selectedAtomId && atom?.atomId === 'explore' ? (
+            <ExploreProperties
+              data={atom?.settings?.data || {}}
+              settings={atom?.settings?.settings || {}}
+              onDataChange={(data) =>
+                updateSettings(selectedAtomId, {
+                  data: { ...(atom?.settings?.data || {}), ...data },
+                })
+              }
+              onSettingsChange={(settings) =>
+                updateSettings(selectedAtomId, {
+                  settings: { ...(atom?.settings?.settings || {}), ...settings },
+                })
+              }
+              onDataUpload={(summary, fileId) =>
+                updateSettings(selectedAtomId, {
+                  data: {
+                    ...(atom?.settings?.data || {}),
+                    columnSummary: summary,
+                    dataframe: fileId,
+                  },
+                })
+              }
+              onApply={(config) =>
+                updateSettings(selectedAtomId, {
+                  data: { ...(atom?.settings?.data || {}), ...config, applied: true },
+                })
+              }
+              chartData={atom?.settings?.chartData}
+            />
           ) : selectedAtomId && atom?.atomId === 'chart-maker' ? (
             <ChartMakerProperties atomId={selectedAtomId} />
           ) : selectedAtomId && atom?.atomId === 'build-model-feature-based' ? (

--- a/TrinityFrontend/src/components/LaboratoryMode/components/SettingsPanel/index.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/components/SettingsPanel/index.tsx
@@ -30,7 +30,7 @@ import MergeProperties from '@/components/AtomList/atoms/merge/components/proper
 import ColumnClassifierProperties from '@/components/AtomList/atoms/column-classifier/components/properties/ColumnClassifierProperties';
 import DataFrameOperationsProperties from '@/components/AtomList/atoms/dataframe-operations/components/properties/DataFrameOperationsProperties';
 import ChartMakerProperties from '@/components/AtomList/atoms/chart-maker/components/properties/ChartMakerProperties';
-import ExploreProperties from '@/components/AtomList/atoms/explore/components/ExploreProperties';
+import ExploreProperties from '@/components/AtomList/atoms/explore/components/properties/ExploreProperties';
 import AtomSettingsTabs from "./AtomSettingsTabs";
 
 interface SettingsPanelProps {
@@ -116,35 +116,7 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
           ) : selectedAtomId && atom?.atomId === 'feature-overview' ? (
             <FeatureOverviewProperties atomId={selectedAtomId} />
           ) : selectedAtomId && atom?.atomId === 'explore' ? (
-            <ExploreProperties
-              data={atom?.settings?.data || {}}
-              settings={atom?.settings?.settings || {}}
-              onDataChange={(data) =>
-                updateSettings(selectedAtomId, {
-                  data: { ...(atom?.settings?.data || {}), ...data },
-                })
-              }
-              onSettingsChange={(settings) =>
-                updateSettings(selectedAtomId, {
-                  settings: { ...(atom?.settings?.settings || {}), ...settings },
-                })
-              }
-              onDataUpload={(summary, fileId) =>
-                updateSettings(selectedAtomId, {
-                  data: {
-                    ...(atom?.settings?.data || {}),
-                    columnSummary: summary,
-                    dataframe: fileId,
-                  },
-                })
-              }
-              onApply={(config) =>
-                updateSettings(selectedAtomId, {
-                  data: { ...(atom?.settings?.data || {}), ...config, applied: true },
-                })
-              }
-              chartData={atom?.settings?.chartData}
-            />
+            <ExploreProperties atomId={selectedAtomId} />
           ) : selectedAtomId && atom?.atomId === 'chart-maker' ? (
             <ChartMakerProperties atomId={selectedAtomId} />
           ) : selectedAtomId && atom?.atomId === 'build-model-feature-based' ? (

--- a/TrinityFrontend/src/components/LaboratoryMode/store/laboratoryStore.ts
+++ b/TrinityFrontend/src/components/LaboratoryMode/store/laboratoryStore.ts
@@ -280,6 +280,72 @@ export const DEFAULT_CHART_MAKER_SETTINGS: ChartMakerSettings = {
   error: undefined,
 };
 
+export interface ExploreData {
+  dataframe?: string;
+  dimensions: string[];
+  measures: string[];
+  graphLayout: {
+    numberOfGraphsInRow: number;
+    rows: number;
+  };
+  allColumns?: string[];
+  numericalColumns?: string[];
+  columnSummary?: any[];
+  showDataSummary?: boolean;
+  filterUnique?: boolean;
+  chartType?: string;
+  xAxis?: string;
+  yAxis?: string;
+  xAxisLabel?: string;
+  yAxisLabel?: string;
+  title?: string;
+  legendField?: string;
+  aggregation?: string;
+  weightColumn?: string;
+  dateFilters?: Array<{
+    column: string;
+    values: string[];
+  }>;
+  columnClassifierConfig?: {
+    identifiers: string[];
+    measures: string[];
+    dimensions: { [key: string]: string[] };
+    client_name?: string;
+    app_name?: string;
+    project_name?: string;
+  };
+  availableDimensions?: string[];
+  availableMeasures?: string[];
+  availableIdentifiers?: string[];
+  chartReadyData?: any;
+  fallbackDimensions?: string[];
+  fallbackMeasures?: string[];
+  applied?: boolean;
+  [key: string]: any;
+}
+
+export interface ExploreSettings {
+  dataSource: string;
+  enableFiltering?: boolean;
+  enableExport?: boolean;
+  autoRefresh?: boolean;
+  [key: string]: any;
+}
+
+export const DEFAULT_EXPLORE_DATA: ExploreData = {
+  dimensions: [],
+  measures: [],
+  graphLayout: { numberOfGraphsInRow: 1, rows: 1 },
+  applied: false,
+};
+
+export const DEFAULT_EXPLORE_SETTINGS: ExploreSettings = {
+  dataSource: "",
+  enableFiltering: false,
+  enableExport: false,
+  autoRefresh: false,
+};
+
 export interface DroppedAtom {
   id: string;
   atomId: string;

--- a/TrinityFrontend/src/lib/api.ts
+++ b/TrinityFrontend/src/lib/api.ts
@@ -129,6 +129,10 @@ export const CHART_MAKER_API =
   normalizeUrl(import.meta.env.VITE_CHART_MAKER_API) ||
   `${backendOrigin.replace(new RegExp(`:${djangoPort}$`), `:${fastapiPort}`)}/api/chart-maker`;
 
+export const EXPLORE_API =
+  normalizeUrl(import.meta.env.VITE_EXPLORE_API) ||
+  `${backendOrigin.replace(new RegExp(`:${djangoPort}$`), `:${fastapiPort}`)}/api/explore`;
+
 export const BUILD_MODEL_API =
   normalizeUrl(import.meta.env.VITE_BUILD_MODEL_API) ||
   `${backendOrigin.replace(new RegExp(`:${djangoPort}$`), `:${fastapiPort}`)}/api/build-model-feature-based`;


### PR DESCRIPTION
## Summary
- wire up Explore atom in laboratory canvas and settings panel
- expose backend explore endpoints and API constant
- document Explore atom inclusion in category data

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest` *(fails: 4 validation errors for Settings)*

------
https://chatgpt.com/codex/tasks/task_e_68a56fb9b72883218a07a87dbdb247a4