### PR TITLE
Fix Trinity AI backend sys.path configuration for app imports

### DIFF
--- a/TrinityAI/main_api.py
+++ b/TrinityAI/main_api.py
@@ -36,10 +36,21 @@ def get_llm_config() -> Dict[str, str]:
 # ``DataStorageRetrieval`` package and ``app`` utilities can be
 # imported normally when running outside Docker.
 BACKEND_ROOT = Path(__file__).resolve().parent
-sys.path.append(str(BACKEND_ROOT))
-BACKEND_API = BACKEND_ROOT.parent / "TrinityBackendFastAPI" / "app"
-if BACKEND_API.exists():
-    sys.path.append(str(BACKEND_API))
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.append(str(BACKEND_ROOT))
+
+BACKEND_REPO = BACKEND_ROOT.parent / "TrinityBackendFastAPI"
+BACKEND_API = BACKEND_REPO / "app"
+
+# ``app`` is a top-level package inside ``TrinityBackendFastAPI`` while
+# helpers such as ``DataStorageRetrieval`` live inside the ``app`` folder.
+# Add both locations to ``sys.path`` so the imports work when running the
+# AI service outside the Docker compose environment.
+for path in (BACKEND_REPO, BACKEND_API):
+    if path.exists():
+        path_str = str(path)
+        if path_str not in sys.path:
+            sys.path.append(path_str)
 
 from app.core.mongo import build_host_mongo_uri
 

--- a/TrinityAI/main_api.py
+++ b/TrinityAI/main_api.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from fastapi import FastAPI, APIRouter, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
-from typing import Dict, Any, Tuple, Optional
+from typing import Dict, Any, Tuple, Optional, Iterable, Mapping
 import numpy as np
 from pymongo import MongoClient
 from fastapi.encoders import jsonable_encoder
@@ -52,7 +52,67 @@ for path in (BACKEND_REPO, BACKEND_API):
         if path_str not in sys.path:
             sys.path.append(path_str)
 
-from app.core.mongo import build_host_mongo_uri
+try:
+    from app.core.mongo import build_host_mongo_uri
+except ModuleNotFoundError:
+    logger.warning(
+        "FastAPI backend package unavailable; falling back to local Mongo URI builder"
+    )
+
+    def _first_non_empty(vars_: Iterable[str], default: str) -> str:
+        """Return the first non-empty environment variable value."""
+
+        for name in vars_:
+            value = os.getenv(name)
+            if value is None:
+                continue
+            stripped = value.strip()
+            if stripped:
+                return stripped
+        return default
+
+    def build_host_mongo_uri(
+        *,
+        username: str = "admin_dev",
+        password: str = "pass_dev",
+        auth_source: str = "admin",
+        default_host: str = "localhost",
+        default_port: str = "9005",
+        host_env_vars: Tuple[str, ...] = ("HOST_IP", "MONGO_HOST"),
+        port_env_vars: Tuple[str, ...] = ("MONGO_PORT",),
+        auth_source_env_vars: Tuple[str, ...] = ("MONGO_AUTH_SOURCE", "MONGO_AUTH_DB"),
+        database: str | None = None,
+        options: Mapping[str, str] | None = None,
+    ) -> str:
+        """Construct a MongoDB URI using host information from the environment."""
+
+        host = _first_non_empty(host_env_vars, default_host)
+        port = _first_non_empty(port_env_vars, default_port)
+        auth_db = _first_non_empty(auth_source_env_vars, auth_source)
+
+        credentials = ""
+        if username and password:
+            credentials = f"{username}:{password}@"
+        elif username:
+            credentials = f"{username}@"
+
+        path = f"/{database}" if database else "/"
+
+        query_params: Dict[str, str] = {}
+        if auth_db:
+            query_params["authSource"] = auth_db
+        if options:
+            for key, value in options.items():
+                if value is None:
+                    continue
+                query_params[key] = value
+
+        query = ""
+        if query_params:
+            joined = "&".join(f"{key}={value}" for key, value in query_params.items())
+            query = f"?{joined}"
+
+        return f"mongodb://{credentials}{host}:{port}{path}{query}"
 
 # Load environment variables from Redis so subsequent configuration
 # functions see CLIENT_NAME, APP_NAME and PROJECT_NAME

--- a/TrinityBackendFastAPI/app/features/data_upload_validate/app/routes.py
+++ b/TrinityBackendFastAPI/app/features/data_upload_validate/app/routes.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import fastexcel
 
 # Add this line with your other imports
-from datetime import datetime
+from datetime import datetime, timezone
 import logging
 
 
@@ -129,6 +129,8 @@ from app.DataStorageRetrieval.flight_registry import (
     remove_arrow_object,
     get_flight_path_for_csv,
     get_arrow_for_flight_path,
+    CSV_TO_FLIGHT,
+    FILEKEY_TO_CSV,
 )
 from app.DataStorageRetrieval.minio_utils import (
     ensure_minio_bucket,
@@ -3025,6 +3027,242 @@ async def get_upload_status(validator_atom_id: str, file_key: str) -> dict:
     if isinstance(status, bytes):
         status = status.decode()
     return {"status": status}
+
+
+_TIMESTAMP_PATTERN = re.compile(r"(\d{8})_(\d{6})")
+
+
+def _normalize_datetime(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    if not isinstance(value, datetime):
+        return None
+    if value.tzinfo is None:
+        try:
+            return value.replace(tzinfo=timezone.utc)
+        except Exception:
+            return value
+    try:
+        return value.astimezone(timezone.utc)
+    except Exception:
+        return value
+
+
+def _extract_timestamp_from_string(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    match = _TIMESTAMP_PATTERN.search(Path(value).name)
+    if not match:
+        return None
+    try:
+        parsed = datetime.strptime(
+            f"{match.group(1)}{match.group(2)}", "%Y%m%d%H%M%S"
+        )
+    except ValueError:
+        return None
+    return parsed.replace(tzinfo=timezone.utc)
+
+
+def _stat_object_metadata(object_name: str) -> tuple[datetime | None, int | None]:
+    try:
+        stat = minio_client.stat_object(MINIO_BUCKET, object_name)
+    except S3Error as exc:
+        code = getattr(exc, "code", "")
+        if code in {"NoSuchKey", "NoSuchBucket"}:
+            return None, None
+        logger.warning("stat_object failed for %s: %s", object_name, exc)
+        return None, None
+    except Exception as exc:
+        logger.warning("stat_object error for %s: %s", object_name, exc)
+        return None, None
+    last_modified = _normalize_datetime(getattr(stat, "last_modified", None))
+    size = getattr(stat, "size", None)
+    return last_modified, size if isinstance(size, int) else None
+
+
+def _choose_newest_candidate(
+    current: dict[str, Any] | None, candidate: dict[str, Any]
+) -> dict[str, Any]:
+    if current is None:
+        return candidate
+    cand_ts = candidate.get("timestamp")
+    curr_ts = current.get("timestamp")
+    if cand_ts and curr_ts:
+        if cand_ts > curr_ts:
+            return candidate
+        if cand_ts < curr_ts:
+            return current
+    elif cand_ts and not curr_ts:
+        return candidate
+    elif curr_ts and not cand_ts:
+        return current
+    cand_mod = candidate.get("last_modified")
+    curr_mod = current.get("last_modified")
+    if cand_mod and curr_mod:
+        if cand_mod > curr_mod:
+            return candidate
+        if cand_mod < curr_mod:
+            return current
+    elif cand_mod and not curr_mod:
+        return candidate
+    elif curr_mod and not cand_mod:
+        return current
+    cand_priority = candidate.get("priority", 0)
+    curr_priority = current.get("priority", 0)
+    if cand_priority != curr_priority:
+        return candidate if cand_priority > curr_priority else current
+    cand_name = candidate.get("object_name", "")
+    curr_name = current.get("object_name", "")
+    return candidate if cand_name > curr_name else current
+
+
+@router.get("/latest_project_dataframe")
+async def latest_project_dataframe(
+    client_name: str = "",
+    app_name: str = "",
+    project_name: str = "",
+    client_id: str = "",
+    app_id: str = "",
+    project_id: str = "",
+) -> dict[str, Any]:
+    prefix, env, env_source = await get_object_prefix(
+        client_id=client_id,
+        app_id=app_id,
+        project_id=project_id,
+        client_name=client_name,
+        app_name=app_name,
+        project_name=project_name,
+        include_env=True,
+    )
+
+    best: dict[str, Any] | None = None
+    arrow_names: set[str] = set()
+    arrow_names.update(name for name in CSV_TO_FLIGHT.keys() if isinstance(name, str))
+    arrow_names.update(
+        value for value in FILEKEY_TO_CSV.values() if isinstance(value, str)
+    )
+
+    for arrow_name in arrow_names:
+        original = get_original_csv(arrow_name)
+        if not arrow_name.startswith(prefix) and not (
+            original and original.startswith(prefix)
+        ):
+            continue
+        flight_path = CSV_TO_FLIGHT.get(arrow_name) or get_flight_path_for_csv(
+            arrow_name
+        )
+        timestamp = _extract_timestamp_from_string(arrow_name) or _extract_timestamp_from_string(
+            flight_path
+        )
+        last_modified, size = _stat_object_metadata(arrow_name)
+        candidate = {
+            "object_name": arrow_name,
+            "csv_name": original or Path(arrow_name).name,
+            "flight_path": flight_path,
+            "timestamp": timestamp or last_modified,
+            "last_modified": last_modified,
+            "size": size,
+            "priority": 2 if flight_path else 1,
+            "source": "flight_registry" if flight_path else "registry",
+        }
+        best = _choose_newest_candidate(best, candidate)
+
+    list_error: str | None = None
+    objects: list[Any] = []
+    try:
+        objects = list(
+            minio_client.list_objects(
+                MINIO_BUCKET, prefix=prefix, recursive=True
+            )
+        )
+    except S3Error as exc:
+        if getattr(exc, "code", "") == "NoSuchBucket":
+            objects = []
+        else:
+            list_error = str(exc)
+            objects = []
+    except Exception as exc:
+        list_error = str(exc)
+        objects = []
+
+    tmp_prefix = prefix + "tmp/"
+    for obj in objects:
+        object_name = getattr(obj, "object_name", "")
+        if not object_name.endswith(".arrow"):
+            continue
+        if object_name.startswith(tmp_prefix):
+            continue
+        last_modified = _normalize_datetime(getattr(obj, "last_modified", None))
+        size = obj.size if isinstance(obj.size, int) else None
+        flight_path = get_flight_path_for_csv(object_name)
+        timestamp = _extract_timestamp_from_string(object_name) or _extract_timestamp_from_string(
+            flight_path
+        )
+        candidate = {
+            "object_name": object_name,
+            "csv_name": get_original_csv(object_name) or Path(object_name).name,
+            "flight_path": flight_path,
+            "timestamp": timestamp or last_modified,
+            "last_modified": last_modified,
+            "size": size,
+            "priority": 2 if flight_path else 1,
+            "source": "minio_flight" if flight_path else "minio",
+        }
+        previous = best
+        best = _choose_newest_candidate(best, candidate)
+        if previous is best and best and best.get("object_name") == object_name:
+            if best.get("last_modified") is None and last_modified:
+                best["last_modified"] = last_modified
+            if best.get("size") is None and size is not None:
+                best["size"] = size
+            if best.get("flight_path") is None and flight_path:
+                best["flight_path"] = flight_path
+            if best.get("csv_name") in (None, "", Path(object_name).name):
+                original = get_original_csv(object_name)
+                if original:
+                    best["csv_name"] = original
+
+    if best and (best.get("last_modified") is None or best.get("size") is None):
+        stat_modified, stat_size = _stat_object_metadata(best["object_name"])
+        if best.get("last_modified") is None and stat_modified:
+            best["last_modified"] = stat_modified
+        if best.get("size") is None and stat_size is not None:
+            best["size"] = stat_size
+
+    if best:
+        logger.info(
+            "latest_project_dataframe resolved %s via %s",
+            best.get("object_name"),
+            best.get("source"),
+        )
+
+    response: dict[str, Any] = {
+        "bucket": MINIO_BUCKET,
+        "prefix": prefix,
+        "environment": env,
+        "env_source": env_source,
+    }
+    if best:
+        response["object_name"] = best.get("object_name")
+        response["csv_name"] = best.get("csv_name") or Path(
+            best["object_name"]
+        ).name
+        if best.get("flight_path"):
+            response["flight_path"] = best.get("flight_path")
+        if best.get("last_modified"):
+            response["last_modified"] = best["last_modified"].isoformat()
+        if best.get("timestamp"):
+            response["timestamp"] = best["timestamp"].isoformat()
+        if best.get("size") is not None:
+            response["size"] = best.get("size")
+        if best.get("source"):
+            response["source"] = best.get("source")
+    else:
+        response["object_name"] = None
+        if list_error:
+            response["error"] = list_error
+
+    return response
 
 
 @router.get("/list_saved_dataframes")

--- a/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea/index.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/components/CanvasArea/index.tsx
@@ -114,31 +114,79 @@ const CanvasArea: React.FC<CanvasAreaProps> = ({
     unique_values: string[];
   }
 
-  const fetchColumnSummary = async (csv: string, signal?: AbortSignal) => {
-    try {
-      console.log('🔎 fetching column summary for', csv);
-      const res = await fetch(
-        `${FEATURE_OVERVIEW_API}/column_summary?object_name=${encodeURIComponent(csv)}`,
-        { signal }
-      );
-      if (!res.ok) {
-        console.warn('⚠️ column summary request failed', res.status);
-        return { summary: [], numeric: [], xField: '' };
-      }
-      const data = await res.json();
-      const summary: ColumnInfo[] = (data.summary || []).filter(Boolean);
-      console.log('ℹ️ fetched column summary rows', summary.length);
-      const numeric = summary
-        .filter(c => !['object', 'string'].includes(c.data_type.toLowerCase()))
-        .map(c => c.column);
-      const xField =
-        summary.find(c => c.column.toLowerCase().includes('date'))?.column ||
-        (summary[0]?.column || '');
-      return { summary, numeric, xField };
-    } catch (err) {
-      console.error('⚠️ failed to fetch column summary', err);
+  interface ColumnSummaryOptions {
+    signal?: AbortSignal;
+    statusCb?: (status: string) => void;
+    retries?: number;
+    retryDelayMs?: number;
+  }
+
+  const sleep = (ms: number) =>
+    new Promise(resolve => {
+      setTimeout(resolve, ms);
+    });
+
+  const fetchColumnSummary = async (
+    csv: string,
+    { signal, statusCb, retries = 0, retryDelayMs = 800 }: ColumnSummaryOptions = {},
+  ) => {
+    if (!csv || !/\.[^/]+$/.test(csv.trim())) {
       return { summary: [], numeric: [], xField: '' };
     }
+
+    let attempt = 0;
+    let lastResult = { summary: [] as ColumnInfo[], numeric: [] as string[], xField: '' };
+
+    while (attempt <= retries) {
+      if (signal?.aborted) {
+        throw new DOMException('Aborted', 'AbortError');
+      }
+
+      const label =
+        attempt === 0 ? 'Fetching column summary' : `Retrying column summary (${attempt + 1})`;
+      statusCb?.(label);
+      console.log(
+        `${attempt === 0 ? '🔎' : '🔄'} ${label.toLowerCase()} for`,
+        csv,
+      );
+
+      try {
+        const res = await fetch(
+          `${FEATURE_OVERVIEW_API}/column_summary?object_name=${encodeURIComponent(csv)}`,
+          { signal },
+        );
+        if (!res.ok) {
+          console.warn('⚠️ column summary request failed', res.status);
+        } else {
+          const data = await res.json();
+          const summary: ColumnInfo[] = (data.summary || []).filter(Boolean);
+          console.log('ℹ️ fetched column summary rows', summary.length);
+          const numeric = summary
+            .filter(c => !['object', 'string'].includes(c.data_type.toLowerCase()))
+            .map(c => c.column);
+          const xField =
+            summary.find(c => c.column.toLowerCase().includes('date'))?.column ||
+            (summary[0]?.column || '');
+          lastResult = { summary, numeric, xField };
+          if (summary.length > 0) {
+            return lastResult;
+          }
+        }
+      } catch (err) {
+        if ((err as any)?.name === 'AbortError') {
+          console.warn('ℹ️ column summary fetch aborted');
+          throw err;
+        }
+        console.error('⚠️ failed to fetch column summary', err);
+      }
+
+      attempt += 1;
+      if (attempt <= retries && retryDelayMs > 0) {
+        await sleep(retryDelayMs);
+      }
+    }
+
+    return lastResult;
   };
 
   const prefetchDataframe = async (
@@ -187,8 +235,22 @@ const CanvasArea: React.FC<CanvasAreaProps> = ({
         const a = card.atoms[j];
         if (a.atomId === 'feature-overview' && a.settings?.dataSource) {
           console.log('✔️ found feature overview data source', a.settings.dataSource);
-          await prefetchDataframe(a.settings.dataSource, signal);
-          const cols = await fetchColumnSummary(a.settings.dataSource, signal);
+          const existingColumns: ColumnInfo[] = Array.isArray(a.settings?.allColumns)
+            ? (a.settings.allColumns as ColumnInfo[]).filter(Boolean)
+            : [];
+          const cols =
+            existingColumns.length > 0
+              ? {
+                  summary: existingColumns,
+                  numeric: Array.isArray(a.settings?.numericColumns)
+                    ? (a.settings.numericColumns as string[])
+                    : [],
+                  xField: a.settings?.xAxis || '',
+                }
+              : await fetchColumnSummary(a.settings.dataSource, {
+                  signal,
+                  retries: 2,
+                });
           return {
             csv: a.settings.dataSource,
             display: a.settings.csvDisplay || a.settings.dataSource,
@@ -211,8 +273,10 @@ const CanvasArea: React.FC<CanvasAreaProps> = ({
                 const ticket = await ticketRes.json();
                 if (ticket.arrow_name) {
                   console.log('✔️ using validated data source', ticket.arrow_name);
-                  await prefetchDataframe(ticket.arrow_name, signal);
-                  const cols = await fetchColumnSummary(ticket.arrow_name, signal);
+                  const cols = await fetchColumnSummary(ticket.arrow_name, {
+                    signal,
+                    retries: 2,
+                  });
                   let ids: string[] = [];
                   if (confRes && confRes.ok) {
                     const cfg = await confRes.json();
@@ -253,29 +317,31 @@ const CanvasArea: React.FC<CanvasAreaProps> = ({
         app_name: env.APP_NAME || '',
         project_name: env.PROJECT_NAME || ''
       });
-      const query = params.toString() ? `?${params.toString()}` : '';
+          const query = params.toString() ? `?${params.toString()}` : '';
 
-      try {
-        const latestRes = await fetch(
-          `${VALIDATE_API}/latest_project_dataframe${query}`,
-          { credentials: 'include', signal }
-        );
-        if (latestRes.ok) {
-          const latestData = await latestRes.json();
-          const latestName = latestData?.object_name;
-          if (typeof latestName === 'string' && latestName.trim()) {
-            console.log(
-              '✔️ defaulting to latest flight dataframe',
-              latestName,
-              latestData?.source || 'unknown'
+          try {
+            const latestRes = await fetch(
+              `${VALIDATE_API}/latest_project_dataframe${query}`,
+              { credentials: 'include', signal }
             );
-            await prefetchDataframe(latestName, signal);
-            const cols = await fetchColumnSummary(latestName, signal);
-            return {
-              csv: latestName,
-              display: latestData?.csv_name || latestName,
-              ...(cols || {}),
-            };
+            if (latestRes.ok) {
+              const latestData = await latestRes.json();
+              const latestName = latestData?.object_name;
+              if (typeof latestName === 'string' && latestName.trim()) {
+                console.log(
+                  '✔️ defaulting to latest flight dataframe',
+                  latestName,
+                  latestData?.source || 'unknown'
+                );
+                const cols = await fetchColumnSummary(latestName, {
+                  signal,
+                  retries: 2,
+                });
+                return {
+                  csv: latestName,
+                  display: latestData?.csv_name || latestName,
+                  ...(cols || {}),
+                };
           }
         } else {
           console.warn('⚠️ latest_project_dataframe failed', latestRes.status);
@@ -318,8 +384,10 @@ const CanvasArea: React.FC<CanvasAreaProps> = ({
         const chosen = latest?.file || fallback;
         if (chosen && chosen.object_name) {
           console.log('✔️ defaulting to latest saved dataframe', chosen.object_name);
-          await prefetchDataframe(chosen.object_name, signal);
-          const cols = await fetchColumnSummary(chosen.object_name, signal);
+          const cols = await fetchColumnSummary(chosen.object_name, {
+            signal,
+            retries: 2,
+          });
           return {
             csv: chosen.object_name,
             display: chosen.csv_name || chosen.object_name,
@@ -353,6 +421,22 @@ const CanvasArea: React.FC<CanvasAreaProps> = ({
       await prefetchDataframe(prev.csv, controller.signal, status =>
         updateAtomSettings(atomId, { loadingStatus: status }),
       );
+
+      let summaryDetails = {
+        summary: Array.isArray(prev.summary) ? prev.summary.filter(Boolean) : [],
+        numeric: Array.isArray(prev.numeric) ? prev.numeric : [],
+        xField: typeof prev.xField === 'string' ? prev.xField : '',
+      };
+
+      if (summaryDetails.summary.length === 0) {
+        summaryDetails = await fetchColumnSummary(prev.csv, {
+          signal: controller.signal,
+          statusCb: status => updateAtomSettings(atomId, { loadingStatus: status }),
+          retries: 2,
+        });
+      }
+
+      updateAtomSettings(atomId, { loadingStatus: 'Fetching dimension mapping' });
       const { mapping: rawMapping } = await fetchDimensionMapping({
         objectName: prev.csv,
         signal: controller.signal,
@@ -363,7 +447,12 @@ const CanvasArea: React.FC<CanvasAreaProps> = ({
         ),
       );
       console.log('✅ pre-filling feature overview with', prev.csv);
-      const summary = Array.isArray(prev.summary) ? prev.summary : [];
+      const summary = Array.isArray(summaryDetails.summary)
+        ? summaryDetails.summary.filter(Boolean)
+        : [];
+      const numericColumns = Array.isArray(summaryDetails.numeric)
+        ? summaryDetails.numeric.filter(Boolean)
+        : [];
       const identifiers = Array.isArray(prev.identifiers) ? prev.identifiers : [];
       const filtered =
         identifiers.length > 0
@@ -374,15 +463,16 @@ const CanvasArea: React.FC<CanvasAreaProps> = ({
           ? identifiers
           : (Array.isArray(summary) ? summary : []).map(cc => cc.column);
 
+      updateAtomSettings(atomId, { loadingStatus: 'Preparing feature overview' });
       updateAtomSettings(atomId, {
         dataSource: prev.csv,
         csvDisplay: prev.display || prev.csv,
         allColumns: summary,
         columnSummary: filtered,
         selectedColumns: selected,
-        numericColumns: Array.isArray(prev.numeric) ? prev.numeric : [],
+        numericColumns,
         dimensionMap: mapping,
-        xAxis: prev.xField || 'date',
+        xAxis: summaryDetails.xField || prev.xField || 'date',
         isLoading: false,
         loadingStatus: '',
         loadingMessage: '',
@@ -516,7 +606,11 @@ const CanvasArea: React.FC<CanvasAreaProps> = ({
       )
       .flatMap(([, v]) => v)
       .filter(Boolean);
-    const allColumns = Array.isArray(prev.summary) ? prev.summary.filter(Boolean) : [];
+    let allColumns = Array.isArray(prev.summary) ? prev.summary.filter(Boolean) : [];
+    if (allColumns.length === 0) {
+      const fetched = await fetchColumnSummary(prev.csv, { retries: 1 });
+      allColumns = Array.isArray(fetched.summary) ? fetched.summary.filter(Boolean) : [];
+    }
     const allCats = allColumns
       .filter(col => {
         const dataType = col.data_type?.toLowerCase() || '';

--- a/TrinityFrontend/src/components/LaboratoryMode/components/SavedDataFramesPanel.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/components/SavedDataFramesPanel.tsx
@@ -12,7 +12,13 @@ interface Props {
 }
 
 const SavedDataFramesPanel: React.FC<Props> = ({ isOpen, onToggle }) => {
-  interface Frame { object_name: string; csv_name: string; arrow_name?: string }
+  interface Frame {
+    object_name: string;
+    csv_name: string;
+    arrow_name?: string;
+    last_modified?: string;
+    size?: number;
+  }
   interface TreeNode {
     name: string;
     path: string;


### PR DESCRIPTION
## Summary
- ensure the Trinity AI service adds both the FastAPI backend root and app directories to `sys.path`
- avoid duplicate path entries so backend helpers and the `app` package are importable outside Docker

## Testing
- `python - <<'PY'
import importlib.util
spec = importlib.util.spec_from_file_location("main_api", "main_api.py")
module = importlib.util.module_from_spec(spec)
spec.loader.exec_module(module)
print("Loaded main_api with", hasattr(module, "app"))
PY` *(fails: missing optional dependency `fastexcel` during backend import)*

------
https://chatgpt.com/codex/tasks/task_e_68d1392c85888321ab657b781fc5aac7