### PR TITLE
Fix project history is_deleted nullable

### DIFF
--- a/TrinityBackendDjango/apps/registry/migrations/0020_alter_historicalproject_is_deleted.py
+++ b/TrinityBackendDjango/apps/registry/migrations/0020_alter_historicalproject_is_deleted.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("registry", "0019_project_is_deleted"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="historicalproject",
+            name="is_deleted",
+            field=models.BooleanField(default=False, null=True),
+        ),
+    ]


### PR DESCRIPTION
## Summary
- allow `registry_historicalproject.is_deleted` to be nullable so project create/delete works

## Testing
- `pytest -q` *(fails: NameResolutionError: Failed to resolve 'minio')*
- `pytest TrinityBackendDjango/tests/test_atom_config.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c7a0d4186883218a82291bf4b97f89