### PR TITLE
Show template info on hover and record base template for projects

### DIFF
--- a/TrinityBackendDjango/apps/registry/migrations/0013_project_base_template.py
+++ b/TrinityBackendDjango/apps/registry/migrations/0013_project_base_template.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("registry", "0012_template"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="project",
+            name="base_template",
+            field=models.ForeignKey(
+                to="registry.template",
+                null=True,
+                blank=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="projects",
+                help_text="Template this project was created from, if any.",
+            ),
+        ),
+    ]

--- a/TrinityBackendDjango/apps/registry/migrations/0013_project_base_template.py
+++ b/TrinityBackendDjango/apps/registry/migrations/0013_project_base_template.py
@@ -21,4 +21,17 @@ class Migration(migrations.Migration):
                 help_text="Template this project was created from, if any.",
             ),
         ),
+        migrations.AddField(
+            model_name="historicalproject",
+            name="base_template",
+            field=models.ForeignKey(
+                to="registry.template",
+                null=True,
+                blank=True,
+                on_delete=django.db.models.deletion.DO_NOTHING,
+                related_name="+",
+                db_constraint=False,
+                help_text="Template this project was created from, if any.",
+            ),
+        ),
     ]

--- a/TrinityBackendDjango/apps/registry/migrations/0014_historicalproject_base_template.py
+++ b/TrinityBackendDjango/apps/registry/migrations/0014_historicalproject_base_template.py
@@ -5,19 +5,20 @@ import django.db.models.deletion
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("registry", "0012_template"),
+        ("registry", "0013_project_base_template"),
     ]
 
     operations = [
         migrations.AddField(
-            model_name="project",
+            model_name="historicalproject",
             name="base_template",
             field=models.ForeignKey(
                 to="registry.template",
                 null=True,
                 blank=True,
-                on_delete=django.db.models.deletion.SET_NULL,
-                related_name="projects",
+                on_delete=django.db.models.deletion.DO_NOTHING,
+                related_name="+",
+                db_constraint=False,
                 help_text="Template this project was created from, if any.",
             ),
         ),

--- a/TrinityBackendDjango/apps/registry/models.py
+++ b/TrinityBackendDjango/apps/registry/models.py
@@ -41,6 +41,14 @@ class Project(models.Model):
         null=True,
         help_text="Persisted workflow/laboratory configuration for this project.",
     )
+    base_template = models.ForeignKey(
+        "Template",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="projects",
+        help_text="Template this project was created from, if any.",
+    )
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
     history = HistoricalRecords()

--- a/TrinityBackendDjango/apps/registry/serializers.py
+++ b/TrinityBackendDjango/apps/registry/serializers.py
@@ -19,6 +19,7 @@ class ProjectSerializer(serializers.ModelSerializer):
         required=False,
         default=serializers.CurrentUserDefault(),
     )
+    base_template = serializers.SerializerMethodField()
 
     class Meta:
         model = Project
@@ -30,10 +31,14 @@ class ProjectSerializer(serializers.ModelSerializer):
             "owner",
             "app",
             "state",
+            "base_template",
             "created_at",
             "updated_at",
         ]
         read_only_fields = ["id", "created_at", "updated_at"]
+
+    def get_base_template(self, obj):
+        return obj.base_template.name if obj.base_template else None
 
 
 class SessionSerializer(serializers.ModelSerializer):

--- a/TrinityBackendDjango/apps/registry/views.py
+++ b/TrinityBackendDjango/apps/registry/views.py
@@ -255,6 +255,7 @@ class ProjectViewSet(viewsets.ModelViewSet):
             owner=request.user,
             app=source.app,
             state=source.state,
+            base_template=source.base_template,
         )
 
         for mode in ["lab", "workflow", "exhibition"]:
@@ -359,6 +360,15 @@ class TemplateViewSet(viewsets.ModelViewSet):
                 qs = qs.filter(app__slug=app_param)
         return qs
 
+    def perform_update(self, serializer):
+        instance = serializer.save()
+        projects = instance.projects.all()
+        if projects.exists():
+            instance.template_projects = [
+                ProjectSerializer(p).data for p in projects
+            ]
+            instance.save(update_fields=["template_projects"])
+
     def _can_edit(self, user):
         perms = [
             "permissions.workflow_edit",
@@ -399,6 +409,7 @@ class TemplateViewSet(viewsets.ModelViewSet):
             owner=request.user,
             app=template.app,
             state=template.state,
+            base_template=template,
         )
 
         for mode in ["lab", "workflow", "exhibition"]:


### PR DESCRIPTION
## Summary
- add `base_template` relationship to projects and expose via API
- update template usage to refresh project references on rename
- display project base template and show template details via hover tooltip

## Testing
- `npm test` *(fails: Missing script "test")*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'polars')*

------
https://chatgpt.com/codex/tasks/task_e_68b52c18ca808321b7fff3529fae8b2c