### PR TITLE
Fix feature overview atom dimension mapping fetch

### DIFF
--- a/TrinityFrontend/src/components/AtomList/atoms/feature-overview/components/FeatureOverviewSettings.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/feature-overview/components/FeatureOverviewSettings.tsx
@@ -143,9 +143,12 @@ const FeatureOverviewSettings: React.FC<FeatureOverviewSettingsProps> = ({ atomI
       }
       const filtered = summary.filter(c => c.unique_count > 1);
       const selected = filtered.map(c => c.column);
-      const rawMap = await fetchDimensionMapping();
+      const { mapping: rawMapping } = await fetchDimensionMapping({ objectName: normalized });
       const mapping = Object.fromEntries(
-        Object.entries(rawMap).filter(([k]) => k.toLowerCase() !== 'unattributed')
+        Object.entries(rawMapping || {}).filter(([k]) => {
+          const key = k.toLowerCase();
+          return key !== 'unattributed' && key !== 'unattributed_dimensions';
+        })
       );
       const activeMetric = '';
       onSettingsChange({


### PR DESCRIPTION
## Summary
- ensure the feature overview settings fetch dimension mappings for the selected dataframe and drop unattributed entries so cached data loads

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d12c47a4c08321ae4ce9cd4788bf2f