### PR TITLE
Fix exhibition slide index effect loop

### DIFF
--- a/TrinityFrontend/src/components/ExhibitionMode/ExhibitionMode.tsx
+++ b/TrinityFrontend/src/components/ExhibitionMode/ExhibitionMode.tsx
@@ -89,13 +89,18 @@ const ExhibitionMode = () => {
   }, [loadSavedConfiguration]);
 
   useEffect(() => {
-    if (currentSlide >= exhibitedCards.length && exhibitedCards.length > 0) {
-      setCurrentSlide(exhibitedCards.length - 1);
-    }
-    if (exhibitedCards.length === 0 && currentSlide !== 0) {
-      setCurrentSlide(0);
-    }
-  }, [currentSlide, exhibitedCards.length]);
+    setCurrentSlide((previous) => {
+      if (exhibitedCards.length === 0) {
+        return previous === 0 ? previous : 0;
+      }
+
+      if (previous >= exhibitedCards.length) {
+        return exhibitedCards.length - 1;
+      }
+
+      return previous;
+    });
+  }, [exhibitedCards.length]);
 
   useEffect(() => {
     const handleFullscreenChange = () => {


### PR DESCRIPTION
## Summary
- guard the exhibition slide index effect with a functional state update so it only reacts to deck size changes
- prevent `setCurrentSlide` from retriggering the synchronization effect when the slide collection shrinks

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e4e13d753c83219aa3bf05eb124eb7