### PR TITLE
Show full dataframe in DataFrame Operations

### DIFF
--- a/TrinityBackendFastAPI/app/features/dataframe_operations/app/routes.py
+++ b/TrinityBackendFastAPI/app/features/dataframe_operations/app/routes.py
@@ -38,15 +38,12 @@ def _get_df(df_id: str) -> pl.DataFrame:
 
 
 def _df_payload(df: pl.DataFrame, df_id: str) -> Dict[str, Any]:
-    """Serialize the entire dataframe for the frontend."""
+    """Serialize the entire dataframe for the frontend using Polars."""
 
-    # Using PyArrow for row conversion is considerably faster and scales
-    # better for large dataframes than converting each row in Python.
-    rows = df.to_arrow().to_pylist()
     return {
         "df_id": df_id,
         "headers": df.columns,
-        "rows": rows,
+        "rows": df.to_dicts(),
         "types": {col: str(dtype) for col, dtype in zip(df.columns, df.dtypes)},
         "row_count": df.height,
         "column_count": df.width,

--- a/TrinityBackendFastAPI/app/features/dataframe_operations/app/routes.py
+++ b/TrinityBackendFastAPI/app/features/dataframe_operations/app/routes.py
@@ -37,10 +37,17 @@ def _get_df(df_id: str) -> pl.DataFrame:
     return df
 
 
-def _df_payload(df: pl.DataFrame, df_id: str, page: int = 1, page_size: int = 100) -> Dict[str, Any]:
-    start = (page - 1) * page_size
-    page_df = df.slice(start, page_size)
-    rows = page_df.to_dicts()
+def _df_payload(df: pl.DataFrame, df_id: str) -> Dict[str, Any]:
+    """
+    Serialize the entire dataframe for the frontend.
+
+    The previous implementation returned only the first 100 rows by default.
+    This caused the frontend to display at most 100 rows regardless of the
+    dataframe size.  By serializing the full dataframe here, the frontend can
+    handle pagination itself and expose all available rows to the user.
+    """
+
+    rows = df.to_dicts()
     return {
         "df_id": df_id,
         "headers": df.columns,
@@ -48,8 +55,6 @@ def _df_payload(df: pl.DataFrame, df_id: str, page: int = 1, page_size: int = 10
         "types": {col: str(dtype) for col, dtype in zip(df.columns, df.dtypes)},
         "row_count": df.height,
         "column_count": df.width,
-        "page": page,
-        "page_size": page_size,
     }
 
 

--- a/TrinityFrontend/src/components/AtomList/atoms/dataframe-operations/components/DataFrameOperationsCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/dataframe-operations/components/DataFrameOperationsCanvas.tsx
@@ -366,11 +366,16 @@ const DataFrameOperationsCanvas: React.FC<DataFrameOperationsCanvasProps> = ({
         .map(item => item.row);
     }
 
-    // Unique values for filter UI (use originalData if available)
-    const sourceRows = originalData?.rows || data.rows;
+    // Unique values for filter UI
+    // Prefer the original unmodified data for existing columns so filters show all options.
+    // For newly added columns (e.g. after duplication) fall back to the current data rows.
     const uniqueValues: { [key: string]: string[] } = {};
     data.headers.forEach(header => {
-      const values = Array.from(new Set(sourceRows.map(row => safeToString(row[header]))))
+      const rowsForHeader =
+        originalData?.headers?.includes(header) ? originalData.rows : data.rows;
+      const values = Array.from(
+        new Set(rowsForHeader.map(row => safeToString(row[header])))
+      )
         .filter(val => val !== '')
         .sort();
       uniqueValues[header] = values.slice(0, 50);

--- a/TrinityFrontend/src/components/AtomList/atoms/dataframe-operations/services/dataframeOperationsApi.ts
+++ b/TrinityFrontend/src/components/AtomList/atoms/dataframe-operations/services/dataframeOperationsApi.ts
@@ -10,7 +10,6 @@ export interface DataFrameResponse {
 }
 
 async function postJSON(url: string, body: any) {
-  console.log('[DataFrameOperationsAPI] POST', url, body);
   const res = await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -18,21 +17,16 @@ async function postJSON(url: string, body: any) {
   });
   const text = await res.text();
   if (!res.ok) {
-    console.error('[DataFrameOperationsAPI] error', url, text);
     throw new Error(text);
   }
   try {
-    const data = JSON.parse(text);
-    console.log('[DataFrameOperationsAPI] response', url, data);
-    return data;
+    return JSON.parse(text);
   } catch {
-    console.error('[DataFrameOperationsAPI] invalid JSON response', text);
     throw new Error(text);
   }
 }
 
 export async function loadDataframe(file: File): Promise<DataFrameResponse> {
-  console.log('[DataFrameOperationsAPI] uploading file', file.name);
   const form = new FormData();
   form.append('file', file);
   const res = await fetch(`${DATAFRAME_OPERATIONS_API}/load`, {
@@ -41,16 +35,12 @@ export async function loadDataframe(file: File): Promise<DataFrameResponse> {
   });
   const text = await res.text();
   if (!res.ok) {
-    console.error('[DataFrameOperationsAPI] load error', text);
     throw new Error(text);
   }
-  const data = JSON.parse(text);
-  console.log('[DataFrameOperationsAPI] load response', data);
-  return data;
+  return JSON.parse(text);
 }
 
 export function loadDataframeByKey(objectName: string): Promise<DataFrameResponse> {
-  console.log('[DataFrameOperationsAPI] load by key', objectName);
   return postJSON(`${DATAFRAME_OPERATIONS_API}/load_cached`, { object_name: objectName });
 }
 


### PR DESCRIPTION
## Summary
- Remove server-side 100-row limit in DataFrame Operations
- Serialize and return entire dataframe so frontend can paginate all entries

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'polars')*
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b99928f1248321859313144bacfe92