### PR TITLE
feat: move dataframe ops to backend

### DIFF
--- a/TrinityBackendFastAPI/app/features/dataframe_operations/README.md
+++ b/TrinityBackendFastAPI/app/features/dataframe_operations/README.md
@@ -14,22 +14,34 @@ Body: `{ "df_id": "<id>", "column": "Country", "value": "India" }`
 Body: `{ "df_id": "<id>", "column": "Date", "direction": "asc" }`
 
 ### POST `/insert_row`
-Body: `{ "df_id": "<id>", "row": {"A":1}, "index": 5 }` *(optional `index` inserts at position)*
+Body: `{ "df_id": "<id>", "index": 4, "direction": "below" }`
 
 ### POST `/delete_row`
 Body: `{ "df_id": "<id>", "index": 10 }`
 
+### POST `/duplicate_row`
+Body: `{ "df_id": "<id>", "index": 7 }`
+
 ### POST `/insert_column`
-Body: `{ "df_id": "<id>", "column": "NewCol", "value": 0, "index": 3 }` *(optional `index` inserts at position)*
+Body: `{ "df_id": "<id>", "index": 3, "name": "New Col", "default": "" }`
 
 ### POST `/delete_column`
-Body: `{ "df_id": "<id>", "column": "OldCol" }`
+Body: `{ "df_id": "<id>", "name": "OldCol" }`
 
-### POST `/update_cell`
-Body: `{ "df_id": "<id>", "row_idx": 0, "column": "Sales", "value": 1000 }`
+### POST `/duplicate_column`
+Body: `{ "df_id": "<id>", "name": "Revenue", "new_name": "Revenue_copy" }`
+
+### POST `/move_column`
+Body: `{ "df_id": "<id>", "from": "Date", "to_index": 1 }`
+
+### POST `/retype_column`
+Body: `{ "df_id": "<id>", "name": "Amount", "new_type": "number" }`
+
+### POST `/edit_cell`
+Body: `{ "df_id": "<id>", "row": 0, "column": "Sales", "value": 1000 }`
 
 ### POST `/rename_column`
-Body: `{ "df_id": "<id>", "old": "Revenue", "new": "Sales" }`
+Body: `{ "df_id": "<id>", "old_name": "Revenue", "new_name": "Sales" }`
 
 ### GET `/preview`
 Query: `df_id`, `n` (optional) – returns first rows for preview.

--- a/TrinityBackendFastAPI/app/features/dataframe_operations/README.md
+++ b/TrinityBackendFastAPI/app/features/dataframe_operations/README.md
@@ -14,13 +14,13 @@ Body: `{ "df_id": "<id>", "column": "Country", "value": "India" }`
 Body: `{ "df_id": "<id>", "column": "Date", "direction": "asc" }`
 
 ### POST `/insert_row`
-Body: `{ "df_id": "<id>", "row": {"A":1} }`
+Body: `{ "df_id": "<id>", "row": {"A":1}, "index": 5 }` *(optional `index` inserts at position)*
 
 ### POST `/delete_row`
 Body: `{ "df_id": "<id>", "index": 10 }`
 
 ### POST `/insert_column`
-Body: `{ "df_id": "<id>", "column": "NewCol", "value": 0 }`
+Body: `{ "df_id": "<id>", "column": "NewCol", "value": 0, "index": 3 }` *(optional `index` inserts at position)*
 
 ### POST `/delete_column`
 Body: `{ "df_id": "<id>", "column": "OldCol" }`

--- a/TrinityBackendFastAPI/app/features/dataframe_operations/README.md
+++ b/TrinityBackendFastAPI/app/features/dataframe_operations/README.md
@@ -1,0 +1,47 @@
+# DataFrame Operations API
+
+Base URL: `/api/dataframe-operations`
+
+## Endpoints
+
+### POST `/load`
+Upload a CSV file and begin a server-side session.
+
+### POST `/filter_rows`
+Body: `{ "df_id": "<id>", "column": "Country", "value": "India" }`
+
+### POST `/sort`
+Body: `{ "df_id": "<id>", "column": "Date", "direction": "asc" }`
+
+### POST `/insert_row`
+Body: `{ "df_id": "<id>", "row": {"A":1} }`
+
+### POST `/delete_row`
+Body: `{ "df_id": "<id>", "index": 10 }`
+
+### POST `/insert_column`
+Body: `{ "df_id": "<id>", "column": "NewCol", "value": 0 }`
+
+### POST `/delete_column`
+Body: `{ "df_id": "<id>", "column": "OldCol" }`
+
+### POST `/update_cell`
+Body: `{ "df_id": "<id>", "row_idx": 0, "column": "Sales", "value": 1000 }`
+
+### POST `/rename_column`
+Body: `{ "df_id": "<id>", "old": "Revenue", "new": "Sales" }`
+
+### GET `/preview`
+Query: `df_id`, `n` (optional) – returns first rows for preview.
+
+### GET `/info`
+Query: `df_id` – returns row/column counts and types.
+
+### POST `/ai/execute_operations`
+Body: `{ "df_id": "<id>", "operations": [ {"op": "filter_rows", "params": {"column":"Country","value":"India"}} ] }`
+
+### POST `/save`
+Existing endpoint for persisting data to MinIO.
+
+## Frontend Integration
+The frontend calls these APIs via `DATAFRAME_OPERATIONS_API` defined in `src/lib/api.ts`. Actions like editing cells, adding rows, or sorting send requests to the corresponding endpoints and refresh the table with returned data.

--- a/TrinityFrontend/src/components/AtomList/atoms/dataframe-operations/DataFrameOperationsAtom.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/dataframe-operations/DataFrameOperationsAtom.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Card, CardContent } from '@/components/ui/card';
-import { Settings, BarChart3, Eye, Table } from 'lucide-react';
 import DataFrameOperationsCanvas from './components/DataFrameOperationsCanvas';
 import DataFrameOperationsSettings from './components/DataFrameOperationsSettings';
 import DataFrameOperationsVisualisation from './components/DataFrameOperationsVisualisation';
@@ -144,18 +143,7 @@ const DataFrameOperationsAtom: React.FC<Props> = ({ atomId }) => {
   return (
     <ErrorBoundary>
       <div className="w-full h-full bg-gradient-to-br from-green-50 via-white to-green-50 rounded-xl border border-green-200 shadow-lg overflow-hidden">
-        <div className="bg-gradient-to-r from-green-500 to-green-600 text-white p-4 flex-shrink-0">
-          <div className="flex items-center space-x-3">
-            <div className="w-10 h-10 bg-white/20 rounded-lg flex items-center justify-center backdrop-blur-sm">
-              <Table className="w-5 h-5" />
-            </div>
-            <div>
-              <h2 className="text-lg font-semibold">DataFrame Operations</h2>
-              <p className="text-green-100 text-sm">Excel-like operations on data frames with editing, filtering, sorting</p>
-            </div>
-          </div>
-        </div>
-        <div className="flex-1 h-[calc(100%-80px)]">
+        <div className="h-full">
           {fileSelected && data && data.headers && data.rows && data.headers.length > 0 && data.rows.length > 0 ? (
             <div className="h-full">
               {/* File name above the table, small font */}

--- a/TrinityFrontend/src/components/AtomList/atoms/dataframe-operations/components/DataFrameOperationsCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/dataframe-operations/components/DataFrameOperationsCanvas.tsx
@@ -643,7 +643,7 @@ const filters = typeof settings.filters === 'object' && settings.filters !== nul
     if (!data || !fileId) return;
     const newColKey = getNextColKey(data.headers);
     try {
-      const resp = await apiInsertColumn(fileId, newColKey, '', colIdx + 1);
+      const resp = await apiInsertColumn(fileId, newColKey, '', colIdx);
       const columnTypes: any = {};
       resp.headers.forEach(h => {
         const t = resp.types[h];

--- a/TrinityFrontend/src/components/AtomList/atoms/dataframe-operations/components/DataFrameOperationsCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/dataframe-operations/components/DataFrameOperationsCanvas.tsx
@@ -1,9 +1,6 @@
 import React, { useState, useMemo, useRef, useCallback, useEffect } from 'react';
-import axios from 'axios';
-import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Badge } from '@/components/ui/badge';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
@@ -35,6 +32,7 @@ import {
   filterRows as apiFilter,
 } from '../services/dataframeOperationsApi';
 import { toast } from '@/components/ui/use-toast';
+import '@/Templates/Table/table.css';
 
 interface DataFrameOperationsCanvasProps {
   data: DataFrameData | null;
@@ -763,7 +761,6 @@ const filters = typeof settings.filters === 'object' && settings.filters !== nul
       {/* Shift the table upwards to use the freed space */}
       {/* Move the pagination controls so they are always visible directly below the table */}
       <div className="h-full flex flex-col bg-background">
-        <div className="flex-shrink-0 p-4 border-b border-border bg-card" />
         {/* Controls section */}
         <div className="flex-shrink-0 p-4 border-b border-border bg-card/50">
           <div className="flex items-center justify-between">
@@ -805,16 +802,20 @@ const filters = typeof settings.filters === 'object' && settings.filters !== nul
               </div>
             </div>
           ) : (
-            <Table className="border-collapse w-full">
-              <TableHeader className="bg-gradient-to-r from-gray-50 to-green-50 border-b-2 border-gray-100">
-                <TableRow className="bg-gradient-to-r from-gray-50 to-green-50 border-b-2 border-gray-100">
+            <div className="table-wrapper">
+              <div className="table-edge-left" />
+              <div className="table-edge-right" />
+              <div className="table-overflow">
+                <Table className="table-base">
+              <TableHeader className="table-header">
+                <TableRow className="table-header-row">
                   {settings.showRowNumbers && (
-                    <TableHead className="w-16 text-center font-bold text-gray-800 text-center py-4 bg-white border-r border-gray-200">#</TableHead>
+                    <TableHead className="table-header-cell w-16 text-center">#</TableHead>
                   )}
                   {Array.isArray(data?.headers) && data.headers.map((header, colIdx) => (
                     <TableHead
                       key={header + '-' + colIdx}
-                      className={`font-bold text-gray-800 text-center py-4 bg-white border-r border-gray-200 ${selectedColumn === header ? 'border-2 border-blue-500' : ''}`}
+                      className={`table-header-cell text-center bg-white border-r border-gray-200 ${selectedColumn === header ? 'border-2 border-blue-500' : ''}`}
                       draggable
                       onDragStart={() => handleDragStart(header)}
                       onDragOver={e => handleDragOver(e, header)}
@@ -875,15 +876,15 @@ const filters = typeof settings.filters === 'object' && settings.filters !== nul
                       )}
                     </TableHead>
                   ))}
-                  <TableHead className="w-8 bg-white border-l border-gray-200" />
+                  <TableHead className="table-header-cell w-8" />
                 </TableRow>
               </TableHeader>
               <TableBody>
                 {paginatedRows.map((row, rowIndex) => (
-                  <TableRow key={rowIndex} className="hover:bg-green-50 border-b border-green-200">
+                  <TableRow key={rowIndex} className="table-row">
                     {settings.showRowNumbers && (
                       <TableCell
-                        className="w-16 text-center bg-white border-r border-gray-200 text-xs text-gray-700 font-medium px-2 py-2"
+                        className="table-cell w-16 text-center text-xs font-medium"
                         onContextMenu={e => {
                           e.preventDefault();
                           setRowContextMenu({ x: e.clientX, y: e.clientY, rowIdx: startIndex + rowIndex });
@@ -899,7 +900,7 @@ const filters = typeof settings.filters === 'object' && settings.filters !== nul
                       return (
                         <TableCell
                           key={colIdx}
-                          className={`py-4 text-center font-medium text-gray-700 bg-white border-r border-gray-200 min-w-[120px] ${selectedCell?.row === rowIndex && selectedCell?.col === column ? 'border border-blue-400' : ''}`}
+                          className={`table-cell text-center font-medium min-w-[120px] ${selectedCell?.row === rowIndex && selectedCell?.col === column ? 'border border-blue-400' : ''}`}
                           onClick={() => setSelectedCell({ row: rowIndex, col: column })}
                           onDoubleClick={() => {
                             // Always allow cell editing regardless of enableEditing setting
@@ -936,12 +937,14 @@ const filters = typeof settings.filters === 'object' && settings.filters !== nul
                         </TableCell>
                       );
                     })}
-                    <TableCell className="w-8 bg-green-50 border-l border-green-200">
+                    <TableCell className="table-cell w-8">
                     </TableCell>
                   </TableRow>
                 ))}
               </TableBody>
             </Table>
+          </div>
+        </div>
           )}
           {totalPages > 1 && (
             <div className="flex flex-col items-center py-4">

--- a/TrinityFrontend/src/components/AtomList/atoms/dataframe-operations/services/dataframeOperationsApi.ts
+++ b/TrinityFrontend/src/components/AtomList/atoms/dataframe-operations/services/dataframeOperationsApi.ts
@@ -22,6 +22,7 @@ async function postJSON(url: string, body: any) {
 export async function loadDataframe(file: File): Promise<DataFrameResponse> {
   const form = new FormData();
   form.append('file', file);
+  console.log('API Call: /load');
   const res = await fetch(`${DATAFRAME_OPERATIONS_API}/load`, {
     method: 'POST',
     body: form,
@@ -31,49 +32,61 @@ export async function loadDataframe(file: File): Promise<DataFrameResponse> {
 }
 
 export function editCell(dfId: string, row: number, column: string, value: any) {
+  console.log('API Call: /edit_cell', { dfId, row, column, value });
   return postJSON(`${DATAFRAME_OPERATIONS_API}/edit_cell`, { df_id: dfId, row, column, value });
 }
 
 export function insertRow(dfId: string, index: number, direction: 'above' | 'below') {
+  console.log('API Call: /insert_row', { dfId, index, direction });
   return postJSON(`${DATAFRAME_OPERATIONS_API}/insert_row`, { df_id: dfId, index, direction });
 }
 
 export function deleteRow(dfId: string, index: number) {
+  console.log('API Call: /delete_row', { dfId, index });
   return postJSON(`${DATAFRAME_OPERATIONS_API}/delete_row`, { df_id: dfId, index });
 }
 
 export function duplicateRow(dfId: string, index: number) {
+  console.log('API Call: /duplicate_row', { dfId, index });
   return postJSON(`${DATAFRAME_OPERATIONS_API}/duplicate_row`, { df_id: dfId, index });
 }
 
 export function insertColumn(dfId: string, index: number, name: string, def: any = '') {
+  console.log('API Call: /insert_column', { dfId, index, name, def });
   return postJSON(`${DATAFRAME_OPERATIONS_API}/insert_column`, { df_id: dfId, index, name, default: def });
 }
 
 export function deleteColumn(dfId: string, name: string) {
+  console.log('API Call: /delete_column', { dfId, name });
   return postJSON(`${DATAFRAME_OPERATIONS_API}/delete_column`, { df_id: dfId, name });
 }
 
 export function duplicateColumn(dfId: string, name: string, new_name: string) {
+  console.log('API Call: /duplicate_column', { dfId, name, new_name });
   return postJSON(`${DATAFRAME_OPERATIONS_API}/duplicate_column`, { df_id: dfId, name, new_name });
 }
 
 export function moveColumn(dfId: string, from: string, to_index: number) {
+  console.log('API Call: /move_column', { dfId, from, to_index });
   return postJSON(`${DATAFRAME_OPERATIONS_API}/move_column`, { df_id: dfId, from, to_index });
 }
 
 export function retypeColumn(dfId: string, name: string, new_type: string) {
+  console.log('API Call: /retype_column', { dfId, name, new_type });
   return postJSON(`${DATAFRAME_OPERATIONS_API}/retype_column`, { df_id: dfId, name, new_type });
 }
 
 export function renameColumn(dfId: string, old_name: string, new_name: string) {
+  console.log('API Call: /rename_column', { dfId, old_name, new_name });
   return postJSON(`${DATAFRAME_OPERATIONS_API}/rename_column`, { df_id: dfId, old_name, new_name });
 }
 
 export function sortDataframe(dfId: string, column: string, direction: 'asc' | 'desc') {
+  console.log('API Call: /sort', { dfId, column, direction });
   return postJSON(`${DATAFRAME_OPERATIONS_API}/sort`, { df_id: dfId, column, direction });
 }
 
 export function filterRows(dfId: string, column: string, value: any) {
+  console.log('API Call: /filter_rows', { dfId, column, value });
   return postJSON(`${DATAFRAME_OPERATIONS_API}/filter_rows`, { df_id: dfId, column, value });
 }

--- a/TrinityFrontend/src/components/AtomList/atoms/dataframe-operations/services/dataframeOperationsApi.ts
+++ b/TrinityFrontend/src/components/AtomList/atoms/dataframe-operations/services/dataframeOperationsApi.ts
@@ -30,24 +30,44 @@ export async function loadDataframe(file: File): Promise<DataFrameResponse> {
   return res.json();
 }
 
-export function updateCell(dfId: string, row_idx: number, column: string, value: any) {
-  return postJSON(`${DATAFRAME_OPERATIONS_API}/update_cell`, { df_id: dfId, row_idx, column, value });
+export function editCell(dfId: string, row: number, column: string, value: any) {
+  return postJSON(`${DATAFRAME_OPERATIONS_API}/edit_cell`, { df_id: dfId, row, column, value });
 }
 
-export function insertRow(dfId: string, row: any = {}, index?: number) {
-  return postJSON(`${DATAFRAME_OPERATIONS_API}/insert_row`, { df_id: dfId, row, index });
+export function insertRow(dfId: string, index: number, direction: 'above' | 'below') {
+  return postJSON(`${DATAFRAME_OPERATIONS_API}/insert_row`, { df_id: dfId, index, direction });
 }
 
 export function deleteRow(dfId: string, index: number) {
   return postJSON(`${DATAFRAME_OPERATIONS_API}/delete_row`, { df_id: dfId, index });
 }
 
-export function insertColumn(dfId: string, column: string, value: any = null, index?: number) {
-  return postJSON(`${DATAFRAME_OPERATIONS_API}/insert_column`, { df_id: dfId, column, value, index });
+export function duplicateRow(dfId: string, index: number) {
+  return postJSON(`${DATAFRAME_OPERATIONS_API}/duplicate_row`, { df_id: dfId, index });
 }
 
-export function deleteColumn(dfId: string, column: string) {
-  return postJSON(`${DATAFRAME_OPERATIONS_API}/delete_column`, { df_id: dfId, column });
+export function insertColumn(dfId: string, index: number, name: string, def: any = '') {
+  return postJSON(`${DATAFRAME_OPERATIONS_API}/insert_column`, { df_id: dfId, index, name, default: def });
+}
+
+export function deleteColumn(dfId: string, name: string) {
+  return postJSON(`${DATAFRAME_OPERATIONS_API}/delete_column`, { df_id: dfId, name });
+}
+
+export function duplicateColumn(dfId: string, name: string, new_name: string) {
+  return postJSON(`${DATAFRAME_OPERATIONS_API}/duplicate_column`, { df_id: dfId, name, new_name });
+}
+
+export function moveColumn(dfId: string, from: string, to_index: number) {
+  return postJSON(`${DATAFRAME_OPERATIONS_API}/move_column`, { df_id: dfId, from, to_index });
+}
+
+export function retypeColumn(dfId: string, name: string, new_type: string) {
+  return postJSON(`${DATAFRAME_OPERATIONS_API}/retype_column`, { df_id: dfId, name, new_type });
+}
+
+export function renameColumn(dfId: string, old_name: string, new_name: string) {
+  return postJSON(`${DATAFRAME_OPERATIONS_API}/rename_column`, { df_id: dfId, old_name, new_name });
 }
 
 export function sortDataframe(dfId: string, column: string, direction: 'asc' | 'desc') {

--- a/TrinityFrontend/src/components/AtomList/atoms/dataframe-operations/services/dataframeOperationsApi.ts
+++ b/TrinityFrontend/src/components/AtomList/atoms/dataframe-operations/services/dataframeOperationsApi.ts
@@ -34,16 +34,16 @@ export function updateCell(dfId: string, row_idx: number, column: string, value:
   return postJSON(`${DATAFRAME_OPERATIONS_API}/update_cell`, { df_id: dfId, row_idx, column, value });
 }
 
-export function insertRow(dfId: string, row: any = {}) {
-  return postJSON(`${DATAFRAME_OPERATIONS_API}/insert_row`, { df_id: dfId, row });
+export function insertRow(dfId: string, row: any = {}, index?: number) {
+  return postJSON(`${DATAFRAME_OPERATIONS_API}/insert_row`, { df_id: dfId, row, index });
 }
 
 export function deleteRow(dfId: string, index: number) {
   return postJSON(`${DATAFRAME_OPERATIONS_API}/delete_row`, { df_id: dfId, index });
 }
 
-export function insertColumn(dfId: string, column: string, value: any = null) {
-  return postJSON(`${DATAFRAME_OPERATIONS_API}/insert_column`, { df_id: dfId, column, value });
+export function insertColumn(dfId: string, column: string, value: any = null, index?: number) {
+  return postJSON(`${DATAFRAME_OPERATIONS_API}/insert_column`, { df_id: dfId, column, value, index });
 }
 
 export function deleteColumn(dfId: string, column: string) {

--- a/TrinityFrontend/src/components/AtomList/atoms/dataframe-operations/services/dataframeOperationsApi.ts
+++ b/TrinityFrontend/src/components/AtomList/atoms/dataframe-operations/services/dataframeOperationsApi.ts
@@ -1,0 +1,59 @@
+import { DATAFRAME_OPERATIONS_API } from '@/lib/api';
+
+export interface DataFrameResponse {
+  df_id: string;
+  headers: string[];
+  rows: any[];
+  types: Record<string, string>;
+  row_count: number;
+  column_count: number;
+}
+
+async function postJSON(url: string, body: any) {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
+export async function loadDataframe(file: File): Promise<DataFrameResponse> {
+  const form = new FormData();
+  form.append('file', file);
+  const res = await fetch(`${DATAFRAME_OPERATIONS_API}/load`, {
+    method: 'POST',
+    body: form,
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
+export function updateCell(dfId: string, row_idx: number, column: string, value: any) {
+  return postJSON(`${DATAFRAME_OPERATIONS_API}/update_cell`, { df_id: dfId, row_idx, column, value });
+}
+
+export function insertRow(dfId: string, row: any = {}) {
+  return postJSON(`${DATAFRAME_OPERATIONS_API}/insert_row`, { df_id: dfId, row });
+}
+
+export function deleteRow(dfId: string, index: number) {
+  return postJSON(`${DATAFRAME_OPERATIONS_API}/delete_row`, { df_id: dfId, index });
+}
+
+export function insertColumn(dfId: string, column: string, value: any = null) {
+  return postJSON(`${DATAFRAME_OPERATIONS_API}/insert_column`, { df_id: dfId, column, value });
+}
+
+export function deleteColumn(dfId: string, column: string) {
+  return postJSON(`${DATAFRAME_OPERATIONS_API}/delete_column`, { df_id: dfId, column });
+}
+
+export function sortDataframe(dfId: string, column: string, direction: 'asc' | 'desc') {
+  return postJSON(`${DATAFRAME_OPERATIONS_API}/sort`, { df_id: dfId, column, direction });
+}
+
+export function filterRows(dfId: string, column: string, value: any) {
+  return postJSON(`${DATAFRAME_OPERATIONS_API}/filter_rows`, { df_id: dfId, column, value });
+}

--- a/TrinityFrontend/src/lib/api.ts
+++ b/TrinityFrontend/src/lib/api.ts
@@ -123,7 +123,8 @@ export const CLASSIFIER_API =
   `${backendOrigin.replace(new RegExp(`:${djangoPort}$`), `:${fastapiPort}`)}/api/classify`;
 
 export const DATAFRAME_OPERATIONS_API =
-  import.meta.env.VITE_DATAFRAME_OPERATIONS_API || `${backendOrigin.replace(/:8000$/, ':8001')}/api/dataframe-operations`;
+  normalizeUrl(import.meta.env.VITE_DATAFRAME_OPERATIONS_API) ||
+  `${backendOrigin.replace(new RegExp(`:${djangoPort}$`), `:${fastapiPort}`)}/api/dataframe-operations`;
 
 export const CORRELATION_API =
   normalizeUrl(import.meta.env.VITE_CORRELATION_API) ||


### PR DESCRIPTION
## Summary
- add session-based dataframe operation endpoints to FastAPI backend
- route frontend dataframe actions through new API service
- document backend dataframe operations API

## Testing
- `pytest` *(fails: ValidationError for Settings)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac4f4add9c8321bdd036fdba6b5923