### PR TITLE
feat: show template details on hover

### DIFF
--- a/TrinityFrontend/src/pages/Projects.tsx
+++ b/TrinityFrontend/src/pages/Projects.tsx
@@ -370,9 +370,6 @@ const Projects = () => {
     }
   };
 
-  const showTemplateDetails = (template: Template) => {
-    alert(`Template based on: ${template.baseProject?.name || 'Unknown'}\nDescription: ${template.description || ''}`);
-  };
 
   const formatDate = (date: Date) => {
     const now = new Date();
@@ -714,22 +711,13 @@ const Projects = () => {
                                   </Button>
                                 </DropdownMenuTrigger>
                                 <DropdownMenuContent align="end">
-                                  <DropdownMenuItem
-                                    onClick={(e) => {
-                                      e.stopPropagation();
-                                      showTemplateDetails(template);
-                                    }}
-                                  >
-                                    <Info className="w-4 h-4 mr-2" />
-                                    Show Details
-                                  </DropdownMenuItem>
-                                  <DropdownMenuItem
-                                    onClick={(e) => {
-                                      e.stopPropagation();
-                                      createProjectFromTemplate(template);
-                                    }}
-                                  >
-                                    <Plus className="w-4 h-4 mr-2" />
+                                <DropdownMenuItem
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    createProjectFromTemplate(template);
+                                  }}
+                                >
+                                  <Plus className="w-4 h-4 mr-2" />
                                     Create Project
                                   </DropdownMenuItem>
                                   <DropdownMenuItem
@@ -814,15 +802,6 @@ const Projects = () => {
                                 </Button>
                               </DropdownMenuTrigger>
                               <DropdownMenuContent align="end">
-                                <DropdownMenuItem
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    showTemplateDetails(template);
-                                  }}
-                                >
-                                  <Info className="w-4 h-4 mr-2" />
-                                  Show Details
-                                </DropdownMenuItem>
                                 <DropdownMenuItem
                                   onClick={(e) => {
                                     e.stopPropagation();

--- a/TrinityFrontend/src/pages/Projects.tsx
+++ b/TrinityFrontend/src/pages/Projects.tsx
@@ -31,6 +31,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 
 interface Project {
   id: string;
@@ -663,17 +664,28 @@ const Projects = () => {
                           </Badge>
                           {hoveredTemplate === template.id && (
                             <div className="flex items-center space-x-1">
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                className="h-8 w-8 p-0"
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  showTemplateDetails(template);
-                                }}
-                              >
-                                <Info className="w-4 h-4" />
-                              </Button>
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    className="h-8 w-8 p-0"
+                                    onClick={(e) => e.stopPropagation()}
+                                  >
+                                    <Info className="w-4 h-4" />
+                                  </Button>
+                                </TooltipTrigger>
+                                <TooltipContent>
+                                  <p className="font-medium">
+                                    Based on: {template.baseProject?.name || 'Unknown'}
+                                  </p>
+                                  {template.description && (
+                                    <p className="text-xs text-muted-foreground">
+                                      {template.description}
+                                    </p>
+                                  )}
+                                </TooltipContent>
+                              </Tooltip>
                               <Button
                                 variant="ghost"
                                 size="sm"
@@ -752,17 +764,28 @@ const Projects = () => {
                         <span className="text-xs text-gray-500">{template.usageCount} uses</span>
                         {viewMode === 'list' && hoveredTemplate === template.id && (
                           <div className="flex items-center space-x-1">
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              className="h-8 w-8 p-0"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                showTemplateDetails(template);
-                              }}
-                            >
-                              <Info className="w-4 h-4" />
-                            </Button>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  className="h-8 w-8 p-0"
+                                  onClick={(e) => e.stopPropagation()}
+                                >
+                                  <Info className="w-4 h-4" />
+                                </Button>
+                              </TooltipTrigger>
+                              <TooltipContent>
+                                <p className="font-medium">
+                                  Based on: {template.baseProject?.name || 'Unknown'}
+                                </p>
+                                {template.description && (
+                                  <p className="text-xs text-muted-foreground">
+                                    {template.description}
+                                  </p>
+                                )}
+                              </TooltipContent>
+                            </Tooltip>
                             <Button
                               variant="ghost"
                               size="sm"


### PR DESCRIPTION
## Summary
- show template details on hover using tooltip instead of alert

## Testing
- `npm test` *(fails: missing script)*
- `npm run lint` *(fails: 50 errors, 65 warnings)*
- `npx eslint src/pages/Projects.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1a9ac702083218c80210b159d7ecb