### PR TITLE
Fix registry migration dependency

### DIFF
--- a/TrinityBackendDjango/apps/registry/migrations/0020_alter_historicalproject_is_deleted.py
+++ b/TrinityBackendDjango/apps/registry/migrations/0020_alter_historicalproject_is_deleted.py
@@ -3,7 +3,7 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("registry", "0020_merge_20250912_0743"),
+        ("registry", "0019_project_is_deleted"),
     ]
 
     operations = [


### PR DESCRIPTION
## Summary
- rename registry migration to 0020 and fix dependency to existing 0019 migration

## Testing
- `python manage.py makemigrations --check --dry-run --skip-checks`
- `python manage.py migrate --plan --skip-checks` *(fails: could not translate host name "postgres" to address)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e52b3d94832194f4a4882a009214