### PR TITLE
Fix explore chart rendering for area, scatter, and pie types

### DIFF
--- a/TrinityFrontend/src/components/AtomList/atoms/explore/components/ExploreCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/explore/components/ExploreCanvas.tsx
@@ -217,12 +217,17 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
     const handleClickOutside = () => {
       setOpenDropdowns({});
       closeChatBubble();
+      setChartSettingsVisible({});
+      setChartFiltersVisible({});
     };
-    if (Object.values(openDropdowns).some(Boolean) || chatBubble.visible) {
+    const hasOpenDropdown = Object.values(openDropdowns).some(Boolean);
+    const hasOpenSettings = Object.values(chartSettingsVisible).some(Boolean);
+    const hasOpenFilters = Object.values(chartFiltersVisible).some(Boolean);
+    if (hasOpenDropdown || chatBubble.visible || hasOpenSettings || hasOpenFilters) {
       document.addEventListener('click', handleClickOutside);
     }
     return () => document.removeEventListener('click', handleClickOutside);
-  }, [openDropdowns, chatBubble.visible]);
+  }, [openDropdowns, chatBubble.visible, chartSettingsVisible, chartFiltersVisible]);
 
   // Initialize data summary collapse state
   useEffect(() => {
@@ -1773,7 +1778,10 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
                         }
                       }}
                     >
-                      <SelectTrigger className="w-28 h-8 ml-2 text-xs leading-none" disabled={isLoadingColumns}>
+                      <SelectTrigger
+                        className="w-32 min-w-[8rem] h-8 ml-2 text-xs leading-none"
+                        disabled={isLoadingColumns}
+                      >
                         <SelectValue placeholder="Select column" />
                       </SelectTrigger>
                       <SelectContent>
@@ -1795,7 +1803,10 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
 
             {/* Individual Chart Settings Panel */}
             {isSettingsVisible && (
-              <div className="mb-4 p-3 bg-blue-50 rounded-lg border border-blue-200 min-w-0 w-full explore-chart-settings">
+              <div
+                className="mb-4 p-3 bg-blue-50 rounded-lg border border-blue-200 min-w-0 w-full explore-chart-settings"
+                onClick={(e) => e.stopPropagation()}
+              >
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 min-w-0 w-full explore-chart-settings">
                   <div>
                     <Label className="text-xs text-gray-600">Chart Title</Label>
@@ -1905,13 +1916,14 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
 
             {/* Individual Chart Filters Panel */}
             {chartFiltersVisible[index] && (
-              <div 
+              <div
                 className={`mb-4 p-3 rounded-lg border relative group transition-all duration-200 cursor-pointer hover:shadow-sm hover:border-blue-300 min-w-0 ${
-                  showFilterCrossButtons[index] 
-                    ? 'bg-blue-100 border-2 border-blue-400 shadow-md' 
+                  showFilterCrossButtons[index]
+                    ? 'bg-blue-100 border-2 border-blue-400 shadow-md'
                     : 'bg-blue-50 border border-blue-200'
                 }`}
                 onDoubleClick={() => toggleFilterCrossButtons(index)}
+                onClick={(e) => e.stopPropagation()}
               >
                 {/* Double-click hint removed from top-right */}
                 

--- a/TrinityFrontend/src/components/AtomList/atoms/explore/components/ExploreCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/explore/components/ExploreCanvas.tsx
@@ -1510,6 +1510,23 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
                 >
                   <X className="w-3 h-3" />
                 </Button>
+                <Dialog>
+                  <DialogTrigger asChild>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-8 w-8 p-0"
+                      aria-label="Full screen"
+                    >
+                      <Maximize2 className="w-3 h-3" />
+                    </Button>
+                  </DialogTrigger>
+                  <DialogContent className="max-w-4xl">
+                    <div className="h-[500px] w-full">
+                      <RechartsChartRenderer {...rendererProps} />
+                    </div>
+                  </DialogContent>
+                </Dialog>
                 <button
                   onClick={() => toggleChartConfigCollapsed(index)}
                   className="p-2 hover:bg-pink-100 rounded-lg transition-colors"
@@ -2191,7 +2208,7 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
                         }`}
                         style={{
                           minHeight: config.chartType === 'pie_chart' ? '450px' : '400px',
-                          height: config.chartType === 'pie_chart' ? 'auto' : '400px',
+                          height: config.chartType === 'pie_chart' ? '450px' : '400px',
                           maxWidth: '100%'
                         }}
                       >
@@ -2221,18 +2238,6 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
                           }
                           return (
                             <div className="relative w-full h-full">
-                              <Dialog>
-                                <DialogTrigger asChild>
-                                  <button type="button" aria-label="Full screen" className="absolute top-2 right-2 z-10">
-                                    <Maximize2 className="w-4 h-4 text-gray-900" />
-                                  </button>
-                                </DialogTrigger>
-                                <DialogContent className="max-w-4xl">
-                                  <div className="h-[500px] w-full">
-                                    <RechartsChartRenderer {...rendererProps} />
-                                  </div>
-                                </DialogContent>
-                              </Dialog>
                               <RechartsChartRenderer {...rendererProps} />
                             </div>
                           );

--- a/TrinityFrontend/src/components/AtomList/atoms/explore/components/ExploreCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/explore/components/ExploreCanvas.tsx
@@ -40,7 +40,7 @@ interface ChartData {
 }
 
 const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataChange, onChartDataChange }) => {
-  const [chartDataSets, setChartDataSets] = useState<{ [idx: number]: any }>({});
+  const [chartDataSets, setChartDataSets] = useState<{ [idx: number]: any }>(data.chartDataSets || {});
   const svgRef = useRef<SVGSVGElement>(null);
   const [chartData, setChartData] = useState<ChartData | null>(null);
   const [isLoading, setIsLoading] = useState<{ [chartIndex: number]: boolean }>({});
@@ -92,14 +92,14 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
   
   // Filter state for each chart - now supports arrays for multi-selection
   const [chartFilters, setChartFilters] = useState<{ [chartIndex: number]: { [identifier: string]: string[] } }>({});
-  
+
   // Unique values for each identifier
   const [identifierUniqueValues, setIdentifierUniqueValues] = useState<{ [identifier: string]: string[] }>({});
   const [loadingUniqueValues, setLoadingUniqueValues] = useState<{ [identifier: string]: boolean }>({});
   const [openDropdowns, setOpenDropdowns] = useState<{ [key: string]: boolean }>({});
   const [appliedFilters, setAppliedFilters] = useState<{ [chartIndex: number]: boolean }>({});
   const [originalChartData, setOriginalChartData] = useState<{ [chartIndex: number]: any }>({});
-  const [chartGenerated, setChartGenerated] = useState<{ [chartIndex: number]: boolean }>({});
+  const [chartGenerated, setChartGenerated] = useState<{ [chartIndex: number]: boolean }>(data.chartGenerated || {});
   const [chartThemes, setChartThemes] = useState<{ [chartIndex: number]: string }>({});
   const [chartOptions, setChartOptions] = useState<{ [chartIndex: number]: { grid: boolean; legend: boolean; axisLabels: boolean; dataLabels: boolean } }>({});
   const [chartSortCounters, setChartSortCounters] = useState<{ [chartIndex: number]: number }>({});
@@ -139,6 +139,8 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
     chartOptions: {},
     appliedFilters: {},
     showUniqueToggles: {},
+    chartDataSets: {},
+    chartGenerated: {},
     ...data
   };
 
@@ -148,6 +150,8 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
     if (safeData.chartOptions) setChartOptions(safeData.chartOptions);
     if (safeData.appliedFilters) setAppliedFilters(safeData.appliedFilters);
     if (safeData.showUniqueToggles) setShowUniqueToggles(safeData.showUniqueToggles);
+    if (safeData.chartDataSets) setChartDataSets(safeData.chartDataSets);
+    if (safeData.chartGenerated) setChartGenerated(safeData.chartGenerated);
   }, []);
 
   // Multi-chart state
@@ -175,6 +179,16 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
     anchor: { x: 0, y: 0 }
   });
   const [chatBubbleShouldRender, setChatBubbleShouldRender] = useState(false);
+
+  // Auto-generate charts on mount if data and configs exist
+  useEffect(() => {
+    chartConfigs.forEach((cfg, index) => {
+      if (!chartDataSets[index] && cfg.xAxis && hasValidYAxes(cfg.yAxes)) {
+        safeTriggerChartGeneration(index, cfg, 0);
+      }
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const openChartTypeTray = (e: React.MouseEvent, index: number) => {
     e.preventDefault();
@@ -2580,6 +2594,8 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
       chartFilters,
       chartThemes,
       chartOptions,
+      chartDataSets,
+      chartGenerated,
       appliedFilters,
       showUniqueToggles,
       xAxis: config.xAxis,

--- a/TrinityFrontend/src/components/AtomList/atoms/explore/components/RechartsChartRenderer.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/explore/components/RechartsChartRenderer.tsx
@@ -513,9 +513,9 @@ const RechartsChartRenderer: React.FC<Props> = ({
     return { pivoted: Array.from(map.values()), uniqueValues };
   };
 
-  // Memoized pivoted data for line charts and bar charts with legend field
+  // Memoized pivoted data for charts with legend field
   const { pivoted: pivotedLineData, uniqueValues: legendValues } = useMemo(() => {
-    if ((type === 'line_chart' || type === 'bar_chart') && legendField && xField && yField) {
+    if ((type === 'line_chart' || type === 'bar_chart' || type === 'area_chart' || type === 'scatter_chart') && legendField && xField && yField) {
       // Check if data is already pivoted (has multiple Y-axis columns)
       const isDataAlreadyPivoted = chartDataForRendering.length > 0 && 
         chartDataForRendering[0] && 
@@ -939,7 +939,7 @@ const RechartsChartRenderer: React.FC<Props> = ({
           // For bar charts, prioritize actual field names over generic keys
           xKey = xField || (availableKeys.includes('x') ? 'x' : availableKeys.includes('name') ? 'name' : availableKeys.includes('category') ? 'category' : availableKeys[0]);
           yKey = yField || (availableKeys.includes('y') ? 'y' : availableKeys.includes('value') ? 'value' : availableKeys[1] || availableKeys[0]);
-        } else if (type === 'line_chart') {
+    } else if (type === 'line_chart' || type === 'area_chart' || type === 'scatter_chart') {
           xKey = availableKeys.includes('x') ? 'x' : availableKeys.includes('date') ? 'date' : availableKeys[0];
           yKey = availableKeys.includes('y') ? 'y' : availableKeys.includes('value') ? 'value' : availableKeys[1] || availableKeys[0];
         }
@@ -956,7 +956,7 @@ const RechartsChartRenderer: React.FC<Props> = ({
         } else if (type === 'bar_chart') {
           xKey = xField || (availableKeys.includes('x') ? 'x' : availableKeys.includes('name') ? 'name' : availableKeys.includes('category') ? 'category' : availableKeys[0]);
           yKey = yField || (availableKeys.includes('y') ? 'y' : availableKeys.includes('value') ? 'value' : availableKeys[1] || availableKeys[0]);
-        } else if (type === 'line_chart') {
+        } else if (type === 'line_chart' || type === 'area_chart' || type === 'scatter_chart') {
           xKey = availableKeys.includes('x') ? 'x' : availableKeys.includes('date') ? 'date' : availableKeys[0];
           yKey = availableKeys.includes('y') ? 'y' : availableKeys.includes('value') ? 'value' : availableKeys[1] || availableKeys[0];
         }
@@ -1977,8 +1977,8 @@ const RechartsChartRenderer: React.FC<Props> = ({
                 const baseWidth = 800; // Minimum width
                 let calculatedWidth = baseWidth;
                 
-                if (type === 'line_chart' || type === 'bar_chart') {
-                  // For line and bar charts, allocate more width per data point
+                if (type === 'line_chart' || type === 'bar_chart' || type === 'area_chart' || type === 'scatter_chart') {
+                  // For line, bar, area and scatter charts, allocate more width per data point
                   calculatedWidth = Math.max(chartDataForRendering.length * 60, baseWidth);
                 } else if (type === 'pie_chart') {
                   // For pie charts, use fixed width as they don't need horizontal scrolling

--- a/TrinityFrontend/src/components/LaboratoryMode/store/laboratoryStore.ts
+++ b/TrinityFrontend/src/components/LaboratoryMode/store/laboratoryStore.ts
@@ -321,6 +321,8 @@ export interface ExploreData {
   fallbackDimensions?: string[];
   fallbackMeasures?: string[];
   applied?: boolean;
+  chartDataSets?: { [idx: number]: any };
+  chartGenerated?: { [chartIndex: number]: boolean };
   [key: string]: any;
 }
 


### PR DESCRIPTION
## Summary
- Support legend-based area and scatter charts in Explore by pivoting data and expanding key detection
- Render pie charts at fixed height and add full-screen control next to chart actions
- Treat all cartesian chart types consistently for width calculations

## Testing
- `npm run lint` *(fails: Fast refresh only works when a file only exports components and other lint errors)*
- `npx eslint src/components/AtomList/atoms/explore/components/ExploreCanvas.tsx src/components/AtomList/atoms/explore/components/RechartsChartRenderer.tsx` *(fails: Empty block statement, no-prototype-builtins, no-case-declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68a72a9e47ac832180eee0a21e5e2fea