### PR TITLE
Fix phantom scroll in DataFrame operations canvas

### DIFF
--- a/TrinityFrontend/src/components/AtomList/atoms/dataframe-operations/components/DataFrameOperationsCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/dataframe-operations/components/DataFrameOperationsCanvas.tsx
@@ -945,11 +945,15 @@ const filters = typeof settings.filters === 'object' && settings.filters !== nul
   useLayoutEffect(() => {
     if (!data) return;
     const el = containerRef.current;
-    if (el) {
-      // Reset any phantom scroll area after heavy table mount
-      el.style.height = 'auto';
-      el.scrollTop = 0;
-    }
+    if (!el) return;
+    // React safety net – re-measure and lock the scroll container
+    // so that no phantom whitespace remains after uploads/render
+    el.style.overflowY = 'hidden';
+    el.style.height = 'auto';
+    const height = el.scrollHeight;
+    el.style.height = `${height}px`;
+    el.scrollTop = 0;
+    el.style.overflowY = 'auto';
   }, [data]);
 
   return (


### PR DESCRIPTION
## Summary
- re-measure and lock DataFrame operations scroll container after data render to prevent phantom whitespace

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68b006a0bc8c8321bf4092b148603f99