### PR TITLE
refactor: use file path references for data uploads

### DIFF
--- a/TrinityBackendFastAPI/tests/test_data_upload_validate.py
+++ b/TrinityBackendFastAPI/tests/test_data_upload_validate.py
@@ -1,0 +1,36 @@
+from fastapi.testclient import TestClient
+from fastapi import FastAPI, APIRouter
+import importlib.util
+import pathlib
+
+
+def load_module(path: pathlib.Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_upload_file(monkeypatch):
+    base = pathlib.Path(__file__).resolve().parents[1] / "app" / "features" / "data_upload_validate"
+    routes_module = load_module(base / "app" / "routes.py", "routes")
+
+    async def fake_get_object_prefix(*args, **kwargs):
+        return ""
+
+    def fake_upload_to_minio(content, filename, prefix):
+        return {"status": "success", "object_name": f"{prefix}{filename}"}
+
+    monkeypatch.setattr(routes_module, "get_object_prefix", fake_get_object_prefix)
+    monkeypatch.setattr(routes_module, "upload_to_minio", fake_upload_to_minio)
+
+    app = FastAPI()
+    router = APIRouter()
+    router.include_router(routes_module.router, prefix="/data-upload-validate", tags=["Data Upload & Validate"])
+    app.include_router(router, prefix="/api")
+    client = TestClient(app)
+    files = {"file": ("test.csv", "a,b\n1,2\n", "text/csv")}
+    response = client.post("/api/data-upload-validate/upload-file", files=files)
+    assert response.status_code == 200
+    assert "file_path" in response.json()
+

--- a/TrinityFrontend/src/components/AtomList/atoms/data-upload-validate/components/upload/UploadSection.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/data-upload-validate/components/upload/UploadSection.tsx
@@ -12,7 +12,7 @@ interface FileRow {
 }
 
 interface UploadSectionProps {
-  uploadedFiles: File[];
+  uploadedFiles: { name: string; path: string; size: number }[];
   files: FileRow[];
   validationResults: Record<string, string>;
   validationDetails: Record<string, any[]>;

--- a/TrinityFrontend/src/components/LaboratoryMode/store/laboratoryStore.ts
+++ b/TrinityFrontend/src/components/LaboratoryMode/store/laboratoryStore.ts
@@ -53,6 +53,8 @@ export interface DataUploadSettings {
   fileMappings?: Record<string, string>;
   /** Map of displayed master file names to the original names known by the backend */
   fileKeyMap?: Record<string, string>;
+  /** Map of uploaded file display names to the stored MinIO object path */
+  filePathMap?: Record<string, string>;
 }
 
 export const DEFAULT_DATAUPLOAD_SETTINGS: DataUploadSettings = {
@@ -69,6 +71,7 @@ export const DEFAULT_DATAUPLOAD_SETTINGS: DataUploadSettings = {
   validations: {},
   fileMappings: {},
   fileKeyMap: {},
+  filePathMap: {},
 };
 
 export const createDefaultDataUploadSettings = (): DataUploadSettings => ({
@@ -85,6 +88,7 @@ export const createDefaultDataUploadSettings = (): DataUploadSettings => ({
   validations: {},
   fileMappings: {},
   fileKeyMap: {},
+  filePathMap: {},
 });
 
 export interface FeatureOverviewSettings {


### PR DESCRIPTION
## Summary
- store file path references for uploaded data instead of raw files
- support MinIO uploads via new FastAPI `/upload-file` endpoint
- allow backend validation and saving using stored file paths

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest tests/test_data_upload_validate.py -q` *(fails: HTTPConnectionPool(host='minio', port=9000): Max retries exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68b185e38e08832189663cd9e8c63d78