### PR TITLE
Add animated transition from Projects to Laboratory

### DIFF
--- a/TrinityFrontend/src/components/LaboratoryMode/LaboratoryMode.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/LaboratoryMode.tsx
@@ -15,6 +15,7 @@ import { REGISTRY_API, LAB_ACTIONS_API } from '@/lib/api';
 import { useLaboratoryStore } from './store/laboratoryStore';
 import { useAuth } from '@/contexts/AuthContext';
 import { addNavigationItem, logSessionState } from '@/lib/session';
+import { animateLabElementsIn, cleanupProjectTransition } from '@/utils/projectTransition';
 
 const LaboratoryMode = () => {
   const [selectedAtomId, setSelectedAtomId] = useState<string>();
@@ -28,6 +29,11 @@ const LaboratoryMode = () => {
   const setExhibitionCards = useExhibitionStore(state => state.setCards);
   const { hasPermission, user } = useAuth();
   const canEdit = hasPermission('laboratory:edit');
+
+  useEffect(() => {
+    animateLabElementsIn();
+    return () => cleanupProjectTransition();
+  }, []);
 
   useEffect(() => {
     if (localStorage.getItem('laboratory-config')) {
@@ -212,14 +218,17 @@ const LaboratoryMode = () => {
       )}
       
       {/* Laboratory Header */}
-      <div className="bg-white/80 backdrop-blur-sm border-b border-gray-200/60 px-6 py-6 flex-shrink-0 shadow-sm">
+      <div
+        data-lab-header="true"
+        className="bg-white/80 backdrop-blur-sm border-b border-gray-200/60 px-6 py-6 flex-shrink-0 shadow-sm"
+      >
         <div className="flex items-center justify-between">
           <div>
             <h2 className="text-3xl font-light text-gray-900 mb-2">Laboratory Mode</h2>
             <p className="text-gray-600 font-light">Build sophisticated applications with modular atoms</p>
           </div>
-          
-          <div className="flex items-center space-x-3">
+
+          <div data-lab-toolbar="true" className="flex items-center space-x-3">
             <Button
               variant="outline"
               size="sm"
@@ -272,12 +281,13 @@ const LaboratoryMode = () => {
 
         <div className="flex-1 flex overflow-hidden">
           {/* Atoms Sidebar */}
-          <div className={`${canEdit ? '' : 'cursor-not-allowed'} h-full`}>
+          <div data-lab-sidebar="true" className={`${canEdit ? '' : 'cursor-not-allowed'} h-full`}>
             <AuxiliaryMenuLeft onAtomDragStart={handleAtomDragStart} />
           </div>
 
           {/* Main Canvas Area */}
           <div
+            data-lab-canvas="true"
             className={`flex-1 p-6 ${canEdit ? '' : 'cursor-not-allowed'}`}
             onClick={
               canEdit
@@ -298,7 +308,7 @@ const LaboratoryMode = () => {
           </div>
 
           {/* Auxiliary menu */}
-          <div className={`${canEdit ? '' : 'cursor-not-allowed'} h-full`}>
+          <div data-lab-settings="true" className={`${canEdit ? '' : 'cursor-not-allowed'} h-full`}>
             <AuxiliaryMenu
               selectedAtomId={selectedAtomId}
               selectedCardId={selectedCardId}

--- a/TrinityFrontend/src/components/LaboratoryMode/LaboratoryMode.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/LaboratoryMode.tsx
@@ -43,7 +43,7 @@ const LaboratoryMode = () => {
     return () => cleanupProjectTransition('laboratory');
   }, []);
 
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     animateLabElementsIn();
   }, []);
 

--- a/TrinityFrontend/src/components/LaboratoryMode/LaboratoryMode.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/LaboratoryMode.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useLayoutEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Play, Save, Share2, Undo2, AlertTriangle, List } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
@@ -15,7 +15,13 @@ import { REGISTRY_API, LAB_ACTIONS_API } from '@/lib/api';
 import { useLaboratoryStore } from './store/laboratoryStore';
 import { useAuth } from '@/contexts/AuthContext';
 import { addNavigationItem, logSessionState } from '@/lib/session';
-import { animateLabElementsIn, cleanupProjectTransition } from '@/utils/projectTransition';
+import {
+  animateLabElementsIn,
+  cleanupProjectTransition,
+  prepareLabElements,
+} from '@/utils/projectTransition';
+
+const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
 
 const LaboratoryMode = () => {
   const [selectedAtomId, setSelectedAtomId] = useState<string>();
@@ -30,9 +36,15 @@ const LaboratoryMode = () => {
   const { hasPermission, user } = useAuth();
   const canEdit = hasPermission('laboratory:edit');
 
+  useIsomorphicLayoutEffect(() => {
+    cleanupProjectTransition('laboratory');
+    prepareLabElements();
+
+    return () => cleanupProjectTransition('laboratory');
+  }, []);
+
   useEffect(() => {
     animateLabElementsIn();
-    return () => cleanupProjectTransition('laboratory');
   }, []);
 
   useEffect(() => {

--- a/TrinityFrontend/src/components/LaboratoryMode/LaboratoryMode.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/LaboratoryMode.tsx
@@ -32,7 +32,7 @@ const LaboratoryMode = () => {
 
   useEffect(() => {
     animateLabElementsIn();
-    return () => cleanupProjectTransition();
+    return () => cleanupProjectTransition('laboratory');
   }, []);
 
   useEffect(() => {

--- a/TrinityFrontend/src/index.css
+++ b/TrinityFrontend/src/index.css
@@ -104,3 +104,37 @@
     @apply bg-background text-foreground;
   }
 }
+
+@keyframes project-card-exit {
+  0% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+
+  100% {
+    opacity: 0;
+    transform: translateY(-20px) scale(0.95);
+  }
+}
+
+.animate-project-exit {
+  animation: project-card-exit 0.45s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  will-change: opacity, transform;
+}
+
+@keyframes lab-element-enter {
+  0% {
+    opacity: 0;
+    transform: translateY(30px) scale(0.95);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.animate-lab-element-enter {
+  animation: lab-element-enter 0.6s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  will-change: opacity, transform;
+}

--- a/TrinityFrontend/src/index.css
+++ b/TrinityFrontend/src/index.css
@@ -141,3 +141,12 @@
   animation-delay: var(--lab-enter-delay, 0s);
   will-change: opacity, transform;
 }
+
+body.lab-transition-prep [data-lab-header],
+body.lab-transition-prep [data-lab-toolbar],
+body.lab-transition-prep [data-lab-sidebar],
+body.lab-transition-prep [data-lab-canvas],
+body.lab-transition-prep [data-lab-settings] {
+  opacity: 0;
+  transform: translateY(30px) scale(0.95);
+}

--- a/TrinityFrontend/src/index.css
+++ b/TrinityFrontend/src/index.css
@@ -119,7 +119,9 @@
 
 .animate-project-exit {
   animation: project-card-exit 0.45s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  animation-delay: var(--project-exit-delay, 0s);
   will-change: opacity, transform;
+  pointer-events: none;
 }
 
 @keyframes lab-element-enter {
@@ -136,5 +138,6 @@
 
 .animate-lab-element-enter {
   animation: lab-element-enter 0.6s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  animation-delay: var(--lab-enter-delay, 0s);
   will-change: opacity, transform;
 }

--- a/TrinityFrontend/src/pages/Projects.tsx
+++ b/TrinityFrontend/src/pages/Projects.tsx
@@ -650,7 +650,12 @@ const Projects = () => {
           </div>
           <main className="flex-1">
             <div className="mx-auto max-w-7xl px-6 py-8">
-              <div className="mb-8 animate-fade-in" style={animationStyle(0.4)}>
+              <div
+                className="mb-8 animate-fade-in"
+                style={animationStyle(0.4)}
+                data-project-transition="section"
+                data-project-transition-order="10"
+              >
                 <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
                   <div className="flex-1">
                     <h2 className="mb-2 text-3xl font-bold text-gray-900">Workspace</h2>
@@ -697,11 +702,18 @@ const Projects = () => {
                 </div>
               </div>
 
-              <div className="animate-fade-in" style={animationStyle(0.6)}>
+              <div
+                className="animate-fade-in"
+                style={animationStyle(0.6)}
+                data-project-transition="section"
+                data-project-transition-order="18"
+              >
                 <Tabs value={activeTab} onValueChange={setActiveTab} className="mb-8">
                   <TabsList
                     className="grid w-full max-w-md grid-cols-2 animate-slide-in-from-top mb-6"
                     style={animationStyle(0.7)}
+                    data-project-transition="tabs-list"
+                    data-project-transition-order="20"
                   >
                     <TabsTrigger value="templates" className="flex items-center space-x-2">
                       <Bookmark className="h-4 w-4" />
@@ -727,6 +739,8 @@ const Projects = () => {
                     >
               <Card
                 data-project-card="true"
+                data-project-transition="card"
+                data-project-transition-order="30"
                 className="group cursor-pointer overflow-hidden border-2 border-dashed border-gray-200 bg-gradient-to-br from-white to-gray-50/30 transition-all duration-500 hover:-translate-y-1 hover:border-gray-300 hover:from-white hover:to-gray-50/50 hover:shadow-xl animate-slide-in-from-bottom"
                 style={animationStyle(0.9)}
                 onClick={createNewProject}
@@ -745,6 +759,8 @@ const Projects = () => {
               {filteredProjects.map((project, index) => (
                 <Card
                   data-project-card="true"
+                  data-project-transition="card"
+                  data-project-transition-order={String(31 + index)}
                   key={project.id}
                   className="group cursor-pointer overflow-hidden border-0 bg-white transition-all duration-500 hover:-translate-y-1 hover:bg-gradient-to-br hover:from-white hover:to-gray-50/30 hover:shadow-xl animate-slide-in-from-bottom"
                   style={animationStyle(1 + index * 0.08)}
@@ -922,7 +938,11 @@ const Projects = () => {
             </div>
 
             {projectsLoading && (
-              <div className="text-center mt-20">
+              <div
+                className="text-center mt-20"
+                data-project-transition="state"
+                data-project-transition-order="40"
+              >
                 <div className="w-20 h-20 rounded-full bg-white/60 backdrop-blur-sm flex items-center justify-center mx-auto mb-6 shadow-inner">
                   <Loader2 className="w-8 h-8 text-emerald-500 animate-spin" />
                 </div>
@@ -932,7 +952,11 @@ const Projects = () => {
             )}
 
             {!projectsLoading && filteredProjects.length === 0 && !searchQuery && (
-              <div className="text-center mt-20">
+              <div
+                className="text-center mt-20"
+                data-project-transition="state"
+                data-project-transition-order="40"
+              >
                 <div className={`w-32 h-32 rounded-3xl bg-gradient-to-br ${appDetails.lightBg} flex items-center justify-center mx-auto mb-8 shadow-inner`}>
                   <Icon className="w-16 h-16 text-gray-400" />
                 </div>
@@ -951,7 +975,11 @@ const Projects = () => {
             )}
 
             {!projectsLoading && filteredProjects.length === 0 && searchQuery && (
-              <div className="text-center mt-20">
+              <div
+                className="text-center mt-20"
+                data-project-transition="state"
+                data-project-transition-order="40"
+              >
                 <div className="w-24 h-24 rounded-full bg-gray-100 flex items-center justify-center mx-auto mb-6">
                   <Search className="w-12 h-12 text-gray-400" />
                 </div>
@@ -976,6 +1004,8 @@ const Projects = () => {
               {filteredTemplates.map((template, index) => (
                 <Card
                   key={template.id}
+                  data-project-transition="card"
+                  data-project-transition-order={String(31 + index)}
                   className="group cursor-pointer overflow-hidden border-0 bg-white transition-all duration-500 hover:-translate-y-1 hover:bg-gradient-to-br hover:from-white hover:to-gray-50/30 hover:shadow-xl animate-slide-in-from-bottom"
                   style={animationStyle(1.1 + index * 0.08)}
                   onMouseEnter={() => setHoveredTemplate(template.id)}

--- a/TrinityFrontend/src/pages/Projects.tsx
+++ b/TrinityFrontend/src/pages/Projects.tsx
@@ -9,6 +9,7 @@ import GreenGlyphRain from '@/components/animations/GreenGlyphRain';
 import { REGISTRY_API } from '@/lib/api';
 import { LOGIN_ANIMATION_TOTAL_DURATION } from '@/constants/loginAnimation';
 import { clearProjectState, saveCurrentProject } from '@/utils/projectStorage';
+import { startProjectTransition, cleanupProjectTransition } from '@/utils/projectTransition';
 import {
   Plus,
   FolderOpen,
@@ -80,6 +81,7 @@ const Projects = () => {
   const [projectsLoading, setProjectsLoading] = useState(true);
   const [playIntro, setPlayIntro] = useState(false);
   const [introBaseDelay, setIntroBaseDelay] = useState(0);
+  const [isTransitioning, setIsTransitioning] = useState(false);
   const navigate = useNavigate();
   const currentApp = JSON.parse(localStorage.getItem('current-app') || '{}');
   const selectedApp = currentApp.slug;
@@ -137,6 +139,11 @@ const Projects = () => {
 
   const appDetails = getAppDetails();
   const Icon = appDetails.icon;
+
+  useEffect(() => {
+    cleanupProjectTransition();
+    return () => cleanupProjectTransition();
+  }, []);
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -267,6 +274,11 @@ const Projects = () => {
   };
 
   const openProject = async (project: Project) => {
+    if (isTransitioning) return;
+
+    setIsTransitioning(true);
+    startProjectTransition(navigate);
+
     clearProjectState();
     saveCurrentProject(project);
 
@@ -312,7 +324,6 @@ const Projects = () => {
     } catch (err) {
       console.log('Project env fetch error', err);
     }
-    navigate('/');
   };
 
   const duplicateProject = async (project: Project) => {
@@ -715,6 +726,7 @@ const Projects = () => {
                       }
                     >
               <Card
+                data-project-card="true"
                 className="group cursor-pointer overflow-hidden border-2 border-dashed border-gray-200 bg-gradient-to-br from-white to-gray-50/30 transition-all duration-500 hover:-translate-y-1 hover:border-gray-300 hover:from-white hover:to-gray-50/50 hover:shadow-xl animate-slide-in-from-bottom"
                 style={animationStyle(0.9)}
                 onClick={createNewProject}
@@ -732,6 +744,7 @@ const Projects = () => {
 
               {filteredProjects.map((project, index) => (
                 <Card
+                  data-project-card="true"
                   key={project.id}
                   className="group cursor-pointer overflow-hidden border-0 bg-white transition-all duration-500 hover:-translate-y-1 hover:bg-gradient-to-br hover:from-white hover:to-gray-50/30 hover:shadow-xl animate-slide-in-from-bottom"
                   style={animationStyle(1 + index * 0.08)}

--- a/TrinityFrontend/src/pages/Projects.tsx
+++ b/TrinityFrontend/src/pages/Projects.tsx
@@ -141,8 +141,8 @@ const Projects = () => {
   const Icon = appDetails.icon;
 
   useEffect(() => {
-    cleanupProjectTransition();
-    return () => cleanupProjectTransition();
+    cleanupProjectTransition('project');
+    return () => cleanupProjectTransition('project');
   }, []);
 
   useEffect(() => {

--- a/TrinityFrontend/src/utils/projectTransition.ts
+++ b/TrinityFrontend/src/utils/projectTransition.ts
@@ -21,6 +21,11 @@ const LAB_ELEMENTS = [
 const LAB_PREP_DELAY_MS = 200;
 const LAB_ANIMATION_DURATION_MS = 600;
 
+const applyLabPreparationState = (element: HTMLElement) => {
+  element.style.opacity = LAB_PREPARE_STYLE.opacity;
+  element.style.transform = LAB_PREPARE_STYLE.transform;
+};
+
 const prefersReducedMotion = () =>
   typeof window !== 'undefined' &&
   typeof window.matchMedia === 'function' &&
@@ -89,6 +94,24 @@ export const startProjectTransition = (navigate: NavigateFunction) => {
   }, totalExitTime);
 };
 
+export const prepareLabElements = () => {
+  if (typeof document === 'undefined' || prefersReducedMotion()) {
+    return;
+  }
+
+  LAB_ELEMENTS.forEach(({ selector }) => {
+    const element = document.querySelector(selector) as HTMLElement | null;
+
+    if (!element || !isElementVisible(element)) {
+      return;
+    }
+
+    clearLabElementTimeouts(element);
+    element.classList.remove(LAB_CLASS);
+    applyLabPreparationState(element);
+  });
+};
+
 export const animateLabElementsIn = () => {
   if (typeof document === 'undefined' || prefersReducedMotion()) {
     return;
@@ -104,8 +127,7 @@ export const animateLabElementsIn = () => {
 
       clearLabElementTimeouts(element);
       element.classList.remove(LAB_CLASS);
-      element.style.opacity = LAB_PREPARE_STYLE.opacity;
-      element.style.transform = LAB_PREPARE_STYLE.transform;
+      applyLabPreparationState(element);
       element.style.willChange = 'opacity, transform';
 
       const ensureVisible = () => {

--- a/TrinityFrontend/src/utils/projectTransition.ts
+++ b/TrinityFrontend/src/utils/projectTransition.ts
@@ -9,8 +9,17 @@ const EXIT_BUFFER_MS = 200;
 const LAB_CLASS = 'animate-lab-element-enter';
 const LAB_PREPARE_STYLE = {
   opacity: '0',
-  transform: 'translateY(32px) scale(0.96)'
+  transform: 'translateY(30px) scale(0.95)'
 } as const;
+const LAB_ELEMENTS = [
+  { selector: '[data-lab-header]', delay: 0 },
+  { selector: '[data-lab-toolbar]', delay: 200 },
+  { selector: '[data-lab-sidebar]', delay: 400 },
+  { selector: '[data-lab-canvas]', delay: 600 },
+  { selector: '[data-lab-settings]', delay: 800 }
+] as const;
+const LAB_PREP_DELAY_MS = 200;
+const LAB_ANIMATION_DURATION_MS = 600;
 
 const prefersReducedMotion = () =>
   typeof window !== 'undefined' &&
@@ -20,6 +29,19 @@ const prefersReducedMotion = () =>
 const isElementVisible = (element: HTMLElement) => {
   const rect = element.getBoundingClientRect();
   return rect.width > 0 && rect.height > 0;
+};
+
+const parseTimeoutIds = (value: string | undefined) =>
+  (value || '')
+    .split(',')
+    .map(id => Number(id))
+    .filter(id => Number.isFinite(id));
+
+const clearLabElementTimeouts = (element: HTMLElement) => {
+  parseTimeoutIds(element.dataset.labTransitionTimeouts).forEach(id => {
+    window.clearTimeout(id);
+  });
+  delete element.dataset.labTransitionTimeouts;
 };
 
 export const startProjectTransition = (navigate: NavigateFunction) => {
@@ -72,52 +94,77 @@ export const animateLabElementsIn = () => {
     return;
   }
 
-  const labElements = [
-    { selector: '[data-lab-header]', delay: 0 },
-    { selector: '[data-lab-toolbar]', delay: 160 },
-    { selector: '[data-lab-sidebar]', delay: 320 },
-    { selector: '[data-lab-canvas]', delay: 480 },
-    { selector: '[data-lab-settings]', delay: 640 }
-  ] as const;
-
   window.setTimeout(() => {
-    labElements.forEach(({ selector, delay }) => {
+    LAB_ELEMENTS.forEach(({ selector, delay }) => {
       const element = document.querySelector(selector) as HTMLElement | null;
 
       if (!element || !isElementVisible(element)) {
         return;
       }
 
+      clearLabElementTimeouts(element);
       element.classList.remove(LAB_CLASS);
-      element.style.setProperty('--lab-enter-delay', `${delay}ms`);
       element.style.opacity = LAB_PREPARE_STYLE.opacity;
       element.style.transform = LAB_PREPARE_STYLE.transform;
       element.style.willChange = 'opacity, transform';
 
-      window.requestAnimationFrame(() => {
-        element.classList.add(LAB_CLASS);
-      });
-
-      const handleAnimationEnd = () => {
-        element.style.opacity = '';
-        element.style.transform = '';
+      const ensureVisible = () => {
+        element.style.opacity = '1';
+        element.style.transform = 'translateY(0) scale(1)';
         element.style.willChange = '';
-        element.removeEventListener('animationend', handleAnimationEnd);
       };
 
+      let fallbackTimeout = 0;
+
+      const handleAnimationEnd = () => {
+        ensureVisible();
+        element.removeEventListener('animationend', handleAnimationEnd);
+        window.clearTimeout(fallbackTimeout);
+        clearLabElementTimeouts(element);
+      };
+
+      fallbackTimeout = window.setTimeout(() => {
+        ensureVisible();
+        element.removeEventListener('animationend', handleAnimationEnd);
+        clearLabElementTimeouts(element);
+      }, delay + LAB_ANIMATION_DURATION_MS + 100);
+
+      const startTimeout = window.setTimeout(() => {
+        element.classList.add(LAB_CLASS);
+      }, delay);
+
       element.addEventListener('animationend', handleAnimationEnd);
+      element.dataset.labTransitionTimeouts = `${startTimeout},${fallbackTimeout}`;
     });
-  }, 120);
+  }, LAB_PREP_DELAY_MS);
 };
 
-export const cleanupProjectTransition = () => {
+type TransitionCleanupScope = 'project' | 'laboratory' | 'all';
+
+const PROJECT_CLEANUP_SELECTOR = '[data-project-transition], [data-project-card]';
+const LAB_CLEANUP_SELECTOR =
+  '[data-lab-header], [data-lab-toolbar], [data-lab-sidebar], [data-lab-canvas], [data-lab-settings]';
+
+export const cleanupProjectTransition = (scope: TransitionCleanupScope = 'all') => {
   if (typeof document === 'undefined') {
     return;
   }
 
-  const allElements = document.querySelectorAll(
-    '[data-project-transition], [data-project-card], [data-lab-header], [data-lab-toolbar], [data-lab-sidebar], [data-lab-canvas], [data-lab-settings]'
-  );
+  const selectors: string[] = [];
+
+  if (scope === 'project' || scope === 'all') {
+    selectors.push(PROJECT_CLEANUP_SELECTOR);
+  }
+
+  if (scope === 'laboratory' || scope === 'all') {
+    selectors.push(LAB_CLEANUP_SELECTOR);
+  }
+
+  if (!selectors.length) {
+    return;
+  }
+
+  const allElements = document.querySelectorAll(selectors.join(', '));
 
   allElements.forEach((element) => {
     const target = element as HTMLElement;
@@ -127,5 +174,6 @@ export const cleanupProjectTransition = () => {
     target.style.removeProperty('--project-exit-delay');
     target.style.removeProperty('--lab-enter-delay');
     target.style.willChange = '';
+    clearLabElementTimeouts(target);
   });
 };

--- a/TrinityFrontend/src/utils/projectTransition.ts
+++ b/TrinityFrontend/src/utils/projectTransition.ts
@@ -1,5 +1,7 @@
 import { NavigateFunction } from 'react-router-dom';
 
+export const LAB_PREP_CLASS = 'lab-transition-prep';
+
 const EXIT_SELECTOR = '[data-project-transition], [data-project-card]';
 const EXIT_CLASS = 'animate-project-exit';
 const EXIT_STAGGER_MS = 120;
@@ -26,7 +28,7 @@ const applyLabPreparationState = (element: HTMLElement) => {
   element.style.transform = LAB_PREPARE_STYLE.transform;
 };
 
-const prefersReducedMotion = () =>
+export const prefersReducedMotion = () =>
   typeof window !== 'undefined' &&
   typeof window.matchMedia === 'function' &&
   window.matchMedia('(prefers-reduced-motion: reduce)').matches;
@@ -54,6 +56,8 @@ export const startProjectTransition = (navigate: NavigateFunction) => {
     navigate('/laboratory');
     return;
   }
+
+  document.body?.classList.add(LAB_PREP_CLASS);
 
   const exitTargets = Array.from(document.querySelectorAll(EXIT_SELECTOR)) as HTMLElement[];
 
@@ -114,6 +118,7 @@ export const prepareLabElements = () => {
 
 export const animateLabElementsIn = () => {
   if (typeof document === 'undefined' || prefersReducedMotion()) {
+    document.body?.classList.remove(LAB_PREP_CLASS);
     return;
   }
 
@@ -135,10 +140,12 @@ export const animateLabElementsIn = () => {
     .filter((value): value is { element: HTMLElement; delay: number } => value !== null);
 
   if (!elementsToAnimate.length) {
+    document.body?.classList.remove(LAB_PREP_CLASS);
     return;
   }
 
   const runAnimations = () => {
+    document.body?.classList.remove(LAB_PREP_CLASS);
     elementsToAnimate.forEach(({ element, delay }) => {
       clearLabElementTimeouts(element);
 
@@ -200,11 +207,16 @@ export const cleanupProjectTransition = (scope: TransitionCleanupScope = 'all') 
     selectors.push(PROJECT_CLEANUP_SELECTOR);
   }
 
-  if (scope === 'laboratory' || scope === 'all') {
+  const shouldClearLabPrepClass = scope === 'laboratory' || scope === 'all';
+
+  if (shouldClearLabPrepClass) {
     selectors.push(LAB_CLEANUP_SELECTOR);
   }
 
   if (!selectors.length) {
+    if (shouldClearLabPrepClass) {
+      document.body?.classList.remove(LAB_PREP_CLASS);
+    }
     return;
   }
 
@@ -220,4 +232,8 @@ export const cleanupProjectTransition = (scope: TransitionCleanupScope = 'all') 
     target.style.willChange = '';
     clearLabElementTimeouts(target);
   });
+
+  if (shouldClearLabPrepClass) {
+    document.body?.classList.remove(LAB_PREP_CLASS);
+  }
 };

--- a/TrinityFrontend/src/utils/projectTransition.ts
+++ b/TrinityFrontend/src/utils/projectTransition.ts
@@ -192,11 +192,18 @@ export const animateLabElementsIn = () => {
 
 type TransitionCleanupScope = 'project' | 'laboratory' | 'all';
 
+type TransitionCleanupOptions = {
+  preserveLabPrepClass?: boolean;
+};
+
 const PROJECT_CLEANUP_SELECTOR = '[data-project-transition], [data-project-card]';
 const LAB_CLEANUP_SELECTOR =
   '[data-lab-header], [data-lab-toolbar], [data-lab-sidebar], [data-lab-canvas], [data-lab-settings]';
 
-export const cleanupProjectTransition = (scope: TransitionCleanupScope = 'all') => {
+export const cleanupProjectTransition = (
+  scope: TransitionCleanupScope = 'all',
+  options: TransitionCleanupOptions = {}
+) => {
   if (typeof document === 'undefined') {
     return;
   }
@@ -207,9 +214,10 @@ export const cleanupProjectTransition = (scope: TransitionCleanupScope = 'all') 
     selectors.push(PROJECT_CLEANUP_SELECTOR);
   }
 
-  const shouldClearLabPrepClass = scope === 'laboratory' || scope === 'all';
+  const shouldCleanupLabElements = scope === 'laboratory' || scope === 'all';
+  const shouldClearLabPrepClass = shouldCleanupLabElements && !options.preserveLabPrepClass;
 
-  if (shouldClearLabPrepClass) {
+  if (shouldCleanupLabElements) {
     selectors.push(LAB_CLEANUP_SELECTOR);
   }
 

--- a/TrinityFrontend/src/utils/projectTransition.ts
+++ b/TrinityFrontend/src/utils/projectTransition.ts
@@ -1,0 +1,72 @@
+import { NavigateFunction } from 'react-router-dom';
+
+export const startProjectTransition = (navigate: NavigateFunction) => {
+  if (typeof document === 'undefined') {
+    navigate('/laboratory');
+    return;
+  }
+
+  const projectCards = document.querySelectorAll('[data-project-card]');
+  console.log('Found project cards:', projectCards.length);
+
+  projectCards.forEach((card, index) => {
+    setTimeout(() => {
+      console.log('Animating card', index);
+      (card as HTMLElement).classList.add('animate-project-exit');
+    }, index * 150);
+  });
+
+  const totalExitTime = projectCards.length * 150 + 500;
+  setTimeout(() => {
+    navigate('/laboratory');
+  }, totalExitTime);
+};
+
+export const animateLabElementsIn = () => {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  console.log('Starting lab elements animation');
+
+  setTimeout(() => {
+    const labElements = [
+      { selector: '[data-lab-header]', delay: 0, name: 'header' },
+      { selector: '[data-lab-toolbar]', delay: 200, name: 'toolbar' },
+      { selector: '[data-lab-sidebar]', delay: 400, name: 'sidebar' },
+      { selector: '[data-lab-canvas]', delay: 600, name: 'canvas' },
+      { selector: '[data-lab-settings]', delay: 800, name: 'settings' }
+    ];
+
+    labElements.forEach(({ selector, delay, name }) => {
+      const element = document.querySelector(selector) as HTMLElement | null;
+      console.log(`Found ${name} element:`, !!element);
+
+      if (element) {
+        element.style.opacity = '0';
+        element.style.transform = 'translateY(30px) scale(0.95)';
+
+        setTimeout(() => {
+          console.log(`Animating ${name} element`);
+          element.classList.add('animate-lab-element-enter');
+        }, delay);
+      }
+    });
+  }, 200);
+};
+
+export const cleanupProjectTransition = () => {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  console.log('Cleaning up project transition');
+  const allElements = document.querySelectorAll(
+    '[data-project-card], [data-lab-header], [data-lab-toolbar], [data-lab-sidebar], [data-lab-canvas], [data-lab-settings]'
+  );
+  allElements.forEach((element) => {
+    (element as HTMLElement).classList.remove('animate-project-exit', 'animate-lab-element-enter');
+    (element as HTMLElement).style.opacity = '';
+    (element as HTMLElement).style.transform = '';
+  });
+};

--- a/TrinityFrontend/src/utils/projectTransition.ts
+++ b/TrinityFrontend/src/utils/projectTransition.ts
@@ -1,58 +1,113 @@
 import { NavigateFunction } from 'react-router-dom';
 
+const EXIT_SELECTOR = '[data-project-transition], [data-project-card]';
+const EXIT_CLASS = 'animate-project-exit';
+const EXIT_STAGGER_MS = 120;
+const EXIT_DURATION_MS = 500;
+const EXIT_BUFFER_MS = 200;
+
+const LAB_CLASS = 'animate-lab-element-enter';
+const LAB_PREPARE_STYLE = {
+  opacity: '0',
+  transform: 'translateY(32px) scale(0.96)'
+} as const;
+
+const prefersReducedMotion = () =>
+  typeof window !== 'undefined' &&
+  typeof window.matchMedia === 'function' &&
+  window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+const isElementVisible = (element: HTMLElement) => {
+  const rect = element.getBoundingClientRect();
+  return rect.width > 0 && rect.height > 0;
+};
+
 export const startProjectTransition = (navigate: NavigateFunction) => {
-  if (typeof document === 'undefined') {
+  if (typeof document === 'undefined' || prefersReducedMotion()) {
     navigate('/laboratory');
     return;
   }
 
-  const projectCards = document.querySelectorAll('[data-project-card]');
-  console.log('Found project cards:', projectCards.length);
+  const exitTargets = Array.from(document.querySelectorAll(EXIT_SELECTOR)) as HTMLElement[];
 
-  projectCards.forEach((card, index) => {
-    setTimeout(() => {
-      console.log('Animating card', index);
-      (card as HTMLElement).classList.add('animate-project-exit');
-    }, index * 150);
+  const orderedTargets = exitTargets
+    .map((element, index) => {
+      const orderAttr = element.getAttribute('data-project-transition-order');
+      const order =
+        orderAttr !== null && orderAttr.trim() !== '' ? Number(orderAttr) : Number.NaN;
+      return { element, order, index };
+    })
+    .filter(({ element }) => isElementVisible(element))
+    .sort((a, b) => {
+      const orderA = Number.isFinite(a.order) ? a.order : a.index;
+      const orderB = Number.isFinite(b.order) ? b.order : b.index;
+      if (orderA !== orderB) return orderA - orderB;
+      return a.index - b.index;
+    });
+
+  orderedTargets.forEach(({ element }, sequenceIndex) => {
+    element.style.setProperty('--project-exit-delay', `${sequenceIndex * EXIT_STAGGER_MS}ms`);
+    element.style.willChange = 'opacity, transform';
+    element.classList.add(EXIT_CLASS);
+
+    const handleExitAnimationEnd = () => {
+      element.style.willChange = '';
+      element.removeEventListener('animationend', handleExitAnimationEnd);
+    };
+
+    element.addEventListener('animationend', handleExitAnimationEnd);
   });
 
-  const totalExitTime = projectCards.length * 150 + 500;
-  setTimeout(() => {
+  const totalExitTime = orderedTargets.length
+    ? EXIT_DURATION_MS + EXIT_STAGGER_MS * (orderedTargets.length - 1) + EXIT_BUFFER_MS
+    : 0;
+
+  window.setTimeout(() => {
     navigate('/laboratory');
   }, totalExitTime);
 };
 
 export const animateLabElementsIn = () => {
-  if (typeof document === 'undefined') {
+  if (typeof document === 'undefined' || prefersReducedMotion()) {
     return;
   }
 
-  console.log('Starting lab elements animation');
+  const labElements = [
+    { selector: '[data-lab-header]', delay: 0 },
+    { selector: '[data-lab-toolbar]', delay: 160 },
+    { selector: '[data-lab-sidebar]', delay: 320 },
+    { selector: '[data-lab-canvas]', delay: 480 },
+    { selector: '[data-lab-settings]', delay: 640 }
+  ] as const;
 
-  setTimeout(() => {
-    const labElements = [
-      { selector: '[data-lab-header]', delay: 0, name: 'header' },
-      { selector: '[data-lab-toolbar]', delay: 200, name: 'toolbar' },
-      { selector: '[data-lab-sidebar]', delay: 400, name: 'sidebar' },
-      { selector: '[data-lab-canvas]', delay: 600, name: 'canvas' },
-      { selector: '[data-lab-settings]', delay: 800, name: 'settings' }
-    ];
-
-    labElements.forEach(({ selector, delay, name }) => {
+  window.setTimeout(() => {
+    labElements.forEach(({ selector, delay }) => {
       const element = document.querySelector(selector) as HTMLElement | null;
-      console.log(`Found ${name} element:`, !!element);
 
-      if (element) {
-        element.style.opacity = '0';
-        element.style.transform = 'translateY(30px) scale(0.95)';
-
-        setTimeout(() => {
-          console.log(`Animating ${name} element`);
-          element.classList.add('animate-lab-element-enter');
-        }, delay);
+      if (!element || !isElementVisible(element)) {
+        return;
       }
+
+      element.classList.remove(LAB_CLASS);
+      element.style.setProperty('--lab-enter-delay', `${delay}ms`);
+      element.style.opacity = LAB_PREPARE_STYLE.opacity;
+      element.style.transform = LAB_PREPARE_STYLE.transform;
+      element.style.willChange = 'opacity, transform';
+
+      window.requestAnimationFrame(() => {
+        element.classList.add(LAB_CLASS);
+      });
+
+      const handleAnimationEnd = () => {
+        element.style.opacity = '';
+        element.style.transform = '';
+        element.style.willChange = '';
+        element.removeEventListener('animationend', handleAnimationEnd);
+      };
+
+      element.addEventListener('animationend', handleAnimationEnd);
     });
-  }, 200);
+  }, 120);
 };
 
 export const cleanupProjectTransition = () => {
@@ -60,13 +115,17 @@ export const cleanupProjectTransition = () => {
     return;
   }
 
-  console.log('Cleaning up project transition');
   const allElements = document.querySelectorAll(
-    '[data-project-card], [data-lab-header], [data-lab-toolbar], [data-lab-sidebar], [data-lab-canvas], [data-lab-settings]'
+    '[data-project-transition], [data-project-card], [data-lab-header], [data-lab-toolbar], [data-lab-sidebar], [data-lab-canvas], [data-lab-settings]'
   );
+
   allElements.forEach((element) => {
-    (element as HTMLElement).classList.remove('animate-project-exit', 'animate-lab-element-enter');
-    (element as HTMLElement).style.opacity = '';
-    (element as HTMLElement).style.transform = '';
+    const target = element as HTMLElement;
+    target.classList.remove(EXIT_CLASS, LAB_CLASS);
+    target.style.opacity = '';
+    target.style.transform = '';
+    target.style.removeProperty('--project-exit-delay');
+    target.style.removeProperty('--lab-enter-delay');
+    target.style.willChange = '';
   });
 };


### PR DESCRIPTION
## Summary
- add a shared utility to animate the project card exit and laboratory entrance transitions
- update the Projects page to trigger the transition, mark cards for animation, and prevent double navigation
- annotate Laboratory mode sections for staged entrance animations and add supporting CSS keyframes

## Testing
- npm run lint *(fails: existing lint violations across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cd43f1c91c83219cb64efe6a336d79