### PR TITLE
Align primary menu branding with login styling

### DIFF
--- a/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
+++ b/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
@@ -9,13 +9,18 @@ interface LogoTextProps {
 }
 
 const LogoText: React.FC<LogoTextProps> = ({ className = '', titleClassName }) => (
-  <div className={`flex flex-col items-center text-center ${className}`.trim()}>
+  <div
+    className={`flex h-12 flex-col justify-center items-start text-left leading-none ${className}`.trim()}
+  >
     <h1
-      className={`text-4xl font-bold font-mono ${titleClassName || 'text-black'}`.trim()}
+      className={`font-mono font-bold text-3xl leading-none ${
+        titleClassName || 'text-black'
+      }`.trim()}
     >
       Trinity
     </h1>
-    <span className="text-xs text-black/60 font-mono mt-1">
+    <div className="h-0.5 w-full bg-[#fec107] my-0.5" />
+    <span className="font-mono text-xs text-black/60 leading-none">
       A Quant Matrix AI Experience
     </span>
   </div>

--- a/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
+++ b/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
@@ -3,23 +3,20 @@ import React from 'react';
 interface LogoTextProps {
   className?: string;
   /**
-   * Additional classes for the title element. If none are provided the
-   * brand gradient is used.
+   * Additional classes for the title element. Defaults to plain black text.
    */
   titleClassName?: string;
 }
 
 const LogoText: React.FC<LogoTextProps> = ({ className = '', titleClassName }) => (
-  <div className={`flex flex-col ${className}`.trim()}>
+  <div className={`flex flex-col items-center text-center ${className}`.trim()}>
     <h1
-      className={`text-2xl font-bold tracking-tight leading-none font-mono ${
-        titleClassName || 'bg-gradient-to-r from-black via-gray-800 to-trinity-yellow bg-clip-text text-transparent'
-      }`}
+      className={`text-4xl font-bold font-mono ${titleClassName || 'text-black'}`.trim()}
     >
       Trinity
     </h1>
-    <span className="text-xs font-light text-gray-600 tracking-widest uppercase mt-0.5 font-mono">
-      A Quant Matrix AI Product
+    <span className="text-xs text-black/60 font-mono mt-1">
+      A Quant Matrix AI Experience
     </span>
   </div>
 );

--- a/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
+++ b/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
@@ -19,8 +19,7 @@ const LogoText: React.FC<LogoTextProps> = ({ className = '', titleClassName }) =
     >
       Trinity
     </h1>
-    <div className="h-0.5 w-full bg-[#fec107] my-0.5" />
-    <span className="font-mono text-xs text-black/60 leading-none">
+    <span className="font-mono text-xs text-black/60 leading-none mt-1">
       A Quant Matrix AI Experience
     </span>
   </div>

--- a/TrinityFrontend/src/pages/Projects.tsx
+++ b/TrinityFrontend/src/pages/Projects.tsx
@@ -565,7 +565,11 @@ const Projects = () => {
                                 onClick={(e) => {
                                   e.stopPropagation();
                                 }}
-                                onPointerDown={(e) => e.stopPropagation()}
+                                onPointerDown={(e) => {
+                                  e.stopPropagation();
+                                  setOpenProjectMenuId(project.id);
+                                  setHoveredProject(project.id);
+                                }}
                               >
                                 <MoreHorizontal className="w-4 h-4" />
                               </Button>
@@ -742,7 +746,7 @@ const Projects = () => {
                                     <Plus className="w-4 h-4" />
                                   </Button>
                                 </TooltipTrigger>
-                                <TooltipContent className="text-xs w-80 whitespace-nowrap">
+                                <TooltipContent className="text-xs w-fit whitespace-nowrap">
                                   Create a Project based on this Template
                                 </TooltipContent>
                               </Tooltip>
@@ -765,7 +769,11 @@ const Projects = () => {
                                     onClick={(e) => {
                                       e.stopPropagation();
                                     }}
-                                    onPointerDown={(e) => e.stopPropagation()}
+                                    onPointerDown={(e) => {
+                                      e.stopPropagation();
+                                      setOpenTemplateMenuId(template.id);
+                                      setHoveredTemplate(template.id);
+                                    }}
                                   >
                                     <MoreHorizontal className="w-4 h-4" />
                                   </Button>
@@ -861,7 +869,7 @@ const Projects = () => {
                                   <Plus className="w-4 h-4" />
                                 </Button>
                               </TooltipTrigger>
-                              <TooltipContent className="text-xs w-80 whitespace-nowrap">
+                              <TooltipContent className="text-xs w-fit whitespace-nowrap">
                                 Create a Project based on this Template
                               </TooltipContent>
                             </Tooltip>
@@ -884,7 +892,11 @@ const Projects = () => {
                                   onClick={(e) => {
                                     e.stopPropagation();
                                   }}
-                                  onPointerDown={(e) => e.stopPropagation()}
+                                  onPointerDown={(e) => {
+                                    e.stopPropagation();
+                                    setOpenTemplateMenuId(template.id);
+                                    setHoveredTemplate(template.id);
+                                  }}
                                 >
                                   <MoreHorizontal className="w-4 h-4" />
                                 </Button>


### PR DESCRIPTION
## Summary
- Match primary menu "Trinity" logo and tagline with login page styling and alignment, using black text

## Testing
- `npm run lint` *(fails: react-refresh/only-export-components)*

------
https://chatgpt.com/codex/tasks/task_e_68b56bec86048321a2c5ac8a4a4d2137