### PR TITLE
fix: define showUniqueToggles state

### DIFF
--- a/TrinityFrontend/src/components/AtomList/atoms/explore/components/ExploreCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/explore/components/ExploreCanvas.tsx
@@ -105,7 +105,8 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
   const [chartThemes, setChartThemes] = useState<{ [chartIndex: number]: string }>({});
   const [chartOptions, setChartOptions] = useState<{ [chartIndex: number]: { grid: boolean; legend: boolean; axisLabels: boolean; dataLabels: boolean } }>({});
   const [dateRanges, setDateRanges] = useState<{ [columnName: string]: { min_date: string; max_date: string } }>({});
-  
+  const [showUniqueToggles, setShowUniqueToggles] = useState<{ [chartIndex: number]: boolean }>({});
+
   // Debouncing mechanism to prevent multiple chart generations
   const chartGenerationTimeouts = useRef<{ [chartIndex: number]: NodeJS.Timeout | null }>({});
 

--- a/TrinityFrontend/src/components/AtomList/atoms/explore/components/ExploreCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/explore/components/ExploreCanvas.tsx
@@ -1797,6 +1797,7 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
                   >
                     <SelectTrigger className="w-32 h-8 text-xs leading-none" disabled={isLoadingColumns}>
                       <SelectValue
+                        className="truncate"
                         placeholder={
                           isLoadingColumns
                             ? "Loading..."
@@ -1860,6 +1861,7 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
                             >
                               <SelectTrigger className="w-32 h-8 text-xs leading-none" disabled={isLoadingColumns}>
                                 <SelectValue
+                                  className="truncate"
                                   placeholder={
                                     isLoadingColumns
                                       ? "Loading..."
@@ -1970,10 +1972,13 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
                     }}
                   >
                     <SelectTrigger
-                      className="min-w-[8rem] h-8 ml-2 pr-4 text-xs leading-none whitespace-nowrap"
+                      className="w-32 h-8 ml-2 pr-4 text-xs leading-none whitespace-nowrap"
                       disabled={isLoadingColumns}
                     >
-                      <SelectValue placeholder="Select Column to Segregate Field Values" />
+                      <SelectValue
+                        className="truncate"
+                        placeholder="Select Column to Segregate Field Values"
+                      />
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="aggregate">Show Aggregate</SelectItem>

--- a/TrinityFrontend/src/components/AtomList/atoms/explore/components/ExploreCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/explore/components/ExploreCanvas.tsx
@@ -11,7 +11,7 @@ import { Switch } from '@/components/ui/switch';
 import { BarChart3, Settings, Filter, Eye, EyeOff, Edit3, Palette, ChevronDown, ChevronUp, X, Plus, RotateCcw, Database, Maximize2 } from 'lucide-react';
 import { ExploreData } from '../ExploreAtom';
 import RechartsChartRenderer from './RechartsChartRenderer';
-import { EXPLORE_API } from '@/lib/api';
+import { EXPLORE_API, TEXT_API } from '@/lib/api';
 import { toast } from '@/components/ui/use-toast';
 import './ExploreCanvas.css';
 import ChatBubble from '../../chart-maker/components/ChatBubble';
@@ -24,6 +24,8 @@ const CHART_COLORS = [
   '#458EE2', '#6BA4E8', '#91BAEE',
   '#F5F5F5', '#E0E0E0', '#C5C5C5'
 ];
+
+const CHART_FONT = `'Inter', 'Segoe UI', sans-serif`;
 
 interface ExploreCanvasProps {
   data: ExploreData;
@@ -71,6 +73,67 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
       chartGenerationTimeouts.current[chartIndex] = null;
     }, delay);
   };
+
+  const getTextId = (index: number) => {
+    const base = (safeData.dataframe || 'explore').replace(/[^a-z0-9-_]/gi, '_').toLowerCase();
+    return `${base}-chart-${index}`;
+  };
+
+  const fetchChartNote = async (index: number) => {
+    const textId = getTextId(index);
+    try {
+      const res = await fetch(`${TEXT_API}/text/${textId}`);
+      if (res.ok) {
+        const data = await res.json();
+        setChartNotes(prev => ({ ...prev, [index]: data?.spec?.content?.value || '' }));
+      }
+    } catch (err) {
+      console.error('Failed to fetch note', err);
+    }
+  };
+
+  const saveChartNote = async (index: number) => {
+    const textId = getTextId(index);
+    const value = chartNotes[index] || '';
+    const payload = {
+      textId,
+      appId: 'explore',
+      type: 'widget',
+      name: 'chart-note',
+      spec: { content: { format: 'plain', value } }
+    };
+    try {
+      let res = await fetch(`${TEXT_API}/text/${textId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      if (res.status === 404) {
+        res = await fetch(`${TEXT_API}/text`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+      }
+      if (!res.ok) {
+        throw new Error(`Failed to save note: ${res.status}`);
+      }
+    } catch (err) {
+      console.error('Error saving note', err);
+      toast({ description: 'Failed to save note', variant: 'destructive' });
+    }
+  };
+
+  const handleNoteChange = (index: number, value: string) => {
+    setChartNotes(prev => ({ ...prev, [index]: value }));
+  };
+
+  const handleNoteKeyDown = (index: number, e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      saveChartNote(index);
+    }
+  };
   
   // State for dropdown positioning
   const [dropdownPosition, setDropdownPosition] = useState<{ top: number; left: number } | null>(null);
@@ -104,6 +167,7 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
   const [chartGenerated, setChartGenerated] = useState<{ [chartIndex: number]: boolean }>(data.chartGenerated || {});
   const [chartThemes, setChartThemes] = useState<{ [chartIndex: number]: string }>({});
   const [chartOptions, setChartOptions] = useState<{ [chartIndex: number]: { grid: boolean; legend: boolean; axisLabels: boolean; dataLabels: boolean } }>({});
+  const [chartNotes, setChartNotes] = useState<{ [chartIndex: number]: string }>({});
   const [dateRanges, setDateRanges] = useState<{ [columnName: string]: { min_date: string; max_date: string } }>({});
   const [showUniqueToggles, setShowUniqueToggles] = useState<{ [chartIndex: number]: boolean }>({});
 
@@ -139,6 +203,7 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
     appliedFilters: {},
     chartDataSets: {},
     chartGenerated: {},
+    chartNotes: {},
     ...data
   };
 
@@ -149,6 +214,7 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
     if (safeData.appliedFilters) setAppliedFilters(safeData.appliedFilters);
     if (safeData.chartDataSets) setChartDataSets(safeData.chartDataSets);
     if (safeData.chartGenerated) setChartGenerated(safeData.chartGenerated);
+    if (safeData.chartNotes) setChartNotes(safeData.chartNotes);
   }, []);
 
   // Multi-chart state
@@ -189,6 +255,7 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
       chartDataSets,
       chartGenerated,
       appliedFilters,
+      chartNotes,
       xAxis: primaryConfig.xAxis || '',
       yAxis: primaryConfig.yAxes?.[0] || '',
       xAxisLabel: primaryConfig.xAxisLabel || '',
@@ -204,11 +271,12 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
     chartConfigs,
     chartFilters,
     chartThemes,
-      chartOptions,
-      chartDataSets,
-      chartGenerated,
-      appliedFilters,
-    ]);
+    chartOptions,
+    chartDataSets,
+    chartGenerated,
+    appliedFilters,
+    chartNotes,
+  ]);
 
   // Auto-generate charts on mount if data and configs exist
   useEffect(() => {
@@ -219,6 +287,11 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    chartConfigs.forEach((_, idx) => fetchChartNote(idx));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [chartConfigs.length, safeData.dataframe]);
 
   const openChartTypeTray = (e: React.MouseEvent, index: number) => {
     e.preventDefault();
@@ -963,6 +1036,20 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
     });
 
     setShowUniqueToggles(prev => {
+      const newState = { ...prev };
+      delete newState[index];
+      Object.keys(newState).forEach(key => {
+        const keyNum = parseInt(key);
+        if (keyNum > index) {
+          newState[keyNum - 1] = newState[keyNum];
+          delete newState[keyNum];
+        }
+      });
+      return newState;
+    });
+
+    // Clean up chart notes
+    setChartNotes(prev => {
       const newState = { ...prev };
       delete newState[index];
       Object.keys(newState).forEach(key => {
@@ -2332,16 +2419,17 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
                 
                 {/* Chart Renderer */}
                 {!isChartLoading(index) && (
+                  <>
                   <div className="w-full h-full min-w-0 flex-shrink-0" style={{ height: 'calc(100% - 60px)' }}>
                     {/* Check if chart data exists and has valid structure */}
                     {(!chartDataSets[index] || (Array.isArray(chartDataSets[index]) && chartDataSets[index].length === 0)) ? (
                       <div className="text-center p-4 border-2 border-dashed border-gray-300 rounded-lg h-full flex items-center justify-center">
                         <div className="text-gray-500 text-sm">
-                          {config.xAxis && config.yAxes && config.yAxes.length > 0 && config.yAxes.every(y => y) ? 
-                            (chartDataSets[index] && chartDataSets[index].length === 0 ? 
-                              'No data available for the selected filters. Try adjusting your filter criteria.' : 
+                          {config.xAxis && config.yAxes && config.yAxes.length > 0 && config.yAxes.every(y => y) ?
+                            (chartDataSets[index] && chartDataSets[index].length === 0 ?
+                              'No data available for the selected filters. Try adjusting your filter criteria.' :
                               `Chart ready: ${config.xAxis} vs ${config.yAxes.filter(y => y).join(', ')}`
-                            ) : 
+                            ) :
                             'Select X and Y axes to generate chart'
                           }
                         </div>
@@ -2392,6 +2480,15 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
                       </div>
                     )}
                   </div>
+                  <Input
+                    placeholder="Add note"
+                    value={chartNotes[index] || ''}
+                    onChange={(e) => handleNoteChange(index, e.target.value)}
+                    onKeyDown={(e) => handleNoteKeyDown(index, e)}
+                    style={{ fontFamily: CHART_FONT }}
+                    className="mt-2 w-full text-sm"
+                  />
+                  </>
                 )}
               </div>
             </div>

--- a/TrinityFrontend/src/components/AtomList/atoms/explore/components/RechartsChartRenderer.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/explore/components/RechartsChartRenderer.tsx
@@ -349,11 +349,8 @@ const RechartsChartRenderer: React.FC<Props> = ({
   const [showContextMenu, setShowContextMenu] = useState(false);
   const [showColorSubmenu, setShowColorSubmenu] = useState(false);
   const [showSortSubmenu, setShowSortSubmenu] = useState(false);
-
-
-
-
-
+  const [colorSubmenuPos, setColorSubmenuPos] = useState<{ x: number; y: number }>({ x: 0, y: 0 });
+  const [sortSubmenuPos, setSortSubmenuPos] = useState<{ x: number; y: number }>({ x: 0, y: 0 });
   const [contextMenuPosition, setContextMenuPosition] = useState({ x: 0, y: 0 });
   const chartRef = useRef<HTMLDivElement>(null);
 
@@ -372,6 +369,23 @@ const RechartsChartRenderer: React.FC<Props> = ({
   const [showLegend, setShowLegend] = useState(true);
   const [showAxisLabels, setShowAxisLabels] = useState(true);
   const [showDataLabels, setShowDataLabels] = useState(true);
+
+  // Sync internal states with external props for persistence
+  useEffect(() => {
+    if (propShowGrid !== undefined) setShowGrid(propShowGrid);
+  }, [propShowGrid]);
+
+  useEffect(() => {
+    if (propShowLegend !== undefined) setShowLegend(propShowLegend);
+  }, [propShowLegend]);
+
+  useEffect(() => {
+    if (propShowAxisLabels !== undefined) setShowAxisLabels(propShowAxisLabels);
+  }, [propShowAxisLabels]);
+
+  useEffect(() => {
+    if (propShowDataLabels !== undefined) setShowDataLabels(propShowDataLabels);
+  }, [propShowDataLabels]);
 
   // Use data prop directly now that sorting is removed
   const chartData = data;
@@ -658,15 +672,21 @@ const RechartsChartRenderer: React.FC<Props> = ({
   };
 
   // Handle color theme submenu toggle
-  const handleColorThemeClick = () => {
-    setShowColorSubmenu(prevState => {
-      const newState = !prevState;
-      return newState;
-    });
+  const handleColorThemeClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    setColorSubmenuPos({ x: rect.right, y: rect.top });
+    setShowColorSubmenu(prevState => !prevState);
+    setShowSortSubmenu(false);
   };
 
   // Handle sort submenu toggle
-  const handleSortClick = () => {
+  const handleSortClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    setSortSubmenuPos({ x: rect.right, y: rect.top });
     setShowSortSubmenu(prev => !prev);
     setShowColorSubmenu(false);
   };
@@ -800,11 +820,7 @@ const RechartsChartRenderer: React.FC<Props> = ({
         {/* Color Theme Option */}
         <button
           className="w-full px-4 py-2 text-sm text-left hover:bg-gray-50 flex items-center gap-3 text-gray-700 relative"
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            handleColorThemeClick();
-          }}
+          onClick={handleColorThemeClick}
         >
           <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zM21 5a2 2 0 00-2-2h-4a2 2 0 00-2 2v12a4 4 0 004 4h4a2 2 0 002-2V5z" />
@@ -818,11 +834,7 @@ const RechartsChartRenderer: React.FC<Props> = ({
         {/* Sort Option */}
         <button
           className="w-full px-4 py-2 text-sm text-left hover:bg-gray-50 flex items-center gap-3 text-gray-700 relative"
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            handleSortClick();
-          }}
+          onClick={handleSortClick}
         >
           <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 9l6-6 6 6M18 15l-6 6-6-6" />
@@ -934,11 +946,11 @@ const RechartsChartRenderer: React.FC<Props> = ({
     if (!showColorSubmenu) return null;
 
     return (
-      <div 
+      <div
         className="fixed z-[9999] bg-white border border-gray-300 rounded-lg shadow-xl p-3 color-submenu"
-        style={{ 
-          left: contextMenuPosition.x + 96, // Half of min-w-48 (192px/2) + small gap
-          top: contextMenuPosition.y - 120, // Align with the context menu
+        style={{
+          left: colorSubmenuPos.x,
+          top: colorSubmenuPos.y,
           minWidth: '240px',
           maxHeight: '320px',
           overflowY: 'auto'
@@ -995,8 +1007,8 @@ const RechartsChartRenderer: React.FC<Props> = ({
       <div
         className="fixed z-[9999] bg-white border border-gray-300 rounded-lg shadow-xl p-2 sort-submenu"
         style={{
-          left: contextMenuPosition.x + 96,
-          top: contextMenuPosition.y - 40,
+          left: sortSubmenuPos.x,
+          top: sortSubmenuPos.y,
           minWidth: '160px'
         }}
       >

--- a/TrinityFrontend/src/components/LaboratoryMode/store/laboratoryStore.ts
+++ b/TrinityFrontend/src/components/LaboratoryMode/store/laboratoryStore.ts
@@ -323,6 +323,7 @@ export interface ExploreData {
   applied?: boolean;
   chartDataSets?: { [idx: number]: any };
   chartGenerated?: { [chartIndex: number]: boolean };
+  chartNotes?: { [chartIndex: number]: string };
   [key: string]: any;
 }
 


### PR DESCRIPTION
## Summary
- define `showUniqueToggles` state in `ExploreCanvas` to prevent crash when adding charts

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Fast refresh only works when a file only exports components... 106 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a878cbe540832181cc2002e3e807b3