### PR TITLE
refactor: enforce arrow-only dataframe processing

### DIFF
--- a/TrinityBackendFastAPI/app/features/dataframe_operations/app/routes.py
+++ b/TrinityBackendFastAPI/app/features/dataframe_operations/app/routes.py
@@ -55,8 +55,10 @@ def _df_payload(df: pd.DataFrame, df_id: str) -> Dict[str, Any]:
 def _fetch_df_from_object(object_name: str) -> pd.DataFrame:
     """Fetch a DataFrame from the Flight server or MinIO given an object key."""
     object_name = unquote(object_name)
-    if not (object_name.endswith('.arrow') or object_name.endswith('.csv')):
-        raise HTTPException(status_code=400, detail="Invalid object_name format")
+    if not object_name.endswith(".arrow"):
+        raise HTTPException(
+            status_code=400, detail="Only .arrow objects are supported"
+        )
     try:
         return download_dataframe(object_name)
     except Exception as e:

--- a/TrinityFrontend/src/components/AtomList/atoms/dataframe-operations/components/properties/DataFrameOperationsInputs.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/dataframe-operations/components/properties/DataFrameOperationsInputs.tsx
@@ -1,10 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import { Card } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { VALIDATE_API, DATAFRAME_OPERATIONS_API } from '@/lib/api';
+import { VALIDATE_API } from '@/lib/api';
 
-interface Frame { object_name: string; csv_name: string; arrow_name?: string }
+interface Frame { object_name: string; arrow_name: string }
 
 const DataFrameOperationsInputs = ({ data, settings, selectedFile, onFileSelect }: any) => {
   const [frames, setFrames] = useState<Frame[]>([]);
@@ -16,7 +15,11 @@ const DataFrameOperationsInputs = ({ data, settings, selectedFile, onFileSelect 
       .then(r => r.json())
       .then(d =>
         setFrames(
-          Array.isArray(d.files) ? d.files.filter((f: Frame) => !!f.arrow_name) : []
+          Array.isArray(d.files)
+            ? d.files
+                .filter((f: any) => !!f.arrow_name)
+                .map((f: any) => ({ object_name: f.object_name, arrow_name: f.arrow_name }))
+            : []
         )
       )
       .catch(() => setFrames([]));
@@ -46,7 +49,7 @@ const DataFrameOperationsInputs = ({ data, settings, selectedFile, onFileSelect 
           <SelectContent>
             {(Array.isArray(frames) ? frames : []).map(f => (
               <SelectItem key={f.object_name} value={f.object_name}>
-                {(f.arrow_name || f.csv_name).split('/').pop()}
+                {f.arrow_name.split('/').pop()}
               </SelectItem>
             ))}
           </SelectContent>

--- a/TrinityFrontend/src/components/AtomList/atoms/dataframe-operations/components/properties/DataFrameOperationsProperties.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/dataframe-operations/components/properties/DataFrameOperationsProperties.tsx
@@ -60,10 +60,12 @@ const DataFrameOperationsProperties: React.FC<Props> = ({ atomId }) => {
     setLoading(true);
     setError(null);
     try {
-      // Fetch the list of frames to get csv_name for display
+      // Fetch the list of frames to resolve the display name
       const framesRes = await fetch(`${VALIDATE_API}/list_saved_dataframes`);
       const framesData = await framesRes.json();
-      const frames = Array.isArray(framesData.files) ? framesData.files : [];
+      const frames = Array.isArray(framesData.files)
+        ? framesData.files.filter((f: any) => f.arrow_name)
+        : [];
       const foundFrame = frames.find((f: any) => f.object_name === fileId);
       setSelectedFrame(foundFrame || null);
       const resp = await loadDataframeByKey(fileId);
@@ -76,7 +78,7 @@ const DataFrameOperationsProperties: React.FC<Props> = ({ atomId }) => {
       const newData: DataFrameData = {
         headers: resp.headers,
         rows: resp.rows,
-        fileName: foundFrame ? foundFrame.csv_name.split('/').pop() : fileId,
+        fileName: foundFrame ? foundFrame.arrow_name.split('/').pop() : fileId,
         columnTypes,
         pinnedColumns: [],
         frozenColumns: 0,

--- a/dataframeOperationsLoading.txt
+++ b/dataframeOperationsLoading.txt
@@ -1,0 +1,45 @@
+Potential Causes of Slow DataFrame Loading (>20–25MB)
+===================================================
+
+- Entire files are parsed into memory at once, leading to high memory pressure and slow garbage collection.
+- CSV or Excel formats are used, requiring expensive string parsing instead of binary columnar formats.
+- Data types are inferred on every load; wide datasets trigger repeated type conversions and object allocations.
+- UI threads perform synchronous parsing, blocking the browser while large payloads are processed.
+- Large results are transferred from server to client without pagination or streaming, causing network bottlenecks.
+- Repeated serialization between Python, JavaScript, and storage layers creates excessive copying.
+
+Performance Improvement Plan
+============================
+
+1. **Adopt Columnar Formats**
+   - Use Apache Parquet or Arrow for uploads and intermediate storage. They load faster and reduce memory footprint.
+
+2. **Stream and Chunk Large Files**
+   - Read CSV/Excel files in chunks (`chunksize` with pandas or streaming parsers) and process incrementally.
+   - Upload files using chunked HTTP requests to avoid buffering entire files in memory.
+
+3. **Optimize Data Types**
+   - Provide explicit `dtype` maps and convert high‑cardinality strings to categoricals.
+   - Drop unused columns early to reduce transfer and processing time.
+
+4. **Offload Heavy Work to the Backend**
+   - Execute joins, filters, and aggregations server‑side with optimized libraries (e.g., Polars, PyArrow, or Dask).
+   - Expose only paginated or summarized results to the client.
+
+5. **Parallelize and Vectorize**
+   - Enable multi‑core execution via libraries that release the GIL or leverage SIMD instructions.
+   - Replace Python loops with vectorized operations or compiled UDFs (Numba, Cython).
+
+6. **Leverage Caching and Reuse**
+   - Cache parsed schemas and commonly used query results.
+   - Memoize expensive transformations when inputs are unchanged.
+
+7. **Use Web Workers or Async Tasks**
+   - Move client‑side parsing into Web Workers so the UI remains responsive.
+   - For server tasks, enqueue long‑running jobs and poll for completion to prevent timeouts.
+
+8. **Monitor and Profile**
+   - Instrument load times and memory usage on both client and server.
+   - Use profilers (cProfile, PySpy, Chrome Performance) to identify bottlenecks and verify improvements.
+
+Implementing these strategies will make DataFrame loading robust for files well beyond 25MB and provide a smoother user experience.


### PR DESCRIPTION
## Summary
- ensure dataframe operations backend only fetches .arrow objects
- update dataframe operations atom to list and load arrow files exclusively

## Testing
- `python -m pytest TrinityBackendFastAPI` *(fails: pydantic validation error during collection)*
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b14aaad1848321b13a97113e05a274