### PR TITLE
feat: enable feature overview exhibition selections

### DIFF
--- a/TrinityFrontend/src/components/AtomList/atoms/feature-overview/components/FeatureOverviewExhibition.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/feature-overview/components/FeatureOverviewExhibition.tsx
@@ -1,49 +1,213 @@
-import React from 'react';
+import React, { useMemo, useState } from 'react';
 import { Card } from '@/components/ui/card';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Eye, Layout, Share2, Download } from 'lucide-react';
+import { Eye, ListChecks, Loader2, Send, X } from 'lucide-react';
+import { useToast } from '@/hooks/use-toast';
+import { getActiveProjectContext } from '@/utils/projectEnv';
+import {
+  fetchExhibitionConfiguration,
+  saveExhibitionConfiguration,
+  type ExhibitionConfigurationPayload,
+} from '@/lib/exhibition';
+import type { FeatureOverviewExhibitionSelection } from '@/components/LaboratoryMode/store/laboratoryStore';
 
-const FeatureOverviewExhibition: React.FC = () => {
+interface FeatureOverviewExhibitionProps {
+  atomId: string;
+  cardId?: string | null;
+  selections: FeatureOverviewExhibitionSelection[];
+  onRemoveSelection?: (key: string) => void;
+}
+
+const INITIAL_VISIBILITY = {
+  headers: true,
+  dataTypes: true,
+  uniqueCounts: true,
+  sampleValues: false,
+  qualityMetrics: false,
+};
+
+type VisibilityKey = keyof typeof INITIAL_VISIBILITY;
+
+const FeatureOverviewExhibition: React.FC<FeatureOverviewExhibitionProps> = ({
+  atomId,
+  cardId,
+  selections,
+  onRemoveSelection,
+}) => {
+  const [visibility, setVisibility] = useState(INITIAL_VISIBILITY);
+  const [isSaving, setIsSaving] = useState(false);
+  const { toast } = useToast();
+
+  const selectionCount = selections.length;
+  const selectionBadgeLabel = useMemo(() => {
+    if (selectionCount === 0) {
+      return '0 combinations';
+    }
+    return selectionCount === 1 ? '1 combination' : `${selectionCount} combinations`;
+  }, [selectionCount]);
+
+  const cardIdentifier = cardId || atomId;
+
+  const toggleVisibility = (key: VisibilityKey) => {
+    setVisibility(prev => ({
+      ...prev,
+      [key]: !prev[key],
+    }));
+  };
+
+  const handleExhibit = async () => {
+    if (selectionCount === 0) {
+      toast({
+        title: 'Select combinations to exhibit',
+        description: 'Mark checkboxes in the statistical summary to stage combinations here.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    const context = getActiveProjectContext();
+    if (!context || !context.client_name || !context.app_name || !context.project_name) {
+      toast({
+        title: 'Project details required',
+        description: 'Please choose a client, app, and project before exhibiting combinations.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      let existingConfig: Awaited<ReturnType<typeof fetchExhibitionConfiguration>> | null = null;
+      try {
+        existingConfig = await fetchExhibitionConfiguration(context);
+      } catch (error) {
+        console.warn('Unable to fetch existing exhibition configuration', error);
+      }
+
+      const existingCards = Array.isArray(existingConfig?.cards) ? existingConfig.cards : [];
+      const existingFeatureOverview = Array.isArray(existingConfig?.feature_overview)
+        ? existingConfig.feature_overview
+        : [];
+
+      const filteredFeatureOverview = existingFeatureOverview.filter(
+        entry => entry?.atomId !== atomId,
+      );
+
+      const payload: ExhibitionConfigurationPayload = {
+        client_name: context.client_name,
+        app_name: context.app_name,
+        project_name: context.project_name,
+        cards: existingCards,
+        feature_overview: [
+          ...filteredFeatureOverview,
+          {
+            atomId,
+            cardId: cardIdentifier,
+            components: {
+              skuStatistics: true,
+              trendAnalysis: true,
+            },
+            skus: selections.map((selection, index) => {
+              const dimensionSummary = selection.dimensions
+                .map(d => d.value)
+                .filter(Boolean)
+                .join(' / ');
+              const title = selection.label ||
+                (dimensionSummary ? `${selection.metric} · ${dimensionSummary}` : selection.metric);
+
+              return {
+                id: selection.key || `${atomId}-${index}`,
+                title,
+                details: {
+                  metric: selection.metric,
+                  combination: selection.combination,
+                  dimensions: selection.dimensions,
+                  rowId: selection.rowId,
+                },
+              };
+            }),
+          },
+        ],
+      };
+
+      await saveExhibitionConfiguration(payload);
+      toast({
+        title: 'Exhibition catalogue updated',
+        description: 'Your selected combinations are now ready to be exhibited.',
+      });
+    } catch (error) {
+      console.error('Failed to save exhibit catalogue entry', error);
+      toast({
+        title: 'Unable to exhibit selections',
+        description:
+          error instanceof Error
+            ? error.message
+            : 'We could not persist the exhibition configuration right now.',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
   return (
     <div className="space-y-4">
-      <Card className="p-4 border border-gray-200 shadow-sm">
-        <div className="flex items-center space-x-2 mb-4">
-          <Layout className="w-4 h-4 text-blue-500" />
-          <h4 className="font-medium text-gray-900">Exhibition Layout</h4>
-        </div>
-        <div className="space-y-4">
+      <Card className="p-4 border border-gray-200 shadow-sm space-y-4">
+        <div className="flex items-start justify-between gap-3">
           <div>
-            <label className="text-sm font-medium text-gray-700 block mb-2">Display Mode</label>
-            <Select>
-              <SelectTrigger className="bg-white border-gray-300">
-                <SelectValue placeholder="Select display mode..." />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="dashboard">Dashboard View</SelectItem>
-                <SelectItem value="report">Report Format</SelectItem>
-                <SelectItem value="presentation">Presentation Mode</SelectItem>
-                <SelectItem value="interactive">Interactive Explorer</SelectItem>
-              </SelectContent>
-            </Select>
+            <div className="flex items-center gap-2 text-sm font-semibold text-gray-900">
+              <ListChecks className="w-4 h-4 text-blue-500" />
+              Selected combinations
+            </div>
+            <p className="text-xs text-gray-500 mt-1">
+              Curate dependent variable and dimension pairings from the statistical summary for exhibition mode.
+            </p>
           </div>
-          
-          <div>
-            <label className="text-sm font-medium text-gray-700 block mb-2">Layout Size</label>
-            <Select>
-              <SelectTrigger className="bg-white border-gray-300">
-                <SelectValue placeholder="Choose layout size..." />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="compact">Compact</SelectItem>
-                <SelectItem value="standard">Standard</SelectItem>
-                <SelectItem value="expanded">Expanded</SelectItem>
-                <SelectItem value="fullscreen">Full Screen</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
+          <Badge variant="secondary" className="text-xs font-medium px-2 py-1">
+            {selectionBadgeLabel}
+          </Badge>
         </div>
+
+        {selectionCount === 0 ? (
+          <div className="rounded-md border border-dashed border-gray-300 bg-gray-50 px-4 py-6 text-center text-sm text-gray-500">
+            No combinations selected yet. Use the Exhibition column in the statistical summary to stage combinations here.
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {selections.map(selection => (
+              <div
+                key={selection.key}
+                className="rounded-md border border-gray-200 bg-white/80 px-3 py-3 shadow-sm flex flex-col gap-2 md:flex-row md:items-start md:justify-between"
+              >
+                <div className="space-y-1">
+                  <p className="text-sm font-semibold text-gray-900">
+                    {selection.label || selection.metric}
+                  </p>
+                  <div className="flex flex-wrap gap-1">
+                    {selection.dimensions.map(dimension => (
+                      <Badge key={`${selection.key}-${dimension.name}`} variant="outline" className="text-[11px]">
+                        {dimension.name}: {dimension.value || '—'}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+                {onRemoveSelection && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="ml-auto text-gray-500 hover:text-gray-700"
+                    onClick={() => onRemoveSelection(selection.key)}
+                  >
+                    <X className="h-4 w-4" />
+                    <span className="sr-only">Remove selection</span>
+                  </Button>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
       </Card>
 
       <Card className="p-4 border border-gray-200 shadow-sm">
@@ -54,110 +218,77 @@ const FeatureOverviewExhibition: React.FC = () => {
         <div className="space-y-3">
           <div className="flex items-center justify-between">
             <span className="text-sm text-gray-700">Show column headers</span>
-            <input type="checkbox" className="rounded border-gray-300" defaultChecked />
+            <input
+              type="checkbox"
+              className="rounded border-gray-300"
+              checked={visibility.headers}
+              onChange={() => toggleVisibility('headers')}
+            />
           </div>
           <div className="flex items-center justify-between">
             <span className="text-sm text-gray-700">Display data types</span>
-            <input type="checkbox" className="rounded border-gray-300" defaultChecked />
+            <input
+              type="checkbox"
+              className="rounded border-gray-300"
+              checked={visibility.dataTypes}
+              onChange={() => toggleVisibility('dataTypes')}
+            />
           </div>
           <div className="flex items-center justify-between">
             <span className="text-sm text-gray-700">Show unique counts</span>
-            <input type="checkbox" className="rounded border-gray-300" defaultChecked />
+            <input
+              type="checkbox"
+              className="rounded border-gray-300"
+              checked={visibility.uniqueCounts}
+              onChange={() => toggleVisibility('uniqueCounts')}
+            />
           </div>
           <div className="flex items-center justify-between">
             <span className="text-sm text-gray-700">Include sample values</span>
-            <input type="checkbox" className="rounded border-gray-300" />
+            <input
+              type="checkbox"
+              className="rounded border-gray-300"
+              checked={visibility.sampleValues}
+              onChange={() => toggleVisibility('sampleValues')}
+            />
           </div>
           <div className="flex items-center justify-between">
             <span className="text-sm text-gray-700">Show data quality metrics</span>
-            <input type="checkbox" className="rounded border-gray-300" />
+            <input
+              type="checkbox"
+              className="rounded border-gray-300"
+              checked={visibility.qualityMetrics}
+              onChange={() => toggleVisibility('qualityMetrics')}
+            />
           </div>
         </div>
       </Card>
 
-      <Card className="p-4 border border-gray-200 shadow-sm">
-        <div className="flex items-center space-x-2 mb-4">
-          <Share2 className="w-4 h-4 text-purple-500" />
-          <h4 className="font-medium text-gray-900">Sharing Options</h4>
-        </div>
-        <div className="space-y-4">
-          <div>
-            <label className="text-sm font-medium text-gray-700 block mb-2">Access Level</label>
-            <Select>
-              <SelectTrigger className="bg-white border-gray-300">
-                <SelectValue placeholder="Select access level..." />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="private">Private</SelectItem>
-                <SelectItem value="team">Team Access</SelectItem>
-                <SelectItem value="organization">Organization Wide</SelectItem>
-                <SelectItem value="public">Public View</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-
-          <div>
-            <label className="text-sm font-medium text-gray-700 block mb-3">Available Actions</label>
-            <div className="flex flex-wrap gap-2">
-              <Badge variant="outline" className="text-xs bg-blue-50 border-blue-200">
-                View Only
-              </Badge>
-              <Badge variant="outline" className="text-xs bg-green-50 border-green-200">
-                Comment
-              </Badge>
-              <Badge variant="outline" className="text-xs bg-orange-50 border-orange-200">
-                Download
-              </Badge>
-              <Badge variant="outline" className="text-xs bg-purple-50 border-purple-200">
-                Export
-              </Badge>
-            </div>
-          </div>
-        </div>
-      </Card>
-
-      <Card className="p-4 border border-gray-200 shadow-sm">
-        <div className="flex items-center space-x-2 mb-4">
-          <Download className="w-4 h-4 text-orange-500" />
-          <h4 className="font-medium text-gray-900">Export Configuration</h4>
-        </div>
-        <div className="space-y-3">
-          <div>
-            <label className="text-sm font-medium text-gray-700 block mb-2">Export Format</label>
-            <Select>
-              <SelectTrigger className="bg-white border-gray-300">
-                <SelectValue placeholder="Choose export format..." />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="pdf">PDF Report</SelectItem>
-                <SelectItem value="excel">Excel Workbook</SelectItem>
-                <SelectItem value="csv">CSV File</SelectItem>
-                <SelectItem value="json">JSON Data</SelectItem>
-                <SelectItem value="png">PNG Image</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-          
-          <div className="flex items-center justify-between">
-            <span className="text-sm text-gray-700">Include metadata</span>
-            <input type="checkbox" className="rounded border-gray-300" defaultChecked />
-          </div>
-          <div className="flex items-center justify-between">
-            <span className="text-sm text-gray-700">Add timestamp</span>
-            <input type="checkbox" className="rounded border-gray-300" defaultChecked />
-          </div>
-        </div>
-      </Card>
-
-      <div className="flex space-x-3">
-        <Button className="flex-1 bg-gradient-to-r from-blue-500 to-blue-600 hover:from-blue-600 hover:to-blue-700 text-white">
-          <Eye className="w-4 h-4 mr-2" />
-          Preview Exhibition
+      <div className="space-y-2">
+        <Button
+          type="button"
+          className="w-full bg-gradient-to-r from-emerald-500 to-emerald-600 hover:from-emerald-600 hover:to-emerald-700 text-white"
+          size="lg"
+          onClick={handleExhibit}
+          disabled={isSaving || selectionCount === 0}
+        >
+          {isSaving ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Saving…
+            </>
+          ) : (
+            <>
+              <Send className="mr-2 h-4 w-4" />
+              Exhibit
+            </>
+          )}
         </Button>
-        <Button variant="outline" className="flex-1">
-          <Share2 className="w-4 h-4 mr-2" />
-          Share Now
-        </Button>
+        {selectionCount === 0 && (
+          <p className="text-xs text-gray-500 text-center">
+            Select at least one combination from the statistical summary to enable the Exhibit action.
+          </p>
+        )}
       </div>
     </div>
   );

--- a/TrinityFrontend/src/components/AtomList/atoms/feature-overview/components/properties/FeatureOverviewProperties.tsx
+++ b/TrinityFrontend/src/components/AtomList/atoms/feature-overview/components/properties/FeatureOverviewProperties.tsx
@@ -14,6 +14,10 @@ const FeatureOverviewProperties: React.FC<Props> = ({ atomId }) => {
   const [tab, setTab] = useState('settings');
   const atom = useLaboratoryStore(state => state.getAtom(atomId));
   const updateSettings = useLaboratoryStore(state => state.updateAtomSettings);
+  const cardId = useLaboratoryStore(state => {
+    const card = state.cards.find(card => card.atoms.some(atom => atom.id === atomId));
+    return card?.id;
+  });
   const settings: SettingsType = (atom?.settings as SettingsType) || { ...DEFAULT_FEATURE_OVERVIEW_SETTINGS };
 
   const [pendingY, setPendingY] = useState<string[]>(settings.yAxes || []);
@@ -34,6 +38,17 @@ const FeatureOverviewProperties: React.FC<Props> = ({ atomId }) => {
   const applyVisual = () => {
     updateSettings(atomId, { yAxes: pendingY, xAxis: pendingX });
   };
+
+  const handleRemoveExhibitionSelection = React.useCallback(
+    (key: string) => {
+      const current = Array.isArray(settings.exhibitionSelections)
+        ? settings.exhibitionSelections
+        : [];
+      const next = current.filter(selection => selection.key !== key);
+      updateSettings(atomId, { exhibitionSelections: next });
+    },
+    [atomId, settings.exhibitionSelections, updateSettings],
+  );
 
   return (
     <div className="h-full flex flex-col">
@@ -82,7 +97,16 @@ const FeatureOverviewProperties: React.FC<Props> = ({ atomId }) => {
           />
         </TabsContent>
         <TabsContent value="exhibition" className="flex-1 mt-0" forceMount>
-          <FeatureOverviewExhibition />
+          <FeatureOverviewExhibition
+            atomId={atomId}
+            cardId={cardId}
+            selections={
+              Array.isArray(settings.exhibitionSelections)
+                ? settings.exhibitionSelections
+                : []
+            }
+            onRemoveSelection={handleRemoveExhibitionSelection}
+          />
         </TabsContent>
       </Tabs>
     </div>

--- a/TrinityFrontend/src/components/LaboratoryMode/store/laboratoryStore.ts
+++ b/TrinityFrontend/src/components/LaboratoryMode/store/laboratoryStore.ts
@@ -95,6 +95,20 @@ export const createDefaultDataUploadSettings = (): DataUploadSettings => ({
   fileSizeMap: {},
 });
 
+export interface FeatureOverviewExhibitionSelectionDimension {
+  name: string;
+  value: string;
+}
+
+export interface FeatureOverviewExhibitionSelection {
+  key: string;
+  metric: string;
+  combination: Record<string, string>;
+  dimensions: FeatureOverviewExhibitionSelectionDimension[];
+  rowId?: string | number;
+  label?: string;
+}
+
 export interface FeatureOverviewSettings {
   selectedColumns: string[];
   hierarchicalView: boolean;
@@ -117,6 +131,7 @@ export interface FeatureOverviewSettings {
   isLoading?: boolean;
   loadingMessage?: string;
   loadingStatus?: string;
+  exhibitionSelections?: FeatureOverviewExhibitionSelection[];
 }
 
 export const DEFAULT_FEATURE_OVERVIEW_SETTINGS: FeatureOverviewSettings = {
@@ -141,6 +156,7 @@ export const DEFAULT_FEATURE_OVERVIEW_SETTINGS: FeatureOverviewSettings = {
   isLoading: false,
   loadingMessage: '',
   loadingStatus: '',
+  exhibitionSelections: [],
 };
 
 export interface ConcatSettings {


### PR DESCRIPTION
## Summary
- track feature overview statistical summary selections as exhibition metadata in the laboratory store
- add exhibition checkboxes to the statistical summary table and sync them to the properties panel
- redesign the feature overview exhibition tab to list selected combinations and persist them via the Exhibit action

## Testing
- npm run lint *(fails: missing @eslint/js in dev environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e677b3d9988321b6edb001d9620f6b