### PR TITLE
Render dataframe re-selection confirmation dialog

### DIFF
--- a/TrinityFrontend/src/components/AtomList/atoms/dataframe-operations/components/properties/DataFrameOperationsProperties.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/dataframe-operations/components/properties/DataFrameOperationsProperties.tsx
@@ -150,6 +150,7 @@ const DataFrameOperationsProperties: React.FC<Props> = ({ atomId }) => {
           <DataFrameOperationsExhibition data={(settings as any).tableData || data} />
         </TabsContent>
       </Tabs>
+      {dialog}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- render the data source change confirmation dialog for the dataframe operations atom so that re-selecting a dataframe triggers the confirmation flow and loads the new data

## Testing
- npm run lint *(fails: repository currently has numerous pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d0ece0ca5883218f2a2843ea669720