### PR TITLE
Use binary glyphs for login animation

### DIFF
--- a/TrinityFrontend/src/components/LoginAnimation.tsx
+++ b/TrinityFrontend/src/components/LoginAnimation.tsx
@@ -22,11 +22,7 @@ const LoginAnimation: React.FC<LoginAnimationProps> = ({ active, onComplete }) =
   const [curtainVisible, setCurtainVisible] = useState(false);
   const [exiting, setExiting] = useState(false);
 
-  const chars = useMemo(
-    () =>
-      'アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワヲン0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ',
-    []
-  );
+  const chars = useMemo(() => ['0', '1'], []);
 
   useEffect(() => {
     if (!active || !canvasRef.current) {


### PR DESCRIPTION
## Summary
- replace the login animation character set with binary digits to show falling 0s and 1s

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cd0cda91948321814d34d4ed7e1c10