### PR TITLE
Persist dataframe formulas and adjust validation alert

### DIFF
--- a/TrinityFrontend/src/components/AtomList/atoms/dataframe-operations/DataFrameOperationsAtom.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/dataframe-operations/DataFrameOperationsAtom.tsx
@@ -33,6 +33,7 @@ export interface DataFrameSettings {
   fileId?: string | null; // Persist backend dataframe id
   columnWidths: { [key: string]: number };
   rowHeights: { [key: number]: number };
+  columnFormulas: Record<string, string>;
 }
 
 interface Props {
@@ -43,7 +44,8 @@ const DataFrameOperationsAtom: React.FC<Props> = ({ atomId }) => {
   const cards = useLaboratoryStore(state => state.cards);
   const atom = cards.flatMap(card => card.atoms).find(a => a.id === atomId);
   const updateSettings = useLaboratoryStore(state => state.updateAtomSettings);
-  const settings: DataFrameSettings = atom?.settings || {
+  const baseSettings = (atom?.settings as Partial<DataFrameSettings> | undefined) || {};
+  const settings: DataFrameSettings = {
     rowsPerPage: 15,
     searchTerm: '',
     sortColumns: [],
@@ -54,6 +56,9 @@ const DataFrameOperationsAtom: React.FC<Props> = ({ atomId }) => {
     fileId: null,
     columnWidths: {},
     rowHeights: {},
+    columnFormulas: {},
+    ...baseSettings,
+    columnFormulas: baseSettings.columnFormulas || {},
   };
   // Always use tableData as the source of truth
   const data = settings.tableData || null;
@@ -80,6 +85,7 @@ const DataFrameOperationsAtom: React.FC<Props> = ({ atomId }) => {
       fileId: backendFileId || settings.fileId || null,
       columnWidths: {},
       rowHeights: {},
+      columnFormulas: {},
     };
     updateSettings(atomId, newSettings);
   };
@@ -124,6 +130,7 @@ const DataFrameOperationsAtom: React.FC<Props> = ({ atomId }) => {
         enableEditing: true,
         columnWidths: {},
         rowHeights: {},
+        columnFormulas: {},
       });
     }
   };

--- a/TrinityFrontend/src/components/AtomList/atoms/dataframe-operations/components/FormularBar.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/dataframe-operations/components/FormularBar.tsx
@@ -30,6 +30,7 @@ interface FormularBarProps {
   onFormulaInputChange: (value: string) => void;
   onFormulaModeChange: (mode: boolean) => void;
   onFormulaSubmit: () => void;
+  onValidationError?: (message: string | null) => void;
 }
 
 function safeToString(val: unknown): string {
@@ -570,13 +571,13 @@ const FormularBar: React.FC<FormularBarProps> = ({
   onFormulaInputChange,
   onFormulaModeChange,
   onFormulaSubmit,
+  onValidationError,
 }) => {
   const [isLibraryOpen, setIsLibraryOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedFormula, setSelectedFormula] = useState<FormulaItem | null>(null);
   const [activeTab, setActiveTab] = useState<TabValue>('all');
   const [isUsageGuideOpen, setIsUsageGuideOpen] = useState(false);
-  const [showValidationError, setShowValidationError] = useState(false);
 
   useEffect(() => {
     if (!isFormulaMode) {
@@ -631,7 +632,7 @@ const FormularBar: React.FC<FormularBarProps> = ({
     setIsLibraryOpen(false);
     setActiveTab('all');
     setIsUsageGuideOpen(false);
-    setShowValidationError(false);
+    onValidationError?.(null);
   };
 
   const handleFormulaSelect = (formula: FormulaItem) => {
@@ -641,7 +642,7 @@ const FormularBar: React.FC<FormularBarProps> = ({
     onFormulaInputChange(expression);
     onFormulaModeChange(true);
     setIsLibraryOpen(false);
-    setShowValidationError(false);
+    onValidationError?.(null);
   };
 
   const handleLibraryOpenChange = (open: boolean) => {
@@ -667,9 +668,7 @@ const FormularBar: React.FC<FormularBarProps> = ({
   const handleInputChange = (value: string) => {
     onFormulaInputChange(value);
     onFormulaModeChange(true);
-    if (showValidationError) {
-      setShowValidationError(false);
-    }
+    onValidationError?.(null);
   };
 
   const handleTabCompletion = () => {
@@ -712,7 +711,7 @@ const FormularBar: React.FC<FormularBarProps> = ({
 
     onFormulaInputChange(expression);
     onFormulaModeChange(true);
-    setShowValidationError(false);
+    onValidationError?.(null);
     return true;
   };
 
@@ -722,11 +721,11 @@ const FormularBar: React.FC<FormularBarProps> = ({
     }
 
     if (!isValidFormulaInput(formulaInput)) {
-      setShowValidationError(true);
+      onValidationError?.('Please enter a valid formula and then hit Apply');
       return;
     }
 
-    setShowValidationError(false);
+    onValidationError?.(null);
     onFormulaSubmit();
   };
 
@@ -879,11 +878,6 @@ const FormularBar: React.FC<FormularBarProps> = ({
                 }}
               />
             </div>
-            {showValidationError && (
-              <p className='mt-1 text-xs text-destructive font-medium'>
-                Please enter a valid formula and then hit Apply
-              </p>
-            )}
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- add a `columnFormulas` map to dataframe settings so calculated column formulas persist across reloads and resets
- synchronize the canvas with stored formulas, updating settings when formulas are applied, columns are renamed, or headers change
- surface formula validation feedback beside the Reset action and update the formula bar to report validation errors to the parent

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js' from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68cbd0d53a0c832198478b723095cd1f