### PR TITLE
fix: ensure initial scope provides filters

### DIFF
--- a/TrinityBackendDjango/apps/registry/serializers.py
+++ b/TrinityBackendDjango/apps/registry/serializers.py
@@ -20,6 +20,13 @@ class ProjectSerializer(serializers.ModelSerializer):
         default=serializers.CurrentUserDefault(),
     )
     base_template = serializers.SerializerMethodField()
+    base_template_id = serializers.PrimaryKeyRelatedField(
+        queryset=Template.objects.all(),
+        source="base_template",
+        write_only=True,
+        required=False,
+        allow_null=True,
+    )
 
     class Meta:
         model = Project
@@ -32,6 +39,7 @@ class ProjectSerializer(serializers.ModelSerializer):
             "app",
             "state",
             "base_template",
+            "base_template_id",
             "created_at",
             "updated_at",
         ]

--- a/TrinityBackendDjango/apps/registry/views.py
+++ b/TrinityBackendDjango/apps/registry/views.py
@@ -314,19 +314,67 @@ class ProjectViewSet(viewsets.ModelViewSet):
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     @action(detail=True, methods=["post"])
+    def import_template(self, request, pk=None):
+        """Apply a template to an existing project."""
+        if not self._can_edit(request.user):
+            return Response({"detail": "Permission denied."}, status=status.HTTP_403_FORBIDDEN)
+        project = self.get_object()
+        template_id = request.data.get("template_id")
+        if not template_id:
+            return Response({"detail": "template_id required."}, status=status.HTTP_400_BAD_REQUEST)
+        try:
+            template = Template.objects.get(id=template_id, app=project.app)
+        except Template.DoesNotExist:
+            return Response({"detail": "Template not found."}, status=status.HTTP_404_NOT_FOUND)
+        overwrite = bool(request.data.get("overwrite"))
+        if overwrite:
+            project.state = template.state
+            project.base_template = template
+            project.save()
+            state = template.state or {}
+            for field, mode in [
+                ("laboratory_config", "lab"),
+                ("workflow_config", "workflow"),
+                ("exhibition_config", "exhibition"),
+            ]:
+                cfg = state.get(field)
+                if cfg and cfg.get("cards"):
+                    save_atom_list_configuration(project, mode, cfg["cards"])
+
+            projects = template.template_projects or []
+            if not any(p.get("id") == project.id for p in projects):
+                projects.append(ProjectSerializer(project).data)
+                template.template_projects = projects
+                template.save(update_fields=["template_projects"])
+        else:
+            project.base_template = template
+            project.save(update_fields=["base_template"])
+        serializer = self.get_serializer(project)
+        return Response(serializer.data)
+
+    @action(detail=True, methods=["post"])
     def save_template(self, request, pk=None):
         """Persist the project as a reusable template."""
         if not self._can_edit(request.user):
             return Response({"detail": "Permission denied."}, status=status.HTTP_403_FORBIDDEN)
         project = self.get_object()
         serialized = ProjectSerializer(project).data
+        state = project.state or {}
+        for field, mode in [
+            ("laboratory_config", "lab"),
+            ("workflow_config", "workflow"),
+            ("exhibition_config", "exhibition"),
+        ]:
+            cfg = load_atom_list_configuration(project, mode)
+            if cfg:
+                state[field] = cfg
         template = Template.objects.create(
             name=f"{project.name} Template",
             slug=slugify(f"{project.slug}-template"),
             description=project.description,
             owner=request.user,
             app=project.app,
-            state=project.state,
+            state=state,
             base_project=serialized,
         )
         return Response(TemplateSerializer(template).data, status=status.HTTP_201_CREATED)
@@ -412,8 +460,13 @@ class TemplateViewSet(viewsets.ModelViewSet):
             base_template=template,
         )
 
-        for mode in ["lab", "workflow", "exhibition"]:
-            cfg = load_atom_list_configuration(source, mode)
+        state = template.state or {}
+        for field, mode in [
+            ("laboratory_config", "lab"),
+            ("workflow_config", "workflow"),
+            ("exhibition_config", "exhibition"),
+        ]:
+            cfg = state.get(field)
             if cfg and cfg.get("cards"):
                 save_atom_list_configuration(new_project, mode, cfg["cards"])
 

--- a/TrinityFrontend/src/components/AtomList/atoms/chart-maker/components/ChartMakerCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/chart-maker/components/ChartMakerCanvas.tsx
@@ -457,10 +457,6 @@ const renderChart = (chart: ChartMakerConfig, index: number, chartKey?: string, 
                    <Card
                      key={chart.id}
                     className="chart-card border border-black shadow-xl bg-white/95 backdrop-blur-sm overflow-hidden transform hover:scale-[1.02] transition-all duration-300 relative flex flex-col group hover:shadow-2xl"
-                     onContextMenu={e => {
-                       e.preventDefault(); // Disable right-click context menu
-                       e.stopPropagation();
-                     }}
                    >
                     <div className="bg-white border-b border-black p-4 relative flex-shrink-0 group-hover:shadow-lg transition-shadow duration-300">
                       <CardTitle className={`font-bold text-gray-900 flex items-center justify-between ${isCompact ? 'text-base' : 'text-lg'}`}>
@@ -503,12 +499,8 @@ const renderChart = (chart: ChartMakerConfig, index: number, chartKey?: string, 
                           }
                         }}
                         onMouseDown={e => handleMouseDown(e, chart.id)}
-                        onContextMenu={e => {
-                           e.preventDefault(); // Disable right-click context menu
-                           e.stopPropagation();
-                         }}
-                         title="Alt+Click to expand, Hold to change chart type"
-                       />
+                        title="Alt+Click to expand, Hold to change chart type"
+                      />
                      </div>
                      
                       {/* Filter Controls - Support both simple and multi-series modes */}

--- a/TrinityFrontend/src/components/AtomList/atoms/chart-maker/components/ChartMakerCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/chart-maker/components/ChartMakerCanvas.tsx
@@ -318,7 +318,9 @@ const renderChart = (chart: ChartMakerConfig, index: number, chartKey?: string, 
   const xAxisConfig = config.x_axis || { dataKey: chart.xAxis };
   const yAxisConfig = config.y_axis || { dataKey: chart.yAxis };
   const key = chartKey || chart.lastUpdateTime || chart.id;
-  const chartHeight = heightClass || '';
+  // Ensure charts have a visible height when rendered in card view
+  // Default to responsive heights based on layout when none provided
+  const chartHeight = heightClass || (isCompact ? 'h-56' : 'h-80');
 
   if (!chartData.length || !xAxisConfig.dataKey || (!yAxisConfig.dataKey && traces.length === 0)) {
     return (

--- a/TrinityFrontend/src/components/AtomList/atoms/chart-maker/components/ChartMakerCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/chart-maker/components/ChartMakerCanvas.tsx
@@ -114,12 +114,20 @@ const ChartMakerCanvas: React.FC<ChartMakerCanvasProps> = ({ atomId, charts, dat
   };
 
   const getFilteredData = (chart: ChartMakerConfig) => {
-    // Only use backend-generated chart data
+    // Prefer backend-provided data when available
     if (chart.chartConfig && chart.chartConfig.data) {
       return chart.chartConfig.data;
     }
-    // No fallback to frontend logic
-    return [];
+    // Fallback to filtering uploaded data based on selected identifiers
+    if (!typedData || !Array.isArray(typedData.rows)) return [];
+
+    const { filters = {} } = chart;
+    return typedData.rows.filter(row =>
+      Object.entries(filters).every(([col, values]) => {
+        if (!values || values.length === 0) return true;
+        return values.includes(String(row[col]));
+      })
+    );
   };
 
   const getChartColors = (index: number) => {
@@ -339,6 +347,11 @@ const renderChart = (chart: ChartMakerConfig, index: number, chartKey?: string, 
     yAxisLabel: yAxisConfig.label || yAxisConfig.dataKey,
     yAxisLabels: traces.length ? traces.map((t: any) => t.name || t.dataKey) : undefined,
     colors: [colors.primary, colors.secondary, colors.tertiary],
+    theme: chart.chartConfig?.theme,
+    showLegend: chart.chartConfig?.showLegend,
+    showAxisLabels: chart.chartConfig?.showAxisLabels,
+    showDataLabels: chart.chartConfig?.showDataLabels,
+    showGrid: chart.chartConfig?.showGrid,
   } as const;
 
   return (

--- a/TrinityFrontend/src/components/AtomList/atoms/chart-maker/components/ChartMakerCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/chart-maker/components/ChartMakerCanvas.tsx
@@ -320,11 +320,15 @@ const renderChart = (chart: ChartMakerConfig, index: number, chartKey?: string, 
   const key = chartKey || chart.lastUpdateTime || chart.id;
   // Ensure charts have a visible height when rendered in card view
   // Default to responsive heights based on layout when none provided
-  const chartHeight = heightClass || (isCompact ? 'h-56' : 'h-80');
+  const chartHeightClass = heightClass || (isCompact ? 'h-56' : 'h-80');
+  const chartHeightValue = heightClass ? undefined : (isCompact ? 224 : 320); // px values for reliability
 
   if (!chartData.length || !xAxisConfig.dataKey || (!yAxisConfig.dataKey && traces.length === 0)) {
     return (
-      <div className={`flex items-center justify-center ${chartHeight || 'h-64'} text-muted-foreground`}>
+      <div
+        className={`flex items-center justify-center ${chartHeightClass || 'h-64'} text-muted-foreground`}
+        style={{ minHeight: chartHeightValue }}
+      >
         <div className="text-center">
           <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-gradient-to-br from-slate-100 to-slate-200 flex items-center justify-center">
             <LineChartIcon className="w-8 h-8 text-slate-400" />
@@ -354,10 +358,11 @@ const renderChart = (chart: ChartMakerConfig, index: number, chartKey?: string, 
     showAxisLabels: chart.chartConfig?.showAxisLabels,
     showDataLabels: chart.chartConfig?.showDataLabels,
     showGrid: chart.chartConfig?.showGrid,
+    height: chartHeightValue,
   } as const;
 
   return (
-    <div className={`w-full ${chartHeight}`}>
+    <div className={`w-full ${chartHeightClass}`} style={{ minHeight: chartHeightValue }}>
       <RechartsChartRenderer {...rendererProps} />
     </div>
   );

--- a/TrinityFrontend/src/components/AtomList/atoms/scope-selector/components/ScopeSelectorCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/scope-selector/components/ScopeSelectorCanvas.tsx
@@ -218,7 +218,7 @@ const ScopeSelectorCanvas: React.FC<ScopeSelectorCanvasProps> = ({ data, onDataC
         description: 'Scope generated from Scope Selector',
       };
 
-      data.scopes.slice(0, 5).forEach((scope, idx) => {
+      const scopeEntries = data.scopes.slice(0, 5).map((scope, idx) => {
         const setNum = idx + 1;
         const identifierFilters: Record<string, string[]> = {};
         Object.entries(scope.identifiers).forEach(([key, value]) => {
@@ -226,6 +226,20 @@ const ScopeSelectorCanvas: React.FC<ScopeSelectorCanvasProps> = ({ data, onDataC
             identifierFilters[key] = Array.isArray(value) ? value : [value as string];
           }
         });
+        return { scope, setNum, identifierFilters };
+      });
+
+      const validScopes = scopeEntries.filter(
+        (entry) => Object.keys(entry.identifierFilters).length > 0
+      );
+
+      if (validScopes.length === 0) {
+        toast({ title: 'No identifier filters selected', variant: 'destructive' });
+        setSaving(false);
+        return;
+      }
+
+      validScopes.forEach(({ scope, setNum, identifierFilters }) => {
         requestBody[`identifier_filters_${setNum}`] = identifierFilters;
         if (scope.timeframe.from && scope.timeframe.to) {
           requestBody[`start_date_${setNum}`] = scope.timeframe.from;
@@ -275,7 +289,7 @@ const ScopeSelectorCanvas: React.FC<ScopeSelectorCanvasProps> = ({ data, onDataC
         }, [[]]);
       };
 
-      for (const scope of data.scopes) {
+      for (const { scope } of validScopes) {
         // Use selectedIdentifiers to maintain the correct order from canvas
         const keys = data.selectedIdentifiers.filter(key => scope.identifiers[key]);
         const valueArrays: string[][] = keys.map(k => {

--- a/TrinityFrontend/src/components/AtomList/atoms/scope-selector/components/ScopeSelectorCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/scope-selector/components/ScopeSelectorCanvas.tsx
@@ -401,7 +401,28 @@ const ScopeSelectorCanvas: React.FC<ScopeSelectorCanvasProps> = ({ data, onDataC
           throw new Error(`Status ${res.status}`);
         }
         const json = await res.json();
-        setDateRange({ min: json.min_date, max: json.max_date, available: true });
+        const fetchedRange = { min: json.min_date, max: json.max_date, available: true };
+        setDateRange(fetchedRange);
+        if (data.scopes?.length) {
+          const updatedScopes = data.scopes.map(scope => ({
+            ...scope,
+            timeframe: {
+              from:
+                fetchedRange.min ??
+                scope.timeframe?.from ??
+                new Date().toISOString().split('T')[0],
+              to:
+                fetchedRange.max ??
+                scope.timeframe?.to ??
+                new Date(
+                  new Date().setFullYear(new Date().getFullYear() + 1)
+                )
+                  .toISOString()
+                  .split('T')[0]
+            }
+          }));
+          onDataChange({ scopes: updatedScopes });
+        }
       } catch (err) {
         console.warn('Date range unavailable:', err);
         setDateRange({ min: null, max: null, available: false });
@@ -409,6 +430,7 @@ const ScopeSelectorCanvas: React.FC<ScopeSelectorCanvasProps> = ({ data, onDataC
     };
     fetchRange();
     return () => controller.abort();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data.dataSource]);
 
   // Combined effect to handle data source and identifier changes

--- a/TrinityFrontend/src/templates/charts/RechartsChartRenderer.tsx
+++ b/TrinityFrontend/src/templates/charts/RechartsChartRenderer.tsx
@@ -1149,23 +1149,30 @@ const RechartsChartRenderer: React.FC<Props> = ({
       }
     }
     
-    // Handle dual Y-axes detection
-    if (yKeys.length === 0 && yFields && yFields.length > 0) {
-      yKeys = yFields;
-    } else if (yKeys.length === 0 && firstItem) {
-      const availableKeys = Object.keys(firstItem);
-      // For dual Y-axes, try to find multiple numeric fields
-      const numericKeys = availableKeys.filter(key => 
-        key !== xKey && 
-        key !== 'category' && 
-        key !== 'label' &&
-        typeof firstItem[key] === 'number' && 
-        !isNaN(firstItem[key])
-      );
-      if (numericKeys.length >= 2) {
-        yKeys = numericKeys.slice(0, 2); // Take first two numeric fields
-      } else if (numericKeys.length === 1) {
-        yKeys = [numericKeys[0]];
+    // Determine which Y-axis fields to use. Only include a secondary axis when explicitly configured.
+    if (yKeys.length === 0) {
+      if (yFields && yFields.length > 0) {
+        // Use provided fields (may include multiple for dual axes)
+        yKeys = yFields;
+      } else if (yField) {
+        // Single field explicitly specified – use it as the only Y axis
+        yKeys = [yField];
+      } else if (firstItem) {
+        // Fallback: auto-detect the first numeric field for a single Y axis
+        const availableKeys = Object.keys(firstItem);
+        const numericKeys = availableKeys.filter(key =>
+          key !== xKey &&
+          key !== 'category' &&
+          key !== 'label' &&
+          typeof firstItem[key] === 'number' &&
+          !isNaN(firstItem[key])
+        );
+        if (numericKeys.length > 0) {
+          yKeys = [numericKeys[0]];
+        }
+      }
+      if (!yKey && yKeys.length > 0) {
+        yKey = yKeys[0];
       }
     }
     

--- a/TrinityFrontend/src/templates/charts/RechartsChartRenderer.tsx
+++ b/TrinityFrontend/src/templates/charts/RechartsChartRenderer.tsx
@@ -652,7 +652,8 @@ const RechartsChartRenderer: React.FC<Props> = ({
   // Handle right-click context menu
   const handleContextMenu = (e: React.MouseEvent) => {
     e.preventDefault();
-    setContextMenuPosition({ x: e.clientX, y: e.clientY });
+    const { pageX, pageY, clientX, clientY } = e;
+    setContextMenuPosition({ x: pageX || clientX, y: pageY || clientY });
     setShowContextMenu(true);
     setShowColorSubmenu(false); // Always close submenu when opening main menu
   };
@@ -806,10 +807,9 @@ const RechartsChartRenderer: React.FC<Props> = ({
     return (
       <div 
         className="fixed z-[9999] bg-white border border-gray-200 rounded-lg shadow-lg py-2 min-w-48 context-menu"
-        style={{ 
-          left: contextMenuPosition.x, 
+        style={{
+          left: contextMenuPosition.x,
           top: contextMenuPosition.y,
-          transform: 'translate(-50%, -100%)',
           pointerEvents: 'auto'
         }}
         onClick={(e) => {

--- a/TrinityFrontend/src/templates/charts/RechartsChartRenderer.tsx
+++ b/TrinityFrontend/src/templates/charts/RechartsChartRenderer.tsx
@@ -652,10 +652,14 @@ const RechartsChartRenderer: React.FC<Props> = ({
   // Handle right-click context menu
   const handleContextMenu = (e: React.MouseEvent) => {
     e.preventDefault();
+    e.stopPropagation();
+
     const { pageX, pageY, clientX, clientY } = e;
     setContextMenuPosition({ x: pageX || clientX, y: pageY || clientY });
+
     setShowContextMenu(true);
     setShowColorSubmenu(false); // Always close submenu when opening main menu
+    setShowSortSubmenu(false);
   };
 
   // Handle theme change

--- a/TrinityFrontend/src/templates/charts/RechartsChartRenderer.tsx
+++ b/TrinityFrontend/src/templates/charts/RechartsChartRenderer.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect, useMemo, useCallback } from 'react';
+import { createPortal } from 'react-dom';
 import "./chart.css";
 import {
   BarChart,
@@ -654,8 +655,7 @@ const RechartsChartRenderer: React.FC<Props> = ({
     e.preventDefault();
     e.stopPropagation();
 
-    const { pageX, pageY, clientX, clientY } = e;
-    setContextMenuPosition({ x: pageX || clientX, y: pageY || clientY });
+    setContextMenuPosition({ x: e.clientX, y: e.clientY });
 
     setShowContextMenu(true);
     setShowColorSubmenu(false); // Always close submenu when opening main menu
@@ -808,8 +808,8 @@ const RechartsChartRenderer: React.FC<Props> = ({
   const ContextMenu = () => {
     if (!showContextMenu) return null;
 
-    return (
-      <div 
+    const menu = (
+      <div
         className="fixed z-[9999] bg-white border border-gray-200 rounded-lg shadow-lg py-2 min-w-48 context-menu"
         style={{
           left: contextMenuPosition.x,
@@ -931,8 +931,6 @@ const RechartsChartRenderer: React.FC<Props> = ({
           </div>
         </button>
 
-
-
         {/* Save Action */}
         <button
           className="w-full px-4 py-2 text-sm text-left hover:bg-gray-50 flex items-center gap-3 text-gray-700"
@@ -945,13 +943,15 @@ const RechartsChartRenderer: React.FC<Props> = ({
         </button>
       </div>
     );
+
+    return createPortal(menu, document.body);
   };
 
   // Color theme submenu component
   const ColorThemeSubmenu = () => {
     if (!showColorSubmenu) return null;
 
-    return (
+    const submenu = (
       <div
         className="fixed z-[9999] bg-white border border-gray-300 rounded-lg shadow-xl p-3 color-submenu"
         style={{
@@ -1003,13 +1003,15 @@ const RechartsChartRenderer: React.FC<Props> = ({
         </div>
       </div>
     );
+
+    return createPortal(submenu, document.body);
   };
 
   // Sort submenu component
   const SortSubmenu = () => {
     if (!showSortSubmenu) return null;
 
-    return (
+    const submenu = (
       <div
         className="fixed z-[9999] bg-white border border-gray-300 rounded-lg shadow-xl p-2 sort-submenu"
         style={{
@@ -1067,6 +1069,8 @@ const RechartsChartRenderer: React.FC<Props> = ({
         </div>
       </div>
     );
+
+    return createPortal(submenu, document.body);
   };
 
 


### PR DESCRIPTION
## Summary
- avoid sending empty identifier filter sets during scope save
- only build preview rows for scopes with identifier selections

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 50 errors)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b80cb8ff5083219aef73b88020a3a5