### PR TITLE
fix: preserve x-axis labels when pivoting

### DIFF
--- a/TrinityFrontend/src/components/AtomList/atoms/explore/components/ExploreCanvas.css
+++ b/TrinityFrontend/src/components/AtomList/atoms/explore/components/ExploreCanvas.css
@@ -155,7 +155,7 @@
 .explore-chart-settings {
   width: 100%;
   max-width: 100%;
-  overflow: hidden;
+  overflow: visible;
   min-width: 0;
 }
 

--- a/TrinityFrontend/src/components/AtomList/atoms/explore/components/ExploreCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/explore/components/ExploreCanvas.tsx
@@ -139,13 +139,32 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
   };
 
   useEffect(() => {
-    if (safeData.chartFilters) setChartFilters(safeData.chartFilters);
-    if (safeData.chartThemes) setChartThemes(safeData.chartThemes);
-    if (safeData.chartOptions) setChartOptions(safeData.chartOptions);
-    if (safeData.appliedFilters) setAppliedFilters(safeData.appliedFilters);
-    if (safeData.chartDataSets) setChartDataSets(safeData.chartDataSets);
-    if (safeData.chartGenerated) setChartGenerated(safeData.chartGenerated);
-  }, []);
+    if (data.chartFilters && data.chartFilters !== chartFilters) {
+      setChartFilters(data.chartFilters);
+    }
+    if (data.chartThemes && data.chartThemes !== chartThemes) {
+      setChartThemes(data.chartThemes);
+    }
+    if (data.chartOptions && data.chartOptions !== chartOptions) {
+      setChartOptions(data.chartOptions);
+    }
+    if (data.appliedFilters && data.appliedFilters !== appliedFilters) {
+      setAppliedFilters(data.appliedFilters);
+    }
+    if (data.chartDataSets && data.chartDataSets !== chartDataSets) {
+      setChartDataSets(data.chartDataSets);
+    }
+    if (data.chartGenerated && data.chartGenerated !== chartGenerated) {
+      setChartGenerated(data.chartGenerated);
+    }
+  }, [
+    data.chartFilters,
+    data.chartThemes,
+    data.chartOptions,
+    data.appliedFilters,
+    data.chartDataSets,
+    data.chartGenerated,
+  ]);
 
   // Multi-chart state
   const [chartConfigs, setChartConfigs] = useState(

--- a/TrinityFrontend/src/components/AtomList/atoms/explore/components/ExploreCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/explore/components/ExploreCanvas.tsx
@@ -1679,7 +1679,7 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
                       }
                     }}
                   >
-                    <SelectTrigger className="w-32 h-8 text-xs leading-none" disabled={isLoadingColumns}>
+                    <SelectTrigger className="w-24 h-8 text-xs leading-none" disabled={isLoadingColumns}>
                       <SelectValue
                         placeholder={
                           isLoadingColumns
@@ -1742,7 +1742,7 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
                                 }
                               }}
                             >
-                              <SelectTrigger className="w-32 h-8 text-xs leading-none" disabled={isLoadingColumns}>
+                              <SelectTrigger className="w-24 h-8 text-xs leading-none" disabled={isLoadingColumns}>
                                 <SelectValue
                                   placeholder={
                                     isLoadingColumns
@@ -1854,10 +1854,10 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
                     }}
                   >
                     <SelectTrigger
-                      className="w-40 h-8 ml-2 pr-4 text-xs leading-none truncate"
+                      className="w-40 h-8 ml-2 pr-2 text-xs leading-none [&>span:last-child>svg]:w-3 [&>span:last-child>svg]:h-3"
                       disabled={isLoadingColumns}
                     >
-                      <SelectValue placeholder="Segregate Field Values" />
+                      <SelectValue placeholder="Segregate Field Values" className="truncate" />
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="aggregate">Show Aggregate</SelectItem>

--- a/TrinityFrontend/src/components/AtomList/atoms/explore/components/ExploreCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/explore/components/ExploreCanvas.tsx
@@ -1854,10 +1854,10 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
                     }}
                   >
                     <SelectTrigger
-                      className="min-w-[8rem] h-8 ml-2 pr-4 text-xs leading-none whitespace-nowrap"
+                      className="w-40 h-8 ml-2 pr-4 text-xs leading-none truncate"
                       disabled={isLoadingColumns}
                     >
-                      <SelectValue placeholder="Select Column to Segregate Field Values" />
+                      <SelectValue placeholder="Segregate Field Values" />
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="aggregate">Show Aggregate</SelectItem>

--- a/TrinityFrontend/src/components/AtomList/atoms/explore/components/ExploreCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/explore/components/ExploreCanvas.tsx
@@ -83,9 +83,6 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
 
   const [chartSettingsVisible, setChartSettingsVisible] = useState<{ [key: number]: boolean }>({});
   const [chartFiltersVisible, setChartFiltersVisible] = useState<{ [key: number]: boolean }>({});
-
-  const settingsRefs = useRef<{ [key: number]: HTMLDivElement | null }>({});
-
   const [isLoadingColumnSummary, setIsLoadingColumnSummary] = useState(false);
   
   // Per-card collapse states
@@ -260,51 +257,26 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
     setOpenDropdowns({});
     closeChatBubble();
     setChatBubbleShouldRender(false);
-    if (Object.values(chartSettingsVisible).some(Boolean)) {
-      setChartSettingsVisible({});
-    }
   };
 
   const overlayVisible =
     chatBubble.visible ||
-    chatBubbleShouldRender ||
-    Object.values(chartSettingsVisible).some(Boolean);
+    chatBubbleShouldRender;
 
   useEffect(() => {
     const handleClickOutside = () => {
       setOpenDropdowns({});
       closeChatBubble();
       setChatBubbleShouldRender(false);
-      if (Object.values(chartSettingsVisible).some(Boolean)) {
-        setChartSettingsVisible({});
-      }
     };
     if (
       Object.values(openDropdowns).some(Boolean) ||
-      chatBubble.visible ||
-      Object.values(chartSettingsVisible).some(Boolean)
+      chatBubble.visible
     ) {
       document.addEventListener('click', handleClickOutside);
     }
     return () => document.removeEventListener('click', handleClickOutside);
-  }, [openDropdowns, chatBubble.visible, chartSettingsVisible]);
-
-  // Close settings tray when clicking outside of it
-  useEffect(() => {
-    const handleSettingsClick = (e: MouseEvent) => {
-      const openEntry = Object.entries(chartSettingsVisible).find(([, v]) => v);
-      if (!openEntry) return;
-      const [index] = openEntry;
-      const ref = settingsRefs.current[Number(index)];
-      if (ref && !ref.contains(e.target as Node)) {
-        setChartSettingsVisible(prev => ({ ...prev, [Number(index)]: false }));
-      }
-    };
-    if (Object.values(chartSettingsVisible).some(Boolean)) {
-      document.addEventListener('mousedown', handleSettingsClick);
-    }
-    return () => document.removeEventListener('mousedown', handleSettingsClick);
-  }, [chartSettingsVisible]);
+  }, [openDropdowns, chatBubble.visible]);
 
   // Initialize data summary collapse state
   useEffect(() => {
@@ -1910,7 +1882,6 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
             {isSettingsVisible && (
               <div
                 className="mb-4 p-3 bg-blue-50 rounded-lg border border-blue-200 min-w-0 w-full explore-chart-settings"
-                ref={(el) => (settingsRefs.current[index] = el)}
                 onClick={(e) => e.stopPropagation()}
                 style={{ position: 'relative', zIndex: 50 }}
               >

--- a/TrinityFrontend/src/components/AtomList/atoms/explore/components/ExploreCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/explore/components/ExploreCanvas.tsx
@@ -1894,10 +1894,10 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
                         const newConfigs = [...chartConfigs];
                         newConfigs[index] = { ...newConfigs[index], title: e.target.value };
                         setChartConfigs(newConfigs);
-                        
-                                                                         // Regenerate chart when title changes to update display
-                        if (config.xAxis && hasValidYAxes(config.yAxes)) {
-                          const newConfig = { ...newConfigs[index], title: e.target.value };
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' && config.xAxis && hasValidYAxes(config.yAxes)) {
+                          const newConfig = { ...chartConfigs[index], title: e.currentTarget.value };
                           safeTriggerChartGeneration(index, newConfig, 100);
                         }
                       }}
@@ -1909,17 +1909,17 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
                     <Label className="text-xs text-gray-600">X-Axis Label</Label>
                     <Input
                       value={config.xAxisLabel || ''}
-                                                onChange={(e) => {
-                            const newConfigs = [...chartConfigs];
-                            newConfigs[index] = { ...newConfigs[index], xAxisLabel: e.target.value };
-                            setChartConfigs(newConfigs);
-                            
-                                                                                 // Regenerate chart when X-axis label changes to update display
-                          if (config.xAxis && hasValidYAxes(config.yAxes)) {
-                            const newConfig = { ...newConfigs[index], xAxisLabel: e.target.value };
-                            safeTriggerChartGeneration(index, newConfig, 100);
-                          }
-                          }}
+                      onChange={(e) => {
+                        const newConfigs = [...chartConfigs];
+                        newConfigs[index] = { ...newConfigs[index], xAxisLabel: e.target.value };
+                        setChartConfigs(newConfigs);
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' && config.xAxis && hasValidYAxes(config.yAxes)) {
+                          const newConfig = { ...chartConfigs[index], xAxisLabel: e.currentTarget.value };
+                          safeTriggerChartGeneration(index, newConfig, 100);
+                        }
+                      }}
                       className="h-8 text-xs"
                       placeholder="X label"
                     />
@@ -1938,16 +1938,15 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
                               yAxisLabels: Array.isArray(newConfigs[index].yAxisLabels) ? newConfigs[index].yAxisLabels.map((_, i) => (i === yAxisIndex ? e.target.value : _)) : []
                             };
                             setChartConfigs(newConfigs);
-                            
-                                                                                 // Regenerate chart when Y-axis label changes to update display
-                          if (config.xAxis && hasValidYAxes(config.yAxes)) {
-                            const newConfig = { 
-                              ...newConfigs[index],
-                              yAxisLabels: Array.isArray(newConfigs[index].yAxisLabels) ? 
-                                newConfigs[index].yAxisLabels.map((_, i) => (i === yAxisIndex ? e.target.value : _)) : []
-                            };
-                            safeTriggerChartGeneration(index, newConfig, 100);
-                          }
+                          }}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter' && config.xAxis && hasValidYAxes(config.yAxes)) {
+                              const updatedLabels = Array.isArray(config.yAxisLabels)
+                                ? config.yAxisLabels.map((label, i) => (i === yAxisIndex ? e.currentTarget.value : label))
+                                : [];
+                              const newConfig = { ...chartConfigs[index], yAxisLabels: updatedLabels };
+                              safeTriggerChartGeneration(index, newConfig, 100);
+                            }
                           }}
                           className="h-8 text-xs"
                           placeholder={`Y${yAxisIndex + 1} label`}

--- a/TrinityFrontend/src/components/AtomList/atoms/explore/components/RechartsChartRenderer.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/explore/components/RechartsChartRenderer.tsx
@@ -349,6 +349,8 @@ const RechartsChartRenderer: React.FC<Props> = ({
   const [showContextMenu, setShowContextMenu] = useState(false);
   const [showColorSubmenu, setShowColorSubmenu] = useState(false);
   const [showSortSubmenu, setShowSortSubmenu] = useState(false);
+  const [colorSubmenuPosition, setColorSubmenuPosition] = useState({ x: 0, y: 0 });
+  const [sortSubmenuPosition, setSortSubmenuPosition] = useState({ x: 0, y: 0 });
 
 
 
@@ -659,15 +661,17 @@ const RechartsChartRenderer: React.FC<Props> = ({
   };
 
   // Handle color theme submenu toggle
-  const handleColorThemeClick = () => {
-    setShowColorSubmenu(prevState => {
-      const newState = !prevState;
-      return newState;
-    });
+  const handleColorThemeClick = (e: React.MouseEvent) => {
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    setColorSubmenuPosition({ x: rect.right + 4, y: rect.top });
+    setShowColorSubmenu(prevState => !prevState);
+    setShowSortSubmenu(false);
   };
 
   // Handle sort submenu toggle
-  const handleSortClick = () => {
+  const handleSortClick = (e: React.MouseEvent) => {
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    setSortSubmenuPosition({ x: rect.right + 4, y: rect.top });
     setShowSortSubmenu(prev => !prev);
     setShowColorSubmenu(false);
   };
@@ -804,7 +808,7 @@ const RechartsChartRenderer: React.FC<Props> = ({
           onClick={(e) => {
             e.preventDefault();
             e.stopPropagation();
-            handleColorThemeClick();
+            handleColorThemeClick(e);
           }}
         >
           <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -822,7 +826,7 @@ const RechartsChartRenderer: React.FC<Props> = ({
           onClick={(e) => {
             e.preventDefault();
             e.stopPropagation();
-            handleSortClick();
+            handleSortClick(e);
           }}
         >
           <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -935,11 +939,11 @@ const RechartsChartRenderer: React.FC<Props> = ({
     if (!showColorSubmenu) return null;
 
     return (
-      <div 
+      <div
         className="fixed z-[9999] bg-white border border-gray-300 rounded-lg shadow-xl p-3 color-submenu"
-        style={{ 
-          left: contextMenuPosition.x + 96, // Half of min-w-48 (192px/2) + small gap
-          top: contextMenuPosition.y - 120, // Align with the context menu
+        style={{
+          left: colorSubmenuPosition.x,
+          top: colorSubmenuPosition.y,
           minWidth: '240px',
           maxHeight: '320px',
           overflowY: 'auto'
@@ -996,8 +1000,8 @@ const RechartsChartRenderer: React.FC<Props> = ({
       <div
         className="fixed z-[9999] bg-white border border-gray-300 rounded-lg shadow-xl p-2 sort-submenu"
         style={{
-          left: contextMenuPosition.x + 96,
-          top: contextMenuPosition.y - 40,
+          left: sortSubmenuPosition.x,
+          top: sortSubmenuPosition.y,
           minWidth: '160px'
         }}
       >

--- a/TrinityFrontend/src/components/AtomList/atoms/explore/components/RechartsChartRenderer.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/explore/components/RechartsChartRenderer.tsx
@@ -607,7 +607,10 @@ const RechartsChartRenderer: React.FC<Props> = ({
           return !isXAxisField && typeof firstRow[key] === 'number';
         });
 
-        const actualXKey = Object.keys(firstRow).find(k => k.toLowerCase() === xField.toLowerCase()) || Object.keys(firstRow)[0];
+        const actualXKey =
+          Object.keys(firstRow).find(k => k.toLowerCase() === xField.toLowerCase()) ||
+          Object.keys(firstRow).find(k => !legendColumns.includes(k)) ||
+          Object.keys(firstRow)[0];
 
         return {
           pivoted: chartDataForRendering,
@@ -1341,7 +1344,11 @@ const RechartsChartRenderer: React.FC<Props> = ({
          * Multi-bar rendering when a legend field is provided
          * ----------------------------------------------------------- */
         if (legendField && legendValues.length > 0 && pivotedLineData.length > 0) {
-          const xKeyForBar = pivotActualXKey || xField || Object.keys(pivotedLineData[0] || {})[0];
+          const xKeyForBar =
+            pivotActualXKey ||
+            xField ||
+            Object.keys(pivotedLineData[0] || {}).find(k => !legendValues.includes(k)) ||
+            Object.keys(pivotedLineData[0] || {})[0];
           return (
             <BarChart data={pivotedLineData} margin={{ top: 20, right: 20, left: 20, bottom: 20 }}>
               {currentShowGrid && <CartesianGrid strokeDasharray="3 3" />}
@@ -1556,7 +1563,11 @@ const RechartsChartRenderer: React.FC<Props> = ({
          * ----------------------------------------------------------- */
         if (legendField && legendValues.length > 0 && pivotedLineData.length > 0) {
           // Use the actual X-axis key determined during pivoting
-          const xKeyForLine = pivotActualXKey || xField || Object.keys(pivotedLineData[0])[0];
+          const xKeyForLine =
+            pivotActualXKey ||
+            xField ||
+            Object.keys(pivotedLineData[0] || {}).find(k => !legendValues.includes(k)) ||
+            Object.keys(pivotedLineData[0] || {})[0];
           return (
             <LineChart data={pivotedLineData} margin={{ top: 20, right: 20, left: 20, bottom: 20 }}>
               {currentShowGrid && <CartesianGrid strokeDasharray="3 3" />}
@@ -1762,7 +1773,11 @@ const RechartsChartRenderer: React.FC<Props> = ({
 
       case 'area_chart':
         if (legendField && legendValues.length > 0 && pivotedLineData.length > 0) {
-          const xKeyForArea = pivotActualXKey || xField || Object.keys(pivotedLineData[0])[0];
+          const xKeyForArea =
+            pivotActualXKey ||
+            xField ||
+            Object.keys(pivotedLineData[0] || {}).find(k => !legendValues.includes(k)) ||
+            Object.keys(pivotedLineData[0] || {})[0];
           return (
             <AreaChart data={pivotedLineData} margin={{ top: 20, right: 20, left: 20, bottom: 20 }}>
               {currentShowGrid && <CartesianGrid strokeDasharray="3 3" />}
@@ -1847,7 +1862,11 @@ const RechartsChartRenderer: React.FC<Props> = ({
       case 'scatter_chart':
         const xKeyForScatter =
           legendField && legendValues.length > 0 && pivotedLineData.length > 0
-            ? pivotActualXKey || xField || Object.keys(pivotedLineData[0])[0]
+            ?
+                pivotActualXKey ||
+                xField ||
+                Object.keys(pivotedLineData[0] || {}).find(k => !legendValues.includes(k)) ||
+                Object.keys(pivotedLineData[0] || {})[0]
             : xKey;
         return (
           <ScatterChart margin={{ top: 20, right: 20, left: 20, bottom: 20 }}>

--- a/TrinityFrontend/src/components/AtomList/atoms/explore/components/RechartsChartRenderer.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/explore/components/RechartsChartRenderer.tsx
@@ -627,10 +627,11 @@ const RechartsChartRenderer: React.FC<Props> = ({
   // Styling for axis ticks & labels
   const axisTickStyle = { fontFamily: FONT_FAMILY, fontSize: 12, fill: '#475569' } as const;
   const axisLabelStyle = {
-    fontFamily: FONT_FAMILY, 
-    fontSize: 14, 
+    fontFamily: FONT_FAMILY,
+    fontSize: 14,
     fontWeight: 'bold',
-    fill: '#334155' 
+    fill: '#334155',
+    textAnchor: 'middle'
   } as const;
 
   // Handle right-click context menu
@@ -1350,7 +1351,7 @@ const RechartsChartRenderer: React.FC<Props> = ({
             Object.keys(pivotedLineData[0] || {}).find(k => !legendValues.includes(k)) ||
             Object.keys(pivotedLineData[0] || {})[0];
           return (
-            <BarChart data={pivotedLineData} margin={{ top: 20, right: 20, left: 20, bottom: 20 }}>
+            <BarChart data={pivotedLineData} margin={{ top: 20, right: 20, left: 20, bottom: 40 }}>
               {currentShowGrid && <CartesianGrid strokeDasharray="3 3" />}
               <XAxis
                 dataKey={xKeyForBar}
@@ -1399,7 +1400,7 @@ const RechartsChartRenderer: React.FC<Props> = ({
                   layout="horizontal"
                   verticalAlign="bottom"
                   align="center"
-                  wrapperStyle={{ paddingTop: '15px', fontSize: '11px' }}
+                  wrapperStyle={{ bottom: 20, fontSize: '11px' }}
                 />
               )}
               {legendValues.map((seriesKey, idx) => (
@@ -1426,7 +1427,7 @@ const RechartsChartRenderer: React.FC<Props> = ({
         } else {
           // ---- Fallback to original single-bar rendering ----
           return (
-            <BarChart data={transformedChartData} margin={{ top: 20, right: 20, left: 20, bottom: 20 }}>
+            <BarChart data={transformedChartData} margin={{ top: 20, right: 20, left: 20, bottom: 40 }}>
               {currentShowGrid && <CartesianGrid strokeDasharray="3 3" />}
             <XAxis 
               dataKey={xKey} 
@@ -1491,16 +1492,11 @@ const RechartsChartRenderer: React.FC<Props> = ({
               cursor={{ stroke: palette[0], strokeWidth: 1, strokeOpacity: 0.4 }}
             />
             {currentShowLegend && (
-              <Legend 
+              <Legend
                 layout="horizontal"
                 verticalAlign="bottom"
                 align="center"
-                wrapperStyle={{ 
-                  paddingTop: '15px',
-                  paddingBottom: '10px',
-                  fontSize: '11px',
-                  marginBottom: '0px'
-                }}
+                wrapperStyle={{ bottom: 20, fontSize: '11px' }}
                 formatter={(value, entry) => {
                   // Format legend labels for dual y-axes
                   if (yFields && yFields.length > 1) {
@@ -1569,7 +1565,7 @@ const RechartsChartRenderer: React.FC<Props> = ({
             Object.keys(pivotedLineData[0] || {}).find(k => !legendValues.includes(k)) ||
             Object.keys(pivotedLineData[0] || {})[0];
           return (
-            <LineChart data={pivotedLineData} margin={{ top: 20, right: 20, left: 20, bottom: 20 }}>
+            <LineChart data={pivotedLineData} margin={{ top: 20, right: 20, left: 20, bottom: 40 }}>
               {currentShowGrid && <CartesianGrid strokeDasharray="3 3" />}
               <XAxis
                 dataKey={xKeyForLine}
@@ -1591,7 +1587,7 @@ const RechartsChartRenderer: React.FC<Props> = ({
                   layout="horizontal"
                   verticalAlign="bottom"
                   align="center"
-                  wrapperStyle={{ paddingTop: '15px', fontSize: '11px' }}
+                  wrapperStyle={{ bottom: 20, fontSize: '11px' }}
                 />
               )}
               {legendValues.map((seriesKey, idx) => (
@@ -1621,7 +1617,7 @@ const RechartsChartRenderer: React.FC<Props> = ({
           // ---- Fallback to original single-line rendering ----
           // Original single line chart logic
           return (
-            <LineChart data={chartDataForRendering} margin={{ top: 20, right: 20, left: 20, bottom: 20 }} className="explore-chart-line">
+            <LineChart data={chartDataForRendering} margin={{ top: 20, right: 20, left: 20, bottom: 40 }} className="explore-chart-line">
               {currentShowGrid && <CartesianGrid strokeDasharray="3 3" />}
               <XAxis 
                 dataKey={xKey}
@@ -1686,16 +1682,11 @@ const RechartsChartRenderer: React.FC<Props> = ({
                 cursor={{ stroke: palette[0], strokeWidth: 1, strokeOpacity: 0.4 }}
               />
               {currentShowLegend && (
-                <Legend 
+                <Legend
                   layout="horizontal"
                   verticalAlign="bottom"
                   align="center"
-                  wrapperStyle={{ 
-                    paddingTop: '15px',
-                    paddingBottom: '10px',
-                    fontSize: '11px',
-                    marginBottom: '0px'
-                  }}
+                  wrapperStyle={{ bottom: 20, fontSize: '11px' }}
                   formatter={(value, entry) => {
                     // Format legend labels for dual y-axes
                     if (yFields && yFields.length > 1) {
@@ -1779,7 +1770,7 @@ const RechartsChartRenderer: React.FC<Props> = ({
             Object.keys(pivotedLineData[0] || {}).find(k => !legendValues.includes(k)) ||
             Object.keys(pivotedLineData[0] || {})[0];
           return (
-            <AreaChart data={pivotedLineData} margin={{ top: 20, right: 20, left: 20, bottom: 20 }}>
+            <AreaChart data={pivotedLineData} margin={{ top: 20, right: 20, left: 20, bottom: 40 }}>
               {currentShowGrid && <CartesianGrid strokeDasharray="3 3" />}
               <XAxis
                 dataKey={xKeyForArea}
@@ -1801,7 +1792,7 @@ const RechartsChartRenderer: React.FC<Props> = ({
                   layout="horizontal"
                   verticalAlign="bottom"
                   align="center"
-                  wrapperStyle={{ paddingTop: '15px', fontSize: '11px' }}
+                  wrapperStyle={{ bottom: 20, fontSize: '11px' }}
                 />
               )}
               {legendValues.map((seriesKey, idx) => (
@@ -1818,7 +1809,7 @@ const RechartsChartRenderer: React.FC<Props> = ({
           );
         }
         return (
-          <AreaChart data={chartDataForRendering} margin={{ top: 20, right: 20, left: 20, bottom: 20 }}>
+          <AreaChart data={chartDataForRendering} margin={{ top: 20, right: 20, left: 20, bottom: 40 }}>
             {currentShowGrid && <CartesianGrid strokeDasharray="3 3" />}
             <XAxis
               dataKey={xKey}
@@ -1849,7 +1840,7 @@ const RechartsChartRenderer: React.FC<Props> = ({
                 layout="horizontal"
                 verticalAlign="bottom"
                 align="center"
-                wrapperStyle={{ paddingTop: '15px', fontSize: '11px' }}
+                wrapperStyle={{ bottom: 20, fontSize: '11px' }}
               />
             )}
             <Area type="monotone" dataKey={yKey} stroke={palette[0]} fill={palette[1]} yAxisId={0} />
@@ -1869,7 +1860,7 @@ const RechartsChartRenderer: React.FC<Props> = ({
                 Object.keys(pivotedLineData[0] || {})[0]
             : xKey;
         return (
-          <ScatterChart margin={{ top: 20, right: 20, left: 20, bottom: 20 }}>
+          <ScatterChart margin={{ top: 20, right: 20, left: 20, bottom: 40 }}>
             {currentShowGrid && <CartesianGrid strokeDasharray="3 3" />}
             <XAxis
               dataKey={xKeyForScatter}
@@ -1902,7 +1893,7 @@ const RechartsChartRenderer: React.FC<Props> = ({
                 layout="horizontal"
                 verticalAlign="bottom"
                 align="center"
-                wrapperStyle={{ paddingTop: '15px', fontSize: '11px' }}
+                wrapperStyle={{ bottom: 20, fontSize: '11px' }}
               />
             )}
             {legendField && legendValues.length > 0 && pivotedLineData.length > 0 ? (

--- a/TrinityFrontend/src/components/AtomList/atoms/explore/components/RechartsChartRenderer.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/explore/components/RechartsChartRenderer.tsx
@@ -349,13 +349,8 @@ const RechartsChartRenderer: React.FC<Props> = ({
   const [showContextMenu, setShowContextMenu] = useState(false);
   const [showColorSubmenu, setShowColorSubmenu] = useState(false);
   const [showSortSubmenu, setShowSortSubmenu] = useState(false);
-  const [colorSubmenuPosition, setColorSubmenuPosition] = useState({ x: 0, y: 0 });
-  const [sortSubmenuPosition, setSortSubmenuPosition] = useState({ x: 0, y: 0 });
-
-
-
-
-
+  const [colorSubmenuPos, setColorSubmenuPos] = useState<{ x: number; y: number }>({ x: 0, y: 0 });
+  const [sortSubmenuPos, setSortSubmenuPos] = useState<{ x: number; y: number }>({ x: 0, y: 0 });
   const [contextMenuPosition, setContextMenuPosition] = useState({ x: 0, y: 0 });
   const chartRef = useRef<HTMLDivElement>(null);
 
@@ -374,6 +369,23 @@ const RechartsChartRenderer: React.FC<Props> = ({
   const [showLegend, setShowLegend] = useState(true);
   const [showAxisLabels, setShowAxisLabels] = useState(true);
   const [showDataLabels, setShowDataLabels] = useState(true);
+
+  // Sync internal states with external props for persistence
+  useEffect(() => {
+    if (propShowGrid !== undefined) setShowGrid(propShowGrid);
+  }, [propShowGrid]);
+
+  useEffect(() => {
+    if (propShowLegend !== undefined) setShowLegend(propShowLegend);
+  }, [propShowLegend]);
+
+  useEffect(() => {
+    if (propShowAxisLabels !== undefined) setShowAxisLabels(propShowAxisLabels);
+  }, [propShowAxisLabels]);
+
+  useEffect(() => {
+    if (propShowDataLabels !== undefined) setShowDataLabels(propShowDataLabels);
+  }, [propShowDataLabels]);
 
   // Use data prop directly now that sorting is removed
   const chartData = data;
@@ -662,16 +674,20 @@ const RechartsChartRenderer: React.FC<Props> = ({
 
   // Handle color theme submenu toggle
   const handleColorThemeClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
     const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-    setColorSubmenuPosition({ x: rect.right + 4, y: rect.top });
+    setColorSubmenuPos({ x: rect.right + 4, y: rect.top });
     setShowColorSubmenu(prevState => !prevState);
     setShowSortSubmenu(false);
   };
 
   // Handle sort submenu toggle
   const handleSortClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
     const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-    setSortSubmenuPosition({ x: rect.right + 4, y: rect.top });
+    setSortSubmenuPos({ x: rect.right + 4, y: rect.top });
     setShowSortSubmenu(prev => !prev);
     setShowColorSubmenu(false);
   };
@@ -805,11 +821,7 @@ const RechartsChartRenderer: React.FC<Props> = ({
         {/* Color Theme Option */}
         <button
           className="w-full px-4 py-2 text-sm text-left hover:bg-gray-50 flex items-center gap-3 text-gray-700 relative"
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            handleColorThemeClick(e);
-          }}
+          onClick={handleColorThemeClick}
         >
           <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zM21 5a2 2 0 00-2-2h-4a2 2 0 00-2 2v12a4 4 0 004 4h4a2 2 0 002-2V5z" />
@@ -823,11 +835,7 @@ const RechartsChartRenderer: React.FC<Props> = ({
         {/* Sort Option */}
         <button
           className="w-full px-4 py-2 text-sm text-left hover:bg-gray-50 flex items-center gap-3 text-gray-700 relative"
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            handleSortClick(e);
-          }}
+          onClick={handleSortClick}
         >
           <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 9l6-6 6 6M18 15l-6 6-6-6" />
@@ -942,8 +950,8 @@ const RechartsChartRenderer: React.FC<Props> = ({
       <div
         className="fixed z-[9999] bg-white border border-gray-300 rounded-lg shadow-xl p-3 color-submenu"
         style={{
-          left: colorSubmenuPosition.x,
-          top: colorSubmenuPosition.y,
+          left: colorSubmenuPos.x,
+          top: colorSubmenuPos.y,
           minWidth: '240px',
           maxHeight: '320px',
           overflowY: 'auto'
@@ -1000,8 +1008,8 @@ const RechartsChartRenderer: React.FC<Props> = ({
       <div
         className="fixed z-[9999] bg-white border border-gray-300 rounded-lg shadow-xl p-2 sort-submenu"
         style={{
-          left: sortSubmenuPosition.x,
-          top: sortSubmenuPosition.y,
+          left: sortSubmenuPos.x,
+          top: sortSubmenuPos.y,
           minWidth: '160px'
         }}
       >

--- a/TrinityFrontend/src/components/LaboratoryMode/store/laboratoryStore.ts
+++ b/TrinityFrontend/src/components/LaboratoryMode/store/laboratoryStore.ts
@@ -323,6 +323,7 @@ export interface ExploreData {
   applied?: boolean;
   chartDataSets?: { [idx: number]: any };
   chartGenerated?: { [chartIndex: number]: boolean };
+  chartNotes?: { [chartIndex: number]: string };
   [key: string]: any;
 }
 


### PR DESCRIPTION
## Summary
- ensure Explore charts keep original x-axis field when data is pivoted
- avoid using legend series as fallback x-axis key for bar, line, area, and scatter charts

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 47 errors, 59 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a874426ff0832199066f4f37c9fe12