### PR TITLE
fix: show matrix settings on right click

### DIFF
--- a/TrinityFrontend/src/components/AtomList/atoms/correlation/components/CorrelationCanvas.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/correlation/components/CorrelationCanvas.tsx
@@ -1404,26 +1404,26 @@ const CorrelationCanvas: React.FC<CorrelationCanvasProps> = ({
                     ? "p-4 flex justify-center"
                     : "p-6 flex justify-center"
                 }
-                onContextMenu={(e) => {
-                  e.preventDefault();
-                  const menuWidth = 240;
-                  const menuHeight = 200;
-                  let x = e.clientX;
-                  let y = e.clientY;
-                  if (window.innerWidth - x < menuWidth) {
-                    x = window.innerWidth - menuWidth;
-                  }
-                  if (window.innerHeight - y < menuHeight) {
-                    y = window.innerHeight - menuHeight;
-                  }
-                  setSettingsPosition({ x, y });
-                  setSettingsOpen(true);
-                }}
               >
                 <svg
                   ref={heatmapRef}
                   height={isCompactMode ? "260" : "650"}
                   className="block"
+                  onContextMenu={(e) => {
+                    e.preventDefault();
+                    const menuWidth = 240;
+                    const menuHeight = 200;
+                    let x = e.clientX;
+                    let y = e.clientY;
+                    if (window.innerWidth - x < menuWidth) {
+                      x = window.innerWidth - menuWidth;
+                    }
+                    if (window.innerHeight - y < menuHeight) {
+                      y = window.innerHeight - menuHeight;
+                    }
+                    setSettingsPosition({ x, y });
+                    setSettingsOpen(true);
+                  }}
                 ></svg>
               </div>
             </Card>

--- a/TrinityFrontend/src/components/AtomList/atoms/correlation/components/MatrixSettingsTray.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/correlation/components/MatrixSettingsTray.tsx
@@ -148,7 +148,7 @@ const MatrixSettingsTray: React.FC<MatrixSettingsTrayProps> = ({
 
   const menu = (
     <div
-      className="fixed z-[9999] bg-white border border-gray-200 rounded-lg shadow-lg py-2 min-w-48 matrix-settings-menu"
+      className="fixed z-[100000] bg-white border border-gray-200 rounded-lg shadow-lg py-2 min-w-48 matrix-settings-menu"
       style={{ left: position.x, top: position.y }}
       onClick={(e) => e.stopPropagation()}
       onMouseDown={(e) => e.stopPropagation()}
@@ -270,7 +270,7 @@ const MatrixSettingsTray: React.FC<MatrixSettingsTrayProps> = ({
   const colorSubmenu = showColorSubmenu
     ? createPortal(
         <div
-          className="fixed z-[10000] bg-white border border-gray-300 rounded-lg shadow-xl p-3 color-submenu"
+          className="fixed z-[100001] bg-white border border-gray-300 rounded-lg shadow-xl p-3 color-submenu"
           style={{
             left: colorSubmenuPos.x,
             top: colorSubmenuPos.y,


### PR DESCRIPTION
## Summary
- open correlation matrix settings tray on right click at cursor position
- raise z-index of tray and color theme submenu to ensure visibility

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: no-prototype-builtins, no-case-declarations, react-refresh/only-export-components, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c10fd6d8048321bc6d97e8b936239a