### PR TITLE
Fix project environment selection for SavedDataFramesPanel

### DIFF
--- a/TrinityFrontend/src/components/AtomList/atoms/data-upload-validate/DataUploadValidateAtom.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/data-upload-validate/DataUploadValidateAtom.tsx
@@ -71,14 +71,30 @@ const DataUploadValidateAtom: React.FC<Props> = ({ atomId }) => {
     for (const file of files) {
       const form = new FormData();
       form.append('file', file);
+      const envStr = localStorage.getItem('env');
+      if (envStr) {
+        try {
+          const env = JSON.parse(envStr);
+          form.append('client_id', env.CLIENT_ID || '');
+          form.append('app_id', env.APP_ID || '');
+          form.append('project_id', env.PROJECT_ID || '');
+          form.append('client_name', env.CLIENT_NAME || '');
+          form.append('app_name', env.APP_NAME || '');
+          form.append('project_name', env.PROJECT_NAME || '');
+        } catch {
+          /* ignore */
+        }
+      }
       try {
         const res = await fetch(`${VALIDATE_API}/upload-file`, {
           method: 'POST',
           body: form,
+          credentials: 'include',
         });
         if (res.ok) {
           const data = await res.json();
           uploaded.push({ name: file.name, path: data.file_path, size: file.size });
+          toast({ title: `${file.name} uploaded successfully` });
         } else {
           toast({ title: `Failed to upload ${file.name}`, variant: 'destructive' });
         }

--- a/TrinityFrontend/src/components/LaboratoryMode/components/SavedDataFramesPanel.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/components/SavedDataFramesPanel.tsx
@@ -42,24 +42,31 @@ const SavedDataFramesPanel: React.FC<Props> = ({ isOpen, onToggle }) => {
         }
 
         if (user) {
-            try {
-              const payload: any = { user_id: user.id };
-              const redisRes = await fetch(`${SESSION_API}/init`, {
-                method: 'POST',
-                credentials: 'include',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(payload)
-              });
+          try {
+            // Provide the full environment context so the session key is
+            // unique per client/app/project and Redis returns the correct
+            // envvars for the active project.
+            const payload: any = {
+              user_id: user.id,
+              client_id: env.CLIENT_ID || '',
+              app_id: env.APP_ID || '',
+              project_id: env.PROJECT_ID || '',
+              client_name: env.CLIENT_NAME || '',
+              app_name: env.APP_NAME || '',
+              project_name: env.PROJECT_NAME || '',
+            };
+            const redisRes = await fetch(`${SESSION_API}/init`, {
+              method: 'POST',
+              credentials: 'include',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(payload),
+            });
             if (redisRes.ok) {
               const redisData = await redisRes.json();
               const redisEnv = redisData.state?.envvars;
               if (redisEnv) {
                 env = { ...env, ...redisEnv };
-                const { CLIENT_NAME, APP_NAME, PROJECT_NAME } = env;
-                localStorage.setItem(
-                  'env',
-                  JSON.stringify({ CLIENT_NAME, APP_NAME, PROJECT_NAME })
-                );
+                localStorage.setItem('env', JSON.stringify(env));
               }
             }
           } catch (err) {
@@ -90,11 +97,7 @@ const SavedDataFramesPanel: React.FC<Props> = ({ isOpen, onToggle }) => {
             setPrefix(prefData.prefix || '');
             if (prefData.environment) {
               env = { ...env, ...prefData.environment };
-              const { CLIENT_NAME, APP_NAME, PROJECT_NAME } = env;
-              localStorage.setItem(
-                'env',
-                JSON.stringify({ CLIENT_NAME, APP_NAME, PROJECT_NAME })
-              );
+              localStorage.setItem('env', JSON.stringify(env));
             }
             // Rebuild query using any refreshed environment variables so the
             // subsequent listing request targets the current namespace.
@@ -119,11 +122,7 @@ const SavedDataFramesPanel: React.FC<Props> = ({ isOpen, onToggle }) => {
             setPrefix(data.prefix || '');
             if (data.environment) {
               env = { ...env, ...data.environment };
-              const { CLIENT_NAME, APP_NAME, PROJECT_NAME } = env;
-              localStorage.setItem(
-                'env',
-                JSON.stringify({ CLIENT_NAME, APP_NAME, PROJECT_NAME })
-              );
+              localStorage.setItem('env', JSON.stringify(env));
             }
             console.log(
               `📁 SavedDataFramesPanel looking in MinIO bucket "${data.bucket}" folder "${data.prefix}" via ${data.env_source} (CLIENT_NAME=${data.environment?.CLIENT_NAME} APP_NAME=${data.environment?.APP_NAME} PROJECT_NAME=${data.environment?.PROJECT_NAME})`

--- a/TrinityFrontend/src/pages/Apps.tsx
+++ b/TrinityFrontend/src/pages/Apps.tsx
@@ -116,10 +116,20 @@ const handleAppSelect = async (appId: string) => {
       const data = await res.json();
       if (data.environment) {
         console.log('Environment after app select', data.environment);
-        // Persist the full environment (including identifiers) so subsequent
-        // requests have access to CLIENT_ID/APP_ID/PROJECT_ID and the
-        // session namespace remains consistent.
-        localStorage.setItem('env', JSON.stringify(data.environment));
+        // Persist the full environment (including identifiers). Explicitly
+        // set the current app's slug/id so the session namespace reflects
+        // the user's selection even if the backend omits these fields.
+        const env = {
+          ...data.environment,
+          APP_NAME: appId,
+          APP_ID: backendId.toString(),
+        };
+        localStorage.setItem('env', JSON.stringify(env));
+      } else {
+        localStorage.setItem(
+          'env',
+          JSON.stringify({ APP_NAME: appId, APP_ID: backendId.toString() })
+        );
       }
     }
   } catch (err) {

--- a/TrinityFrontend/src/pages/Apps.tsx
+++ b/TrinityFrontend/src/pages/Apps.tsx
@@ -116,11 +116,10 @@ const handleAppSelect = async (appId: string) => {
       const data = await res.json();
       if (data.environment) {
         console.log('Environment after app select', data.environment);
-        const { CLIENT_NAME, APP_NAME, PROJECT_NAME } = data.environment;
-        localStorage.setItem(
-          'env',
-          JSON.stringify({ CLIENT_NAME, APP_NAME, PROJECT_NAME })
-        );
+        // Persist the full environment (including identifiers) so subsequent
+        // requests have access to CLIENT_ID/APP_ID/PROJECT_ID and the
+        // session namespace remains consistent.
+        localStorage.setItem('env', JSON.stringify(data.environment));
       }
     }
   } catch (err) {

--- a/TrinityFrontend/src/pages/Projects.tsx
+++ b/TrinityFrontend/src/pages/Projects.tsx
@@ -221,15 +221,30 @@ const Projects = () => {
     try {
       const envStr = localStorage.getItem('env');
       const baseEnv = envStr ? JSON.parse(envStr) : {};
-      const { CLIENT_NAME, APP_NAME } = baseEnv;
+      const {
+        CLIENT_NAME,
+        CLIENT_ID,
+        APP_NAME,
+        APP_ID,
+      } = baseEnv;
+      // Seed local storage with the new project name while preserving any
+      // existing identifiers. This ensures components relying on
+      // CLIENT_ID/APP_ID/PROJECT_ID immediately reflect the selection.
       localStorage.setItem(
         'env',
-        JSON.stringify({ CLIENT_NAME, APP_NAME, PROJECT_NAME: project.name })
+        JSON.stringify({
+          CLIENT_NAME,
+          CLIENT_ID,
+          APP_NAME,
+          APP_ID,
+          PROJECT_NAME: project.name,
+          PROJECT_ID: project.id?.toString() || '',
+        })
       );
     } catch {
       localStorage.setItem(
         'env',
-        JSON.stringify({ PROJECT_NAME: project.name })
+        JSON.stringify({ PROJECT_NAME: project.name, PROJECT_ID: project.id?.toString() || '' })
       );
     }
 
@@ -238,11 +253,9 @@ const Projects = () => {
       if (res.ok) {
         const data = await res.json();
         if (data.environment) {
-          const { CLIENT_NAME, APP_NAME, PROJECT_NAME } = data.environment;
-          localStorage.setItem(
-            'env',
-            JSON.stringify({ CLIENT_NAME, APP_NAME, PROJECT_NAME })
-          );
+          // Persist the full environment returned by the backend so IDs are
+          // available for session lookups and MinIO prefixes.
+          localStorage.setItem('env', JSON.stringify(data.environment));
         }
       }
     } catch (err) {

--- a/TrinityFrontend/src/pages/Projects.tsx
+++ b/TrinityFrontend/src/pages/Projects.tsx
@@ -218,44 +218,43 @@ const Projects = () => {
     clearProjectState();
     saveCurrentProject(project);
 
+    // Construct an initial environment using any existing client identifiers
+    // and the currently selected app/project. This ensures env-dependent
+    // components (session state, MinIO prefixing, etc.) immediately reflect
+    // the user's context even before the backend responds with its
+    // canonical environment payload.
+    let env: Record<string, string> = {
+      APP_NAME: selectedApp || '',
+      APP_ID: appId?.toString() || '',
+      PROJECT_NAME: project.name,
+      PROJECT_ID: project.id?.toString() || '',
+    };
     try {
       const envStr = localStorage.getItem('env');
       const baseEnv = envStr ? JSON.parse(envStr) : {};
-      const {
-        CLIENT_NAME,
-        CLIENT_ID,
-        APP_NAME,
-        APP_ID,
-      } = baseEnv;
-      // Seed local storage with the new project name while preserving any
-      // existing identifiers. This ensures components relying on
-      // CLIENT_ID/APP_ID/PROJECT_ID immediately reflect the selection.
-      localStorage.setItem(
-        'env',
-        JSON.stringify({
-          CLIENT_NAME,
-          CLIENT_ID,
-          APP_NAME,
-          APP_ID,
-          PROJECT_NAME: project.name,
-          PROJECT_ID: project.id?.toString() || '',
-        })
-      );
+      if (baseEnv.CLIENT_NAME) env.CLIENT_NAME = baseEnv.CLIENT_NAME;
+      if (baseEnv.CLIENT_ID) env.CLIENT_ID = baseEnv.CLIENT_ID;
     } catch {
-      localStorage.setItem(
-        'env',
-        JSON.stringify({ PROJECT_NAME: project.name, PROJECT_ID: project.id?.toString() || '' })
-      );
+      /* ignore parse errors */
     }
+    localStorage.setItem('env', JSON.stringify(env));
 
     try {
       const res = await fetch(`${REGISTRY_API}/projects/${project.id}/`, { credentials: 'include' });
       if (res.ok) {
         const data = await res.json();
         if (data.environment) {
-          // Persist the full environment returned by the backend so IDs are
-          // available for session lookups and MinIO prefixes.
-          localStorage.setItem('env', JSON.stringify(data.environment));
+          // Persist the full environment returned by the backend, but ensure
+          // current app/project identifiers remain accurate.
+          env = {
+            ...env,
+            ...data.environment,
+            APP_NAME: selectedApp || env.APP_NAME,
+            APP_ID: appId?.toString() || env.APP_ID,
+            PROJECT_NAME: project.name,
+            PROJECT_ID: project.id?.toString() || env.PROJECT_ID,
+          };
+          localStorage.setItem('env', JSON.stringify(env));
         }
       }
     } catch (err) {


### PR DESCRIPTION
## Summary
- store full environment (including IDs) when selecting apps or projects
- send full env to session init and cache refreshed env after MinIO calls

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bedc34e3488321a813d67fa57854cb