### PR TITLE
fix: persist explore atom state on reload

### DIFF
--- a/TrinityFrontend/src/components/AtomList/atoms/explore/components/ExploreCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/explore/components/ExploreCanvas.tsx
@@ -180,6 +180,40 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
   });
   const [chatBubbleShouldRender, setChatBubbleShouldRender] = useState(false);
 
+  // Persist chart state changes to parent atom settings for saving/loading
+  useEffect(() => {
+    const primaryConfig = chartConfigs[0] || {};
+    onDataChange({
+      chartConfigs,
+      chartFilters,
+      chartThemes,
+      chartOptions,
+      chartDataSets,
+      chartGenerated,
+      appliedFilters,
+      showUniqueToggles,
+      xAxis: primaryConfig.xAxis || '',
+      yAxis: primaryConfig.yAxes?.[0] || '',
+      xAxisLabel: primaryConfig.xAxisLabel || '',
+      yAxisLabel: primaryConfig.yAxisLabels?.[0] || '',
+      chartType: primaryConfig.chartType || 'line_chart',
+      legendField: primaryConfig.legendField || '',
+      aggregation: primaryConfig.aggregation || 'no_aggregation',
+      weightColumn: primaryConfig.weightColumn || '',
+      title: primaryConfig.title || '',
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    chartConfigs,
+    chartFilters,
+    chartThemes,
+    chartOptions,
+    chartDataSets,
+    chartGenerated,
+    appliedFilters,
+    showUniqueToggles,
+  ]);
+
   // Auto-generate charts on mount if data and configs exist
   useEffect(() => {
     chartConfigs.forEach((cfg, index) => {


### PR DESCRIPTION
## Summary
- persist chart config and data to atom settings so explore atom reloads correctly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: React Hooks must be called in same order, unexpected lexical declarations, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a73b9f23c48321a788c853f1b6add3