### PR TITLE
feat: add animated tagline to logo

### DIFF
--- a/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
+++ b/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
@@ -14,15 +14,15 @@ const LogoText: React.FC<LogoTextProps> = ({ className = '', titleClassName }) =
   >
     <div className="flex flex-col items-start w-fit">
       <h1
-        className={`font-mono font-bold text-3xl leading-none ${
+        className={`font-mono font-bold text-2xl leading-none ${
           titleClassName || 'text-black'
         }`.trim()}
       >
         Trinity
       </h1>
-      <div className="h-0.5 bg-trinity-yellow mt-0.5 w-full" />
+      <div className="h-0.5 bg-trinity-yellow mt-px w-full" />
     </div>
-    <div className="overflow-hidden mt-0.5 w-full">
+    <div className="overflow-hidden mt-px w-full">
       <span className="font-mono text-xs text-black/60 leading-none whitespace-nowrap inline-block animate-tagline-scroll">
         A Quant Matrix AI Experience
       </span>

--- a/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
+++ b/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
@@ -21,11 +21,11 @@ const LogoText: React.FC<LogoTextProps> = ({ className = '', titleClassName }) =
         Trinity
       </h1>
       <div className="h-0.5 bg-trinity-yellow mt-0.5 w-full" />
-      <div className="overflow-hidden mt-1 w-full">
-        <span className="font-mono text-xs text-black/60 leading-none whitespace-nowrap inline-block animate-tagline-scroll">
-          A Quant Matrix AI Experience
-        </span>
-      </div>
+    </div>
+    <div className="overflow-hidden mt-1 w-full">
+      <span className="font-mono text-xs text-black/60 leading-none whitespace-nowrap inline-block animate-tagline-scroll">
+        A Quant Matrix AI Experience
+      </span>
     </div>
   </div>
 );

--- a/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
+++ b/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
@@ -22,7 +22,7 @@ const LogoText: React.FC<LogoTextProps> = ({ className = '', titleClassName }) =
       </h1>
       <div className="h-0.5 bg-trinity-yellow mt-1 w-full" />
     </div>
-    <div className="overflow-hidden w-full -mt-px">
+    <div className="overflow-hidden w-full -mt-0.5">
       <span className="font-mono text-xs text-black/60 leading-none whitespace-nowrap inline-block animate-tagline-scroll">
         A Quant Matrix AI Experience
       </span>

--- a/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
+++ b/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
@@ -10,9 +10,9 @@ interface LogoTextProps {
 
 const LogoText: React.FC<LogoTextProps> = ({ className = '', titleClassName }) => (
   <div
-    className={`flex h-12 flex-col justify-center items-start text-left w-fit ${className}`.trim()}
+    className={`flex h-12 flex-col justify-start items-start text-left w-fit ${className}`.trim()}
   >
-    <div className="flex flex-col items-start w-fit mb-1">
+    <div className="flex flex-col items-start w-fit">
       <h1
         className={`font-mono font-bold text-2xl leading-none ${
           titleClassName || 'text-black'
@@ -22,8 +22,8 @@ const LogoText: React.FC<LogoTextProps> = ({ className = '', titleClassName }) =
       </h1>
       <div className="h-0.5 bg-trinity-yellow mt-1 w-full" />
     </div>
-    <div className="overflow-hidden w-full">
-      <span className="font-mono text-xs text-black/60 leading-none whitespace-nowrap inline-block animate-tagline-scroll">
+    <div className="overflow-hidden w-full mt-1">
+      <span className="font-mono text-xs text-black/60 leading-tight whitespace-nowrap inline-block animate-slide-in-left">
         A Quant Matrix AI Experience
       </span>
     </div>

--- a/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
+++ b/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
@@ -22,7 +22,7 @@ const LogoText: React.FC<LogoTextProps> = ({ className = '', titleClassName }) =
       </h1>
       <div className="relative w-full mt-1 h-0.5">
         <div className="absolute left-0 top-0 h-full bg-trinity-yellow w-0 animate-line-grow" />
-        <span className="absolute left-0 top-0 w-2 h-2 rounded-full bg-trinity-blue -translate-x-1/2 animate-dot-travel" />
+        <span className="absolute left-0 top-1/2 w-2 h-2 rounded-full bg-trinity-blue -translate-x-1/2 -translate-y-1/2 animate-dot-travel" />
       </div>
     </div>
     <div className="w-full -mt-0.5">

--- a/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
+++ b/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
@@ -21,10 +21,12 @@ const LogoText: React.FC<LogoTextProps> = ({ className = '', titleClassName }) =
         Trinity
       </h1>
       <div className="w-full h-0.5 bg-trinity-yellow mt-0.5" />
+      <div className="w-full overflow-hidden mt-1">
+        <span className="font-mono text-xs text-black/60 leading-none whitespace-nowrap inline-block animate-tagline-scroll">
+          A Quant Matrix AI Experience
+        </span>
+      </div>
     </div>
-    <span className="font-mono text-xs text-black/60 leading-none mt-1 animate-slide-in-left">
-      A Quant Matrix AI Experience
-    </span>
   </div>
 );
 

--- a/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
+++ b/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
@@ -12,14 +12,17 @@ const LogoText: React.FC<LogoTextProps> = ({ className = '', titleClassName }) =
   <div
     className={`flex h-12 flex-col justify-center items-start text-left leading-none ${className}`.trim()}
   >
-    <h1
-      className={`font-mono font-bold text-3xl leading-none ${
-        titleClassName || 'text-black'
-      }`.trim()}
-    >
-      Trinity
-    </h1>
-    <span className="font-mono text-xs text-black/60 leading-none mt-1">
+    <div className="flex flex-col items-start">
+      <h1
+        className={`font-mono font-bold text-3xl leading-none ${
+          titleClassName || 'text-black'
+        }`.trim()}
+      >
+        Trinity
+      </h1>
+      <div className="w-full h-0.5 bg-trinity-yellow mt-0.5" />
+    </div>
+    <span className="font-mono text-xs text-black/60 leading-none mt-1 animate-slide-in-left">
       A Quant Matrix AI Experience
     </span>
   </div>

--- a/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
+++ b/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
@@ -22,7 +22,7 @@ const LogoText: React.FC<LogoTextProps> = ({ className = '', titleClassName }) =
       </h1>
       <div className="h-0.5 bg-trinity-yellow mt-1 w-full" />
     </div>
-    <div className="overflow-hidden w-full mt-1">
+    <div className="overflow-hidden w-full mt-px">
       <span className="font-mono text-xs text-black/60 leading-tight whitespace-nowrap inline-block animate-slide-in-left">
         A Quant Matrix AI Experience
       </span>

--- a/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
+++ b/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
@@ -22,7 +22,7 @@ const LogoText: React.FC<LogoTextProps> = ({ className = '', titleClassName }) =
       </h1>
       <div className="relative w-full mt-1 h-0.5">
         <div className="absolute left-0 top-0 h-full bg-trinity-yellow w-0 animate-line-grow" />
-        <span className="absolute left-0 top-0 w-2 h-2 rounded-full bg-trinity-blue animate-dot-travel" />
+        <span className="absolute left-0 top-0 w-2 h-2 rounded-full bg-trinity-blue -translate-x-1/2 animate-dot-travel" />
       </div>
     </div>
     <div className="w-full -mt-0.5">

--- a/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
+++ b/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
@@ -10,9 +10,9 @@ interface LogoTextProps {
 
 const LogoText: React.FC<LogoTextProps> = ({ className = '', titleClassName }) => (
   <div
-    className={`flex h-12 flex-col justify-center items-start text-left leading-none ${className}`.trim()}
+    className={`flex h-12 flex-col justify-center items-start text-left leading-none w-fit ${className}`.trim()}
   >
-    <div className="flex flex-col items-start">
+    <div className="flex flex-col items-start w-fit">
       <h1
         className={`font-mono font-bold text-3xl leading-none ${
           titleClassName || 'text-black'
@@ -20,8 +20,8 @@ const LogoText: React.FC<LogoTextProps> = ({ className = '', titleClassName }) =
       >
         Trinity
       </h1>
-      <div className="w-full h-0.5 bg-trinity-yellow mt-0.5" />
-      <div className="w-full overflow-hidden mt-1">
+      <div className="h-0.5 bg-trinity-yellow mt-0.5 w-full" />
+      <div className="overflow-hidden mt-1 w-full">
         <span className="font-mono text-xs text-black/60 leading-none whitespace-nowrap inline-block animate-tagline-scroll">
           A Quant Matrix AI Experience
         </span>

--- a/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
+++ b/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
@@ -12,7 +12,7 @@ const LogoText: React.FC<LogoTextProps> = ({ className = '', titleClassName }) =
   <div
     className={`flex h-12 flex-col justify-center items-start text-left w-fit ${className}`.trim()}
   >
-    <div className="flex flex-col items-start w-fit">
+    <div className="flex flex-col items-start w-fit mb-1">
       <h1
         className={`font-mono font-bold text-2xl leading-none ${
           titleClassName || 'text-black'
@@ -20,9 +20,9 @@ const LogoText: React.FC<LogoTextProps> = ({ className = '', titleClassName }) =
       >
         Trinity
       </h1>
-      <div className="h-0.5 bg-trinity-yellow mt-px w-full" />
+      <div className="h-0.5 bg-trinity-yellow mt-1 w-full" />
     </div>
-    <div className="overflow-hidden mt-px w-full">
+    <div className="overflow-hidden w-full">
       <span className="font-mono text-xs text-black/60 leading-none whitespace-nowrap inline-block animate-tagline-scroll">
         A Quant Matrix AI Experience
       </span>

--- a/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
+++ b/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
@@ -12,7 +12,7 @@ const LogoText: React.FC<LogoTextProps> = ({ className = '', titleClassName }) =
   <div
     className={`flex h-12 flex-col justify-start items-start text-left w-fit ${className}`.trim()}
   >
-    <div className="flex flex-col items-start w-fit">
+    <div className="relative flex flex-col items-start w-fit">
       <h1
         className={`font-mono font-bold text-2xl leading-none ${
           titleClassName || 'text-black'
@@ -20,10 +20,13 @@ const LogoText: React.FC<LogoTextProps> = ({ className = '', titleClassName }) =
       >
         Trinity
       </h1>
-      <div className="h-0.5 bg-trinity-yellow mt-1 w-full" />
+      <div className="relative w-full mt-1 h-0.5">
+        <div className="absolute left-0 top-0 h-full bg-trinity-yellow w-0 animate-line-grow" />
+        <span className="absolute left-0 top-0 w-2 h-2 rounded-full bg-trinity-blue animate-dot-travel" />
+      </div>
     </div>
-    <div className="overflow-hidden w-full -mt-0.5">
-      <span className="font-mono text-xs text-black/60 leading-none whitespace-nowrap inline-block animate-tagline-scroll">
+    <div className="w-full -mt-0.5">
+      <span className="font-mono text-xs text-black/60 leading-none whitespace-nowrap">
         A Quant Matrix AI Experience
       </span>
     </div>

--- a/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
+++ b/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
@@ -22,8 +22,8 @@ const LogoText: React.FC<LogoTextProps> = ({ className = '', titleClassName }) =
       </h1>
       <div className="h-0.5 bg-trinity-yellow mt-1 w-full" />
     </div>
-    <div className="overflow-hidden w-full mt-0">
-      <span className="font-mono text-xs text-black/60 leading-none whitespace-nowrap inline-block animate-slide-in-left">
+    <div className="overflow-hidden w-full -mt-px">
+      <span className="font-mono text-xs text-black/60 leading-none whitespace-nowrap inline-block animate-tagline-scroll">
         A Quant Matrix AI Experience
       </span>
     </div>

--- a/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
+++ b/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
@@ -22,8 +22,8 @@ const LogoText: React.FC<LogoTextProps> = ({ className = '', titleClassName }) =
       </h1>
       <div className="h-0.5 bg-trinity-yellow mt-1 w-full" />
     </div>
-    <div className="overflow-hidden w-full mt-px">
-      <span className="font-mono text-xs text-black/60 leading-tight whitespace-nowrap inline-block animate-slide-in-left">
+    <div className="overflow-hidden w-full mt-0">
+      <span className="font-mono text-xs text-black/60 leading-none whitespace-nowrap inline-block animate-slide-in-left">
         A Quant Matrix AI Experience
       </span>
     </div>

--- a/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
+++ b/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
@@ -10,7 +10,7 @@ interface LogoTextProps {
 
 const LogoText: React.FC<LogoTextProps> = ({ className = '', titleClassName }) => (
   <div
-    className={`flex h-12 flex-col justify-center items-start text-left leading-none w-fit ${className}`.trim()}
+    className={`flex min-h-12 flex-col justify-center items-start text-left w-fit ${className}`.trim()}
   >
     <div className="flex flex-col items-start w-fit">
       <h1
@@ -23,7 +23,7 @@ const LogoText: React.FC<LogoTextProps> = ({ className = '', titleClassName }) =
       <div className="h-0.5 bg-trinity-yellow mt-0.5 w-full" />
     </div>
     <div className="overflow-hidden mt-1 w-full">
-      <span className="font-mono text-xs text-black/60 leading-none whitespace-nowrap inline-block animate-tagline-scroll">
+      <span className="font-mono text-xs text-black/60 leading-tight whitespace-nowrap inline-block animate-tagline-scroll">
         A Quant Matrix AI Experience
       </span>
     </div>

--- a/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
+++ b/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
@@ -10,7 +10,7 @@ interface LogoTextProps {
 
 const LogoText: React.FC<LogoTextProps> = ({ className = '', titleClassName }) => (
   <div
-    className={`flex min-h-12 flex-col justify-center items-start text-left w-fit ${className}`.trim()}
+    className={`flex h-12 flex-col justify-center items-start text-left w-fit ${className}`.trim()}
   >
     <div className="flex flex-col items-start w-fit">
       <h1
@@ -22,8 +22,8 @@ const LogoText: React.FC<LogoTextProps> = ({ className = '', titleClassName }) =
       </h1>
       <div className="h-0.5 bg-trinity-yellow mt-0.5 w-full" />
     </div>
-    <div className="overflow-hidden mt-1 w-full">
-      <span className="font-mono text-xs text-black/60 leading-tight whitespace-nowrap inline-block animate-tagline-scroll">
+    <div className="overflow-hidden mt-0.5 w-full">
+      <span className="font-mono text-xs text-black/60 leading-none whitespace-nowrap inline-block animate-tagline-scroll">
         A Quant Matrix AI Experience
       </span>
     </div>

--- a/TrinityFrontend/tailwind.config.ts
+++ b/TrinityFrontend/tailwind.config.ts
@@ -125,10 +125,10 @@ export default {
                                 },
                                 'tagline-scroll': {
                                         '0%': {
-                                                transform: 'translateX(100%)'
+                                                transform: 'translateX(-100%)'
                                         },
                                         '100%': {
-                                                transform: 'translateX(-100%)'
+                                                transform: 'translateX(100%)'
                                         }
                                 }
                         },

--- a/TrinityFrontend/tailwind.config.ts
+++ b/TrinityFrontend/tailwind.config.ts
@@ -126,14 +126,14 @@ export default {
                                 'dot-travel': {
                                         '0%': {
                                                 top: '-3rem',
-                                                left: '-3.75rem'
+                                                left: '0'
                                         },
                                         '30%': {
-                                                top: '0',
+                                                top: '50%',
                                                 left: '0'
                                         },
                                         '100%': {
-                                                top: '0',
+                                                top: '50%',
                                                 left: '100%'
                                         }
                                 },
@@ -154,8 +154,8 @@ export default {
                                 'accordion-up': 'accordion-up 0.2s ease-out',
                                 'fade-in': 'fade-in 0.3s ease-out',
                                 'scale-in': 'scale-in 0.2s ease-out',
-                                'dot-travel': 'dot-travel 1.5s ease-in-out forwards',
-                                'line-grow': 'line-grow 1.5s ease-in-out forwards'
+                                'dot-travel': 'dot-travel 4s ease-in-out forwards',
+                                'line-grow': 'line-grow 4s ease-in-out forwards'
                         }
                 }
         },

--- a/TrinityFrontend/tailwind.config.ts
+++ b/TrinityFrontend/tailwind.config.ts
@@ -123,14 +123,15 @@ export default {
                                                 opacity: '1'
                                         }
                                 },
-                                'slide-in-left': {
+                                'tagline-scroll': {
                                         '0%': {
-                                                opacity: '0',
                                                 transform: 'translateX(-100%)'
                                         },
+                                        '50%': {
+                                                transform: 'translateX(100%)'
+                                        },
                                         '100%': {
-                                                opacity: '1',
-                                                transform: 'translateX(0)'
+                                                transform: 'translateX(-100%)'
                                         }
                                 }
                         },
@@ -139,7 +140,7 @@ export default {
                                 'accordion-up': 'accordion-up 0.2s ease-out',
                                 'fade-in': 'fade-in 0.3s ease-out',
                                 'scale-in': 'scale-in 0.2s ease-out',
-                                'slide-in-left': 'slide-in-left 0.5s linear forwards'
+                                'tagline-scroll': 'tagline-scroll 12s linear infinite'
                         }
                 }
         },

--- a/TrinityFrontend/tailwind.config.ts
+++ b/TrinityFrontend/tailwind.config.ts
@@ -123,20 +123,26 @@ export default {
                                                 opacity: '1'
                                         }
                                 },
-                                'slide-in-left': {
+                                'dot-travel': {
                                         '0%': {
-                                                transform: 'translateX(-100%)'
+                                                transform: 'translateX(0) translateY(-100%)'
+                                        },
+                                        '20%': {
+                                                transform: 'translateX(0) translateY(0)'
                                         },
                                         '100%': {
-                                                transform: 'translateX(0)'
+                                                transform: 'translateX(100%) translateY(0)'
                                         }
                                 },
-                                'tagline-scroll': {
+                                'line-grow': {
                                         '0%': {
-                                                transform: 'translateX(100%)'
+                                                width: '0%'
+                                        },
+                                        '20%': {
+                                                width: '0%'
                                         },
                                         '100%': {
-                                                transform: 'translateX(-100%)'
+                                                width: '100%'
                                         }
                                 }
                         },
@@ -145,8 +151,8 @@ export default {
                                 'accordion-up': 'accordion-up 0.2s ease-out',
                                 'fade-in': 'fade-in 0.3s ease-out',
                                 'scale-in': 'scale-in 0.2s ease-out',
-                                'slide-in-left': 'slide-in-left 0.7s linear forwards',
-                                'tagline-scroll': 'tagline-scroll 12s linear infinite'
+                                'dot-travel': 'dot-travel 1.5s ease-in-out forwards',
+                                'line-grow': 'line-grow 1.5s ease-in-out forwards'
                         }
                 }
         },

--- a/TrinityFrontend/tailwind.config.ts
+++ b/TrinityFrontend/tailwind.config.ts
@@ -125,20 +125,23 @@ export default {
                                 },
                                 'dot-travel': {
                                         '0%': {
-                                                transform: 'translateX(0) translateY(-100%)'
+                                                top: '-3rem',
+                                                left: '-3.75rem'
                                         },
-                                        '20%': {
-                                                transform: 'translateX(0) translateY(0)'
+                                        '30%': {
+                                                top: '0',
+                                                left: '0'
                                         },
                                         '100%': {
-                                                transform: 'translateX(100%) translateY(0)'
+                                                top: '0',
+                                                left: '100%'
                                         }
                                 },
                                 'line-grow': {
                                         '0%': {
                                                 width: '0%'
                                         },
-                                        '20%': {
+                                        '30%': {
                                                 width: '0%'
                                         },
                                         '100%': {

--- a/TrinityFrontend/tailwind.config.ts
+++ b/TrinityFrontend/tailwind.config.ts
@@ -126,7 +126,7 @@ export default {
                                 'dot-travel': {
                                         '0%': {
                                                 top: '-3rem',
-                                                left: '0'
+                                                left: '-2.25rem'
                                         },
                                         '30%': {
                                                 top: '50%',

--- a/TrinityFrontend/tailwind.config.ts
+++ b/TrinityFrontend/tailwind.config.ts
@@ -123,12 +123,12 @@ export default {
                                                 opacity: '1'
                                         }
                                 },
-                                'tagline-scroll': {
+                                'slide-in-left': {
                                         '0%': {
                                                 transform: 'translateX(-100%)'
                                         },
                                         '100%': {
-                                                transform: 'translateX(100%)'
+                                                transform: 'translateX(0)'
                                         }
                                 }
                         },
@@ -137,7 +137,7 @@ export default {
                                 'accordion-up': 'accordion-up 0.2s ease-out',
                                 'fade-in': 'fade-in 0.3s ease-out',
                                 'scale-in': 'scale-in 0.2s ease-out',
-                                'tagline-scroll': 'tagline-scroll 12s linear infinite'
+                                'slide-in-left': 'slide-in-left 0.7s linear forwards'
                         }
                 }
         },

--- a/TrinityFrontend/tailwind.config.ts
+++ b/TrinityFrontend/tailwind.config.ts
@@ -86,51 +86,62 @@ export default {
 				md: 'calc(var(--radius) - 2px)',
 				sm: 'calc(var(--radius) - 4px)'
 			},
-			keyframes: {
-				'accordion-down': {
-					from: {
-						height: '0'
-					},
-					to: {
-						height: 'var(--radix-accordion-content-height)'
-					}
-				},
-				'accordion-up': {
-					from: {
-						height: 'var(--radix-accordion-content-height)'
-					},
-					to: {
-						height: '0'
-					}
-				},
-				'fade-in': {
-					'0%': {
-						opacity: '0',
-						transform: 'translateY(10px)'
-					},
-					'100%': {
-						opacity: '1',
-						transform: 'translateY(0)'
-					}
-				},
-				'scale-in': {
-					'0%': {
-						transform: 'scale(0.95)',
-						opacity: '0'
-					},
-					'100%': {
-						transform: 'scale(1)',
-						opacity: '1'
-					}
-				}
-			},
-			animation: {
-				'accordion-down': 'accordion-down 0.2s ease-out',
-				'accordion-up': 'accordion-up 0.2s ease-out',
-				'fade-in': 'fade-in 0.3s ease-out',
-				'scale-in': 'scale-in 0.2s ease-out'
-			}
-		}
-	},
-	plugins: [require("tailwindcss-animate")],
+                        keyframes: {
+                                'accordion-down': {
+                                        from: {
+                                                height: '0'
+                                        },
+                                        to: {
+                                                height: 'var(--radix-accordion-content-height)'
+                                        }
+                                },
+                                'accordion-up': {
+                                        from: {
+                                                height: 'var(--radix-accordion-content-height)'
+                                        },
+                                        to: {
+                                                height: '0'
+                                        }
+                                },
+                                'fade-in': {
+                                        '0%': {
+                                                opacity: '0',
+                                                transform: 'translateY(10px)'
+                                        },
+                                        '100%': {
+                                                opacity: '1',
+                                                transform: 'translateY(0)'
+                                        }
+                                },
+                                'scale-in': {
+                                        '0%': {
+                                                transform: 'scale(0.95)',
+                                                opacity: '0'
+                                        },
+                                        '100%': {
+                                                transform: 'scale(1)',
+                                                opacity: '1'
+                                        }
+                                },
+                                'slide-in-left': {
+                                        '0%': {
+                                                opacity: '0',
+                                                transform: 'translateX(-100%)'
+                                        },
+                                        '100%': {
+                                                opacity: '1',
+                                                transform: 'translateX(0)'
+                                        }
+                                }
+                        },
+                        animation: {
+                                'accordion-down': 'accordion-down 0.2s ease-out',
+                                'accordion-up': 'accordion-up 0.2s ease-out',
+                                'fade-in': 'fade-in 0.3s ease-out',
+                                'scale-in': 'scale-in 0.2s ease-out',
+                                'slide-in-left': 'slide-in-left 0.5s linear forwards'
+                        }
+                }
+        },
+        plugins: [require("tailwindcss-animate")],
 } satisfies Config;

--- a/TrinityFrontend/tailwind.config.ts
+++ b/TrinityFrontend/tailwind.config.ts
@@ -130,6 +130,14 @@ export default {
                                         '100%': {
                                                 transform: 'translateX(0)'
                                         }
+                                },
+                                'tagline-scroll': {
+                                        '0%': {
+                                                transform: 'translateX(100%)'
+                                        },
+                                        '100%': {
+                                                transform: 'translateX(-100%)'
+                                        }
                                 }
                         },
                         animation: {
@@ -137,7 +145,8 @@ export default {
                                 'accordion-up': 'accordion-up 0.2s ease-out',
                                 'fade-in': 'fade-in 0.3s ease-out',
                                 'scale-in': 'scale-in 0.2s ease-out',
-                                'slide-in-left': 'slide-in-left 0.7s linear forwards'
+                                'slide-in-left': 'slide-in-left 0.7s linear forwards',
+                                'tagline-scroll': 'tagline-scroll 12s linear infinite'
                         }
                 }
         },

--- a/TrinityFrontend/tailwind.config.ts
+++ b/TrinityFrontend/tailwind.config.ts
@@ -125,9 +125,6 @@ export default {
                                 },
                                 'tagline-scroll': {
                                         '0%': {
-                                                transform: 'translateX(-100%)'
-                                        },
-                                        '50%': {
                                                 transform: 'translateX(100%)'
                                         },
                                         '100%': {


### PR DESCRIPTION
## Summary
- underline Trinity logo with brand yellow
- animate tagline to slide in from left

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 50 errors, 65 warnings)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b58ba256bc8321826ba148658e3389