### PR TITLE
Allow tunneled domain for FastAPI CORS

### DIFF
--- a/TrinityBackendFastAPI/app/main.py
+++ b/TrinityBackendFastAPI/app/main.py
@@ -15,7 +15,7 @@ app = FastAPI()
 
 origins = os.getenv(
     "FASTAPI_CORS_ORIGINS",
-    "http://10.2.1.207:8080,http://127.0.0.1:8080,http://172.22.64.1:8080,http://172.22.64.1:8080,https://trinity.quantmatrixai.com,http://172.22.64.1:8080"
+    "http://10.2.1.207:8080,http://127.0.0.1:8080,http://172.22.64.1:8080,http://172.22.64.1:8080,https://trinity.quantmatrixai.com,https://trinity-dev.quantmatrixai.com,http://172.22.64.1:8080"
 )
 allowed_origins = [o.strip() for o in origins.split(",") if o.strip()]
 


### PR DESCRIPTION
## Summary
- include trinity-dev.quantmatrixai.com in default CORS origins so uploads work from tunnelled dev environment

## Testing
- `pytest` *(fails: ImportError: cannot import name 'MinioAdmin' from 'minio')*


------
https://chatgpt.com/codex/tasks/task_e_68c0366ea2648321b8b9214db0cc7dc2