### PR TITLE
Fix FloatingNavigationList position during lab animations

### DIFF
--- a/TrinityFrontend/src/components/LaboratoryMode/components/FloatingNavigationList.tsx
+++ b/TrinityFrontend/src/components/LaboratoryMode/components/FloatingNavigationList.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect, useLayoutEffect, useCallback } from 'react';
+import { createPortal } from 'react-dom';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { GripVertical, X, Minimize2, Maximize2 } from 'lucide-react';
@@ -214,7 +215,7 @@ const FloatingNavigationList: React.FC<FloatingNavigationListProps> = ({
 
   if (!isVisible || !isReady) return null;
 
-  return (
+  const content = (
     <div
       ref={widgetRef}
       className="fixed z-50 select-none transition-opacity duration-500 ease-out"
@@ -228,7 +229,7 @@ const FloatingNavigationList: React.FC<FloatingNavigationListProps> = ({
     >
       <Card className="bg-white/95 backdrop-blur-sm shadow-lg border border-gray-200 min-w-[250px] max-w-[300px]">
         {/* Header */}
-        <div 
+        <div
           className="flex items-center justify-between p-3 border-b border-gray-200 cursor-grab active:cursor-grabbing bg-gray-50"
           onMouseDown={handleMouseDown}
         >
@@ -266,7 +267,7 @@ const FloatingNavigationList: React.FC<FloatingNavigationListProps> = ({
               </div>
             ) : (
               <div className="space-y-2 max-h-[300px] overflow-y-auto">
-                {allAtoms.map((atom) => (
+                {allAtoms.map(atom => (
                   <div
                     key={atom.id}
                     className="flex items-center space-x-2 p-2 bg-gray-50 rounded-md hover:bg-gray-100 transition-colors cursor-pointer"
@@ -281,7 +282,7 @@ const FloatingNavigationList: React.FC<FloatingNavigationListProps> = ({
                 ))}
               </div>
             )}
-            
+
             {allAtoms.length > 0 && (
               <div className="mt-3 pt-2 border-t border-gray-200">
                 <p className="text-xs text-gray-500 text-center">
@@ -294,6 +295,12 @@ const FloatingNavigationList: React.FC<FloatingNavigationListProps> = ({
       </Card>
     </div>
   );
+
+  if (typeof document === 'undefined') {
+    return null;
+  }
+
+  return createPortal(content, document.body);
 };
 
 export default FloatingNavigationList;


### PR DESCRIPTION
## Summary
- render the FloatingNavigationList inside a React portal so its fixed positioning is not affected by animated ancestors
- retain the existing fade-in, drag, and atom listing behavior while ensuring it still anchors over the Laboratory Mode header

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d13a35ee80832182b15c40e067138d