### PR TITLE
fix: support dual y-axis for bar charts

### DIFF
--- a/TrinityFrontend/src/components/AtomList/atoms/explore/components/ExploreCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/explore/components/ExploreCanvas.tsx
@@ -1636,17 +1636,30 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
   const renderChartComponent = (index: number) => {
     const config = chartConfigs[index] || chartConfigs[0];
     const isSettingsVisible = chartSettingsVisible[index] || false;
+
+    // Remove any empty Y-axis selections and preserve their labels
+    const validYAxes = config.yAxes
+      .map((yAxis: string, idx: number) => ({
+        field: yAxis,
+        label: config.yAxisLabels[idx] || yAxis || '',
+      }))
+      .filter(({ field }) => field && field.trim() !== '');
+
     const rendererProps = {
-      key: `chart-${index}-${config.chartType}-${chartThemes[index] || 'default'}-${chartDataSets[index]?.length || 0}-${Object.keys(chartFilters[index] || {}).length}-${appliedFilters[index] ? 'filtered' : 'unfiltered'}-theme-${chartThemes[index] || 'default'}-sort-${config.sortOrder || 'none'}-yaxes-${config.yAxes.join('-')}`,
+      key: `chart-${index}-${config.chartType}-${chartThemes[index] || 'default'}-${
+        chartDataSets[index]?.length || 0
+      }-${Object.keys(chartFilters[index] || {}).length}-${appliedFilters[index] ? 'filtered' : 'unfiltered'}-theme-${
+        chartThemes[index] || 'default'
+      }-sort-${config.sortOrder || 'none'}-yaxes-${config.yAxes.join('-')}`,
       type: config.chartType as 'bar_chart' | 'line_chart' | 'pie_chart' | 'area_chart' | 'scatter_chart',
       data: chartDataSets[index] || [],
       xField: config.xAxis || undefined,
-      yField: config.yAxes[0] || undefined,
+      yField: validYAxes[0]?.field,
       title: config.title,
       xAxisLabel: config.xAxisLabel || config.xAxis || '',
-      yAxisLabel: config.yAxisLabels[0] || config.yAxes[0] || '',
-      yFields: config.yAxes,
-      yAxisLabels: config.yAxes.map((yAxis: string, idx: number) => config.yAxisLabels[idx] || yAxis || ''),
+      yAxisLabel: validYAxes[0]?.label || '',
+      yFields: validYAxes.map((y) => y.field),
+      yAxisLabels: validYAxes.map((y) => y.label),
       legendField:
         config.legendField && config.legendField !== 'aggregate'
           ? config.legendField
@@ -1666,7 +1679,7 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
       showLegend: chartOptions[index]?.legend,
       showAxisLabels: chartOptions[index]?.axisLabels,
       showDataLabels: chartOptions[index]?.dataLabels,
-      showGrid: chartOptions[index]?.grid
+      showGrid: chartOptions[index]?.grid,
     } as const;
     
     return (

--- a/TrinityFrontend/src/components/AtomList/atoms/explore/components/ExploreCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/explore/components/ExploreCanvas.tsx
@@ -542,17 +542,6 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
         return newState;
       });
       
-      setChartSortCounters(prev => {
-        const newState = { ...prev };
-        Object.keys(newState).forEach(key => {
-          const keyNum = parseInt(key);
-          if (keyNum > 0) {
-            delete newState[keyNum];
-          }
-        });
-        return newState;
-      });
-      
       setCardSelectedIdentifiers(prev => {
         const newState = { ...prev };
         Object.keys(newState).forEach(key => {

--- a/TrinityFrontend/src/components/AtomList/atoms/explore/components/ExploreCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/explore/components/ExploreCanvas.tsx
@@ -1647,8 +1647,10 @@ const ExploreCanvas: React.FC<ExploreCanvasProps> = ({ data, isApplied, onDataCh
       title: config.title,
       xAxisLabel: config.xAxisLabel || config.xAxis || '',
       yAxisLabel: validYAxes[0]?.label || '',
-      yFields: validYAxes.map((y) => y.field),
-      yAxisLabels: validYAxes.map((y) => y.label),
+      ...(validYAxes.length > 1 && {
+        yFields: validYAxes.map((y) => y.field),
+        yAxisLabels: validYAxes.map((y) => y.label),
+      }),
       legendField:
         config.legendField && config.legendField !== 'aggregate'
           ? config.legendField

--- a/TrinityFrontend/src/components/AtomList/atoms/explore/components/RechartsChartRenderer.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/explore/components/RechartsChartRenderer.tsx
@@ -338,6 +338,7 @@ const RechartsChartRenderer: React.FC<Props> = ({
   const yFields = (yFieldsProp || []).filter((field) => field && field.trim() !== '');
   const yAxisLabels = yFields.map((field, idx) => yAxisLabelsProp?.[idx] || field);
   const yField = yFieldProp || yFields[0];
+  let yKeys: string[] = yFields.length > 0 ? yFields : (yField ? [yField] : []);
 
   // State for color theme - simplified approach
   const [selectedTheme, setSelectedTheme] = useState<string>('default');
@@ -1113,7 +1114,6 @@ const RechartsChartRenderer: React.FC<Props> = ({
     const firstItem = chartDataForRendering[0];
     let xKey = xField;
     let yKey = yField;
-    let yKeys: string[] = yFields || [];
     
 
     // Auto-detect keys based on data structure and chart type
@@ -1316,7 +1316,7 @@ const RechartsChartRenderer: React.FC<Props> = ({
       // Determine if any expected fields are missing (case-insensitive check)
       const hasField = (key: string) =>
         availableKeys.some(k => k.toLowerCase() === key.toLowerCase());
-      const expectedFields = [xField, ...(yFields || [])];
+      const expectedFields = Array.from(new Set([xField, yField, ...yFields]));
       const needsTransformation = expectedFields.some(field => !hasField(field));
 
       if (needsTransformation) {

--- a/TrinityFrontend/src/components/AtomList/atoms/explore/components/RechartsChartRenderer.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/explore/components/RechartsChartRenderer.tsx
@@ -303,18 +303,18 @@ const CustomPieLabel = ({ cx, cy, midAngle, innerRadius, outerRadius, percent, n
   );
 };
 
-const RechartsChartRenderer: React.FC<Props> = ({ 
-  type, 
-  data, 
-  xField, 
-  yField, 
-  yFields, 
-  width = 400, 
+const RechartsChartRenderer: React.FC<Props> = ({
+  type,
+  data,
+  xField,
+  yField: yFieldProp,
+  yFields: yFieldsProp,
+  width = 400,
   height = 300,
   title,
   xAxisLabel,
   yAxisLabel,
-  yAxisLabels,
+  yAxisLabels: yAxisLabelsProp,
   legendField,
   colors,
   enableScroll = false,
@@ -333,6 +333,11 @@ const RechartsChartRenderer: React.FC<Props> = ({
   showGrid: propShowGrid, // External control for grid visibility
   chartsPerRow
 }) => {
+
+  // Sanitize Y-axis props to ensure we only work with valid selections
+  const yFields = (yFieldsProp || []).filter((field) => field && field.trim() !== '');
+  const yAxisLabels = yFields.map((field, idx) => yAxisLabelsProp?.[idx] || field);
+  const yField = yFieldProp || yFields[0];
 
   // State for color theme - simplified approach
   const [selectedTheme, setSelectedTheme] = useState<string>('default');

--- a/TrinityFrontend/src/components/AtomList/atoms/explore/components/RechartsChartRenderer.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/explore/components/RechartsChartRenderer.tsx
@@ -1369,6 +1369,12 @@ const RechartsChartRenderer: React.FC<Props> = ({
 
           return transformed;
         });
+
+        // Update the keys to point to the requested field names so the chart
+        // renders using the transformed data instead of the generic x/y keys.
+        xKey = xField;
+        yKey = yField;
+        yKeys = yFields.length > 0 ? yFields : [yField];
       }
     }
 


### PR DESCRIPTION
## Summary
- sanitize Y-axis selections before rendering charts
- handle cleaned Y-axis fields and labels in renderer for proper dual-axis bar charts

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: 47 errors, 59 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ac08e7f52483218d89d11fa2917023