### PR TITLE
Ensure floating lab navigation list appears after transition

### DIFF
--- a/TrinityFrontend/src/components/LaboratoryMode/LaboratoryMode.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/LaboratoryMode.tsx
@@ -34,20 +34,21 @@ const useIsomorphicInsertionEffect =
 const ENTRANCE_COMPLETION_BUFFER_MS = 200;
 
 const LaboratoryMode = () => {
+  const initialReduceMotion = useMemo(() => prefersReducedMotion(), []);
   const [selectedAtomId, setSelectedAtomId] = useState<string>();
   const [selectedCardId, setSelectedCardId] = useState<string>();
   const [cardExhibited, setCardExhibited] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
-  const [showFloatingNavigationList, setShowFloatingNavigationList] = useState(true);
+  const [showFloatingNavigationList, setShowFloatingNavigationList] = useState(initialReduceMotion);
   const [auxActive, setAuxActive] = useState<string | null>(null);
   const { toast } = useToast();
   const { cards, setCards: setLabCards } = useLaboratoryStore();
   const setExhibitionCards = useExhibitionStore(state => state.setCards);
   const { hasPermission, user } = useAuth();
   const canEdit = hasPermission('laboratory:edit');
-  const initialReduceMotion = useMemo(() => prefersReducedMotion(), []);
   const skipInitialLabCleanupRef = useRef(true);
   const reduceMotionRef = useRef(initialReduceMotion);
+  const hasAutoShownNavigationRef = useRef(initialReduceMotion);
   const [isPreparingAnimation, setIsPreparingAnimation] = useState(!initialReduceMotion);
   const [hasEntranceFinished, setHasEntranceFinished] = useState(initialReduceMotion);
 
@@ -151,6 +152,15 @@ const LaboratoryMode = () => {
       window.clearTimeout(completionFallback);
     };
   }, []);
+
+  useEffect(() => {
+    if (!hasEntranceFinished || hasAutoShownNavigationRef.current) {
+      return;
+    }
+
+    hasAutoShownNavigationRef.current = true;
+    setShowFloatingNavigationList(true);
+  }, [hasEntranceFinished]);
 
   useEffect(() => {
     if (localStorage.getItem('laboratory-config')) {


### PR DESCRIPTION
## Summary
- defer showing the laboratory navigation list until the entrance sequence completes and auto-open it after animations finish
- refine the floating navigation list anchoring logic so it re-centers beside the header text once the UI is ready

## Testing
- npm run lint *(fails: pre-existing lint errors throughout the project)*

------
https://chatgpt.com/codex/tasks/task_e_68d12932419c83218bd836ac89339949