### PR TITLE
Ensure polars is installed for Django-based FastAPI service

### DIFF
--- a/TrinityBackendDjango/requirements.txt
+++ b/TrinityBackendDjango/requirements.txt
@@ -30,6 +30,7 @@ whitenoise
 requests>=2.28.0
 minio
 pandas
+polars
 motor
 python-multipart
 pydantic-settings==2.10.1


### PR DESCRIPTION
## Summary
- include polars in Django backend requirements so the FastAPI service built from the Django image has access to it

## Testing
- `pytest TrinityBackendFastAPI/tests/test_arrow_flight.py::test_flight_round_trip -q` *(fails: ValidationError: Field required [mongo_uri, MINIO_ENDPOINT, minio_access_key, minio_secret_key])*

------
https://chatgpt.com/codex/tasks/task_e_68b16eed53e48321ae64a6540ea1c646