### PR TITLE
feat: allow importing templates into projects

### DIFF
--- a/TrinityBackendDjango/apps/registry/serializers.py
+++ b/TrinityBackendDjango/apps/registry/serializers.py
@@ -20,6 +20,13 @@ class ProjectSerializer(serializers.ModelSerializer):
         default=serializers.CurrentUserDefault(),
     )
     base_template = serializers.SerializerMethodField()
+    base_template_id = serializers.PrimaryKeyRelatedField(
+        queryset=Template.objects.all(),
+        source="base_template",
+        write_only=True,
+        required=False,
+        allow_null=True,
+    )
 
     class Meta:
         model = Project
@@ -32,6 +39,7 @@ class ProjectSerializer(serializers.ModelSerializer):
             "app",
             "state",
             "base_template",
+            "base_template_id",
             "created_at",
             "updated_at",
         ]


### PR DESCRIPTION
## Summary
- add "Import from Template" submenu for projects
- support overwriting project config with a selected template
- expose backend endpoint to apply templates to existing projects

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b80e050344832183fba07b801502fd