### PR TITLE
fix: center primary menu logo animation

### DIFF
--- a/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
+++ b/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
@@ -22,7 +22,7 @@ const LogoText: React.FC<LogoTextProps> = ({ className = '', titleClassName }) =
       </h1>
       <div className="relative w-full mt-1 h-0.5">
         <div className="absolute left-0 top-0 h-full bg-trinity-yellow w-0 animate-line-grow" />
-        <span className="absolute left-0 top-1/2 w-2 h-2 rounded-full bg-trinity-blue -translate-x-1/2 -translate-y-1/2 animate-dot-travel" />
+        <span className="absolute left-0 top-1/2 w-2 h-2 rounded-full bg-black -translate-x-1/2 -translate-y-1/2 animate-dot-travel" />
       </div>
     </div>
     <div className="w-full -mt-0.5">

--- a/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
+++ b/TrinityFrontend/src/components/PrimaryMenu/TrinityAssets/LogoText.tsx
@@ -20,8 +20,21 @@ const LogoText: React.FC<LogoTextProps> = ({ className = '', titleClassName }) =
       >
         Trinity
       </h1>
-      <div className="relative w-full mt-1 h-0.5">
-        <div className="absolute left-0 top-0 h-full bg-trinity-yellow w-0 animate-line-grow" />
+      <div className="relative w-full mt-1 h-1">
+        <div className="absolute left-0 top-0 h-full w-0 overflow-hidden animate-line-grow">
+          <svg
+            className="w-full h-full text-trinity-yellow"
+            viewBox="0 0 100 4"
+            preserveAspectRatio="none"
+          >
+            <polyline
+              points="0,2 10,1 20,3 30,1 40,3 50,1 60,3 70,1 80,3 90,1 100,2"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            />
+          </svg>
+        </div>
         <span className="absolute left-0 top-1/2 w-2 h-2 rounded-full bg-black -translate-x-1/2 -translate-y-1/2 animate-dot-travel" />
       </div>
     </div>

--- a/TrinityFrontend/tailwind.config.ts
+++ b/TrinityFrontend/tailwind.config.ts
@@ -125,10 +125,6 @@ export default {
                                 },
                                 'dot-travel': {
                                         '0%': {
-                                                top: '-3rem',
-                                                left: '-1.5rem'
-                                        },
-                                        '30%': {
                                                 top: '50%',
                                                 left: '0'
                                         },
@@ -141,9 +137,6 @@ export default {
                                         '0%': {
                                                 width: '0%'
                                         },
-                                        '30%': {
-                                                width: '0%'
-                                        },
                                         '100%': {
                                                 width: '100%'
                                         }
@@ -154,8 +147,8 @@ export default {
                                 'accordion-up': 'accordion-up 0.2s ease-out',
                                 'fade-in': 'fade-in 0.3s ease-out',
                                 'scale-in': 'scale-in 0.2s ease-out',
-                                'dot-travel': 'dot-travel 4s ease-in-out forwards',
-                                'line-grow': 'line-grow 4s ease-in-out forwards'
+                                'dot-travel': 'dot-travel 4s ease-in-out infinite',
+                                'line-grow': 'line-grow 4s ease-in-out infinite'
                         }
                 }
         },

--- a/TrinityFrontend/tailwind.config.ts
+++ b/TrinityFrontend/tailwind.config.ts
@@ -126,7 +126,7 @@ export default {
                                 'dot-travel': {
                                         '0%': {
                                                 top: '-3rem',
-                                                left: '-2.25rem'
+                                                left: '-1.5rem'
                                         },
                                         '30%': {
                                                 top: '50%',


### PR DESCRIPTION
## Summary
- center origin of dot animation for primary menu logo

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 115 problems (50 errors, 65 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68b6abbbe41c8321b55047f2fbddf40e