### PR TITLE
Use binary-safe Redis caching for feature overview dataframes

### DIFF
--- a/TrinityBackendFastAPI/app/features/feature_overview/deps.py
+++ b/TrinityBackendFastAPI/app/features/feature_overview/deps.py
@@ -12,6 +12,13 @@ db = client["feature_overview_db"]
 
 REDIS_HOST = os.getenv("REDIS_HOST", "redis")
 redis_client = redis.Redis(host=REDIS_HOST, port=6379, decode_responses=True)
+# Separate binary-safe Redis client for caching dataframe artifacts such as
+# Arrow IPC files.  ``decode_responses=False`` ensures redis-py returns raw
+# ``bytes`` instead of attempting UTF-8 decoding, which can fail for binary
+# payloads containing non-text bytes (e.g., ``0xff``).
+redis_binary_client = redis.Redis(
+    host=REDIS_HOST, port=6379, decode_responses=False
+)
 
 async def get_unique_dataframe_results_collection():
     return db["unique_dataframe"]


### PR DESCRIPTION
## Summary
- add a binary-safe Redis client for feature overview caches so Arrow data isn't decoded as UTF-8
- use the binary cache helpers when reading or writing dataframe artifacts in column summary, cached dataframe, and sku stats paths

## Testing
- python -m compileall TrinityBackendFastAPI/app/features/feature_overview/deps.py TrinityBackendFastAPI/app/features/feature_overview/routes.py

------
https://chatgpt.com/codex/tasks/task_e_68d1659c5e848321aa056ba3b0c4ee73