### PR TITLE
Fix laboratory header animation flicker

### DIFF
--- a/TrinityFrontend/src/index.css
+++ b/TrinityFrontend/src/index.css
@@ -150,3 +150,12 @@ body.lab-transition-prep [data-lab-settings] {
   opacity: 0;
   transform: translateY(30px) scale(0.95);
 }
+
+[data-lab-preparing='true'] [data-lab-header],
+[data-lab-preparing='true'] [data-lab-toolbar],
+[data-lab-preparing='true'] [data-lab-sidebar],
+[data-lab-preparing='true'] [data-lab-canvas],
+[data-lab-preparing='true'] [data-lab-settings] {
+  opacity: 0;
+  transform: translateY(30px) scale(0.95);
+}


### PR DESCRIPTION
## Summary
- ensure laboratory mode UI elements start in an off-screen state so the entrance animation plays only once
- skip the animation prep when reduced motion is preferred and clear the preparatory flag once the entrance animation begins
- add CSS to back the preparatory state so the header and toolbar stay hidden until the animation runs

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d0fd0e1a548321aa852683ef85c76d