### PR TITLE
Handle localStorage quota when saving current project

### DIFF
--- a/DataframeOperationsIssue.txt
+++ b/DataframeOperationsIssue.txt
@@ -1,0 +1,7 @@
+Issue: Reopening a project after performing DataFrame operations fails with a browser error `QuotaExceededError: Failed to execute 'setItem' on 'Storage': Setting the value of 'current-project' exceeded the quota.`
+
+Reason: Large results from DataFrame operations were being cached in `localStorage`. When switching projects, these oversized entries remained and `current-project` could not be written, causing the project to fail loading.
+
+Potential Prognosis: Without trimming or clearing these cached items, repeated DataFrame interactions can fill the browser's storage. Users would be unable to reopen projects until manually clearing site data, leading to potential data loss or confusion.
+
+Implemented Changes: Added a safe storage helper (`saveCurrentProject`) that strips in‑memory DataFrame data and catches quota errors. When storage is full, it now purges heavy cache keys before retrying, preventing the `QuotaExceededError` and allowing projects to reopen reliably.

--- a/TrinityFrontend/src/components/PrimaryMenu/AppIdentity/AppIdentity.tsx
+++ b/TrinityFrontend/src/components/PrimaryMenu/AppIdentity/AppIdentity.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import BackToAppsIcon from '../TrinityAssets/BackToAppsIcon';
 import { REGISTRY_API } from '@/lib/api';
-import { serializeProject } from '@/utils/projectStorage';
+import { saveCurrentProject } from '@/utils/projectStorage';
 
 interface AppIdentityProps {
   projectName: string | null;
@@ -35,7 +35,7 @@ const AppIdentity: React.FC<AppIdentityProps> = ({ projectName, onGoBack, onRena
         if (res.ok) {
           const updated = await res.json();
           console.log('Project renamed from primary menu', updated);
-          localStorage.setItem('current-project', serializeProject(updated));
+          saveCurrentProject(updated);
           try {
             const envRes = await fetch(`${REGISTRY_API}/projects/${proj.id}/`, {
               credentials: 'include'

--- a/TrinityFrontend/src/pages/Projects.tsx
+++ b/TrinityFrontend/src/pages/Projects.tsx
@@ -17,7 +17,7 @@ import { REGISTRY_API, CLASSIFIER_API } from '@/lib/api';
 import { fetchDimensionMapping } from '@/lib/dimensions';
 import { molecules } from '@/components/MoleculeList/data/molecules';
 import { safeStringify } from '@/utils/safeStringify';
-import { serializeProject, sanitizeLabConfig } from '@/utils/projectStorage';
+import { saveCurrentProject, sanitizeLabConfig } from '@/utils/projectStorage';
 import { useLaboratoryStore } from '@/components/LaboratoryMode/store/laboratoryStore';
 import { useExhibitionStore } from '@/components/ExhibitionMode/store/exhibitionStore';
 import { useAuth } from '@/contexts/AuthContext';
@@ -170,7 +170,7 @@ const Projects = () => {
       });
       if (res.ok) {
         const project = await res.json();
-        localStorage.setItem('current-project', serializeProject(project));
+        saveCurrentProject(project);
 
         try {
           const envRes = await fetch(`${REGISTRY_API}/projects/${project.id}/`, {
@@ -279,7 +279,7 @@ const Projects = () => {
           try {
             const obj = JSON.parse(stored);
             if (obj && obj.id === updated.id) {
-              localStorage.setItem('current-project', serializeProject(updated));
+              saveCurrentProject(updated);
             }
           } catch {
             /* ignore */
@@ -324,7 +324,7 @@ const Projects = () => {
   };
 
   const openProject = async (project: Project) => {
-    localStorage.setItem('current-project', serializeProject(project));
+    saveCurrentProject(project);
     resetLaboratory();
     resetExhibition();
     try {


### PR DESCRIPTION
## Summary
- document QuotaExceededError caused by large DataFrame caches
- add safe `saveCurrentProject` helper that clears heavy cache keys on quota errors
- use `saveCurrentProject` across project creation/rename/open flows

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 49 errors, 65 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68afe2d95558832182e2520eb100abeb